### PR TITLE
DON-15 - fix type errors blocking demo build + improve tests

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -1,7 +1,7 @@
 <img class="banner" [src]="campaign.bannerUri" alt="Campaign Banner">
 <div class="details">
 	<div>
-		<h2>{{campaign.title}} <em *ngIf="campaign.championName"> | Championed by: {{campaign.championName}}</em></h2>
+		<h2>{{campaign.title}}<em *ngIf="campaign.championName"> | Championed by: {{campaign.championName}}</em></h2>
 		<h3 *ngIf="campaign.isMatched">Matched Campaign!</h3>
 		<h4 *ngIf="!campaign.isMatched">Regular campaign</h4>
 	</div>

--- a/src/app/campaign-details/campaign-details.component.spec.ts
+++ b/src/app/campaign-details/campaign-details.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { Campaign } from '../campaign.model';
 import { CampaignDetailsComponent } from './campaign-details.component';
 
 describe('CampaignDetailsComponent', () => {
@@ -22,10 +23,35 @@ describe('CampaignDetailsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CampaignDetailsComponent);
     component = fixture.componentInstance;
+    component.campaign = new Campaign(
+      'testCampaignId',
+      123,
+      [],
+      'https://example.com/banner.png',
+      [],
+      'Some Champion',
+      { id: 'testCharityId', name: 'Test Charity' },
+      new Date(),
+      [],
+      true,
+      [],
+      new Date(),
+      'Test campaign description',
+      1234,
+      'Test Campaign!',
+      [],
+      [],
+    );
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load key data from test campaign', () => {
+    expect(component.campaign.title).toBe('Test Campaign!');
+    expect(component.campaign.isMatched).toBe(true);
+    expect(component.campaign.charity.name).toBe('Test Charity');
   });
 });

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CampaignService } from '../campaign.service';
 import { ActivatedRoute } from '@angular/router';
+import { Campaign } from '../campaign.model';
 
 @Component({
   selector: 'app-campaign-details',
@@ -8,9 +9,8 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./campaign-details.component.scss'],
 })
 export class CampaignDetailsComponent implements OnInit {
-
+  public campaign: Campaign;
   public campaignId: string;
-  public campaign = [];
 
   constructor(
     private campaignService: CampaignService,

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { CampaignService } from '../campaign.service';
 import { ActivatedRoute } from '@angular/router';
+
 import { Campaign } from '../campaign.model';
+import { CampaignService } from '../campaign.service';
 
 @Component({
   selector: 'app-campaign-details',

--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -6,7 +6,7 @@ export class Campaign {
     public bannerUri: string,
     public budgetDetails: Array<{amount: number, description: string}>,
     public championName: string,
-    public charity: Array<{id: string, name: string}>,
+    public charity: {id: string, name: string},
     public endDate: Date,
     public giftHandles: Array<{amount: number, description: string}>,
     public isMatched: boolean,

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { Campaign } from './campaign.model';
 import { CampaignService } from './campaign.service';
@@ -15,7 +15,7 @@ describe('CampaignService', () => {
     const service: CampaignService = TestBed.get(CampaignService);
     const httpMock: HttpTestingController = TestBed.get(HttpTestingController);
 
-    const dummyCampaign: Campaign[] = [{
+    const dummyCampaign: Campaign = {
       video: [
         {
           provider: 'youtube',
@@ -41,12 +41,10 @@ describe('CampaignService', () => {
           amount: 50.01,
         },
       ],
-      charity: [
-        {
-          name: 'Awesome Charity',
-          id: '0011r00002HHAprAAH',
-        },
-      ],
+      charity: {
+        name: 'Awesome Charity',
+        id: '0011r00002HHAprAAH',
+      },
       endDate: new Date(),
       championName: 'The Big Give Match Fund',
       budgetDetails: [
@@ -65,10 +63,9 @@ describe('CampaignService', () => {
           order: 100,
         },
       ],
-    }];
+    };
 
     service.getOne('a051r00001EywjpAAB').subscribe(campaign => {
-      expect(campaign.length).toBe(1);
       expect(campaign).toEqual(dummyCampaign);
     }, () => {
       expect(false).toBe(true); // Always fail if observable errors
@@ -77,7 +74,5 @@ describe('CampaignService', () => {
     const request = httpMock.expectOne(`${environment.apiUriPrefix}/campaigns/services/apexrest/v1.0/campaigns/a051r00001EywjpAAB`);
     expect(request.request.method).toBe('GET');
     request.flush(dummyCampaign);
-
   });
-
 });

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -20,7 +20,7 @@ export class CampaignService {
     return this.http.get<CampaignSummary[]>(`${environment.apiUriPrefix}${this.apiPath}?term=${term}`);
   }
 
-  getOne(campaignId): Observable<Campaign[]> {
-    return this.http.get<Campaign[]>(`${environment.apiUriPrefix}${this.apiPath}/${campaignId}`);
+  getOne(campaignId): Observable<Campaign> {
+    return this.http.get<Campaign>(`${environment.apiUriPrefix}${this.apiPath}/${campaignId}`);
   }
 }


### PR DESCRIPTION
@tbg-jasonfung I missed some of the type issues in review, sorry. Please keep an eye out for what should and should be an array (multiple) type.

You can also see on the CLI server if there are runtime type errors like the ones that blocked the previous S3 demo build from transpiling. I don't think these will be very common but if this happens again we can look into how we can have these caught during the CI `build` job too so this type of error doesn't get into `master`.

* Fix several places incorrectly looking for an _array of_ charities or an _array of_ campaigns when retrieving a single campaign or linked charity from a campaign (many-to-one relation)
* Update `CampaignService` spec's dummy data so it passes now that types are correct
* Add some actual test data and some more substantial assertions to `CampaignDetailsComponent` spec so it can be rendered in the test now that types are correct