### PR TITLE
DON-9, DON-14 - existing donation handling & cancellations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6492,6 +6492,14 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "ngx-webstorage-service": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-webstorage-service/-/ngx-webstorage-service-4.1.0.tgz",
+      "integrity": "sha512-t0aO4X8rqesLqypU8ZK2W7xGVbpi/z7u/Xg7qhnLoKVauI29NFzdKxV2oaYZmpkxIpgdbLSsIfklkjgxIM0IFA==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nguniversal/module-map-ngfactory-loader": "^8.1.1",
     "express": "^4.17.1",
     "hammerjs": "^2.0.8",
+    "ngx-webstorage-service": "^4.1.0",
     "rxjs": "~6.5.0",
     "tslib": "^1.9.0",
     "typeface-maven-pro": "0.0.75",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { CampaignCardComponent } from './campaign-card/campaign-card.component';
 import { CampaignSearchFormComponent } from './campaign-search-form/campaign-search-form.component';
 import { DonationStartComponent } from './donation-start/donation-start.component';
 import { DonationStartMatchConfirmDialogComponent } from './donation-start/donation-start-match-confirm-dialog.component';
+import { DonationStartOfferReuseDialogComponent } from './donation-start/donation-start-offer-reuse-dialog.component';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { CampaignDetailsComponent } from './campaign-details/campaign-details.component';
 import { MetaCampaignComponent } from './meta-campaign/meta-campaign.component';
@@ -32,12 +33,14 @@ import { TimeLeftPipe } from './time-left.pipe';
     CampaignSearchFormComponent,
     DonationStartComponent,
     DonationStartMatchConfirmDialogComponent,
+    DonationStartOfferReuseDialogComponent,
     SearchResultsComponent,
     MetaCampaignComponent,
     TimeLeftPipe,
   ],
   entryComponents: [
     DonationStartMatchConfirmDialogComponent,
+    DonationStartOfferReuseDialogComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),

--- a/src/app/donation-start/donation-start-offer-reuse-dialog.component.ts
+++ b/src/app/donation-start/donation-start-offer-reuse-dialog.component.ts
@@ -1,0 +1,12 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { Donation } from '../donation.model';
+
+@Component({
+  selector: 'app-donation-start-offer-reuse-dialog',
+  templateUrl: 'donation-start-offer-reuse-dialog.html',
+})
+export class DonationStartOfferReuseDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { donation: Donation }) { }
+}

--- a/src/app/donation-start/donation-start-offer-reuse-dialog.html
+++ b/src/app/donation-start/donation-start-offer-reuse-dialog.html
@@ -1,0 +1,17 @@
+<h2 mat-dialog-title>Continue donation?</h2>
+
+<mat-dialog-content class="mat-typography">
+  <h3>You have an existing incomplete donation to this campaign which you may continue.</h3>
+
+  <p>Donation amount: <strong>{{ data.donation.donationAmount | currency : '£' : 'symbol' : '1.0-0' }}</strong></p>
+
+  <p *ngIf="data.donation.matchReservedAmount > 0">Match funds reserved: <strong>{{ data.donation.matchReservedAmount | currency : '£' : 'symbol' : '1.0-0' }}</strong></p>
+  <p *ngIf="data.donation.matchReservedAmount == 0">No match funds are reserved.</p>
+
+  <p>Please confirm if you would rather proceed, or cancel this and provide new donation details.</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-raised-button [mat-dialog-close]="false" color="accent">Cancel</button>
+  <button mat-raised-button [mat-dialog-close]="true" cdkFocusInitial color="primary">Proceed</button>
+</mat-dialog-actions>

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -10,6 +10,7 @@ import { Donation } from '../donation.model';
 import { DonationCreatedResponse } from '../donation-created-response.model';
 import { DonationService } from '../donation.service';
 import { DonationStartMatchConfirmDialogComponent } from './donation-start-match-confirm-dialog.component';
+import { DonationStartOfferReuseDialogComponent } from './donation-start-offer-reuse-dialog.component';
 import { environment } from '../../environments/environment';
 
 @Component({
@@ -46,6 +47,8 @@ export class DonationStartComponent implements OnInit {
   ngOnInit() {
     this.campaignService.getOne(this.campaignId)
       .subscribe(campaign => this.campaign = campaign);
+
+    this.donationService.checkForExistingDonations(this.campaignId, this);
 
     this.donationForm = this.formBuilder.group({
       // TODO require a whole number of pounds, unless scrapping that constraint
@@ -90,14 +93,15 @@ export class DonationStartComponent implements OnInit {
 
     this.donationService
       .create(donation) // Create Salesforce donation
-      .subscribe((donationCreatedResponse: DonationCreatedResponse) => {
+      .subscribe((response: DonationCreatedResponse) => {
+        this.donationService.saveDonation(response.donation, response.jwt);
+
         // If that succeeded proceed to Charity Checkout donation page, providing key
         // fields are present in the Salesforce response's Donation.
-
         const salesforceResponseMissingRequiredData = (
-          !donationCreatedResponse.donation.charityId ||
-          !donationCreatedResponse.donation.donationId ||
-          !donationCreatedResponse.donation.projectId
+          !response.donation.charityId ||
+          !response.donation.donationId ||
+          !response.donation.projectId
         );
         if (salesforceResponseMissingRequiredData) {
           // TODO log detail of missing info back from Salesforce
@@ -107,18 +111,18 @@ export class DonationStartComponent implements OnInit {
           return;
         }
 
-        if (donation.donationMatched && !donationCreatedResponse.donation.donationMatched) {
-          this.promptToContinueWithNoMatchingLeft(donationCreatedResponse.donation);
+        if (donation.donationMatched && !response.donation.donationMatched) {
+          this.promptToContinueWithNoMatchingLeft(response.donation);
           return;
         }
 
-        if (donation.donationMatched && donation.donationAmount < donationCreatedResponse.donation.matchReservedAmount) {
-          this.promptToContinueWithPartialMatching(donationCreatedResponse.donation);
+        if (donation.donationMatched && donation.donationAmount < response.donation.matchReservedAmount) {
+          this.promptToContinueWithPartialMatching(response.donation);
           return;
         }
 
         // Else either the donation was not expected to be matched or has 100% match funds allocated -> no need for an extra step
-        this.redirectToCharityCheckout(donationCreatedResponse.donation);
+        this.redirectToCharityCheckout(response.donation);
       }, error => {
         // TODO log the detailed `error` message somewhere
         this.sfApiError = true;
@@ -137,6 +141,17 @@ export class DonationStartComponent implements OnInit {
    * Quick getter for form controls, to keep validation message handling concise.
    */
   get f() { return this.donationForm.controls; }
+
+  offerExistingDonation(donation: Donation) {
+    this.submitting = true;
+
+    const reuseDialog = this.dialog.open(DonationStartOfferReuseDialogComponent, {
+      data: { donation },
+      disableClose: true,
+      role: 'alertdialog',
+    });
+    reuseDialog.afterClosed().subscribe(this.getDialogResponseFn(donation));
+  }
 
   private redirectToCharityCheckout(donation: Donation) {
     this.charityCheckoutService.startDonation(donation);
@@ -162,23 +177,32 @@ export class DonationStartComponent implements OnInit {
   }
 
   private promptToContinue(status: string, cancelCopy: string, donation: Donation) {
-    const dialogRef = this.dialog.open(DonationStartMatchConfirmDialogComponent, {
+    const continueDialog = this.dialog.open(DonationStartMatchConfirmDialogComponent, {
       data: { cancelCopy, status },
       disableClose: true,
       role: 'alertdialog',
     });
+    continueDialog.afterClosed().subscribe(this.getDialogResponseFn(donation));
+  }
 
-    dialogRef.afterClosed().subscribe((proceed: boolean) => {
+  /**
+   * Thunk returning a fn which can handle a dialog true/false response and continue/cancel `donation` accordingly.
+   */
+  private getDialogResponseFn(donation: Donation) {
+    return (proceed: boolean) => {
       if (proceed) {
         this.redirectToCharityCheckout(donation);
 
         return;
       }
 
-      // Else cancel the pending donation
-      // TODO release match funds reserved, if any - DON-12
-
+      // Else cancel the existing donation in Salesforce and remove our local record of it
+      this.donationService.cancel(donation)
+        .subscribe(
+          response => console.log('Cancelled donation', response), // TODO log to GA?
+          error => console.log('Cancel error:', error), // TODO definitely log these to GA
+        );
       this.submitting = false;
-    });
+    };
   }
 }

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -111,11 +111,13 @@ export class DonationStartComponent implements OnInit {
           return;
         }
 
-        if (donation.donationMatched && !response.donation.donationMatched) {
+        // Amount reserved for matching is 'false-y', i.e. £0
+        if (donation.donationMatched && !response.donation.matchReservedAmount) {
           this.promptToContinueWithNoMatchingLeft(response.donation);
           return;
         }
 
+        // Amount reserved for matching is >£0 but less than the full donation
         if (donation.donationMatched && donation.donationAmount < response.donation.matchReservedAmount) {
           this.promptToContinueWithPartialMatching(response.donation);
           return;

--- a/src/app/donation-status.type.ts
+++ b/src/app/donation-status.type.ts
@@ -9,6 +9,7 @@ enum DonationStatusEnum {
   'PendingCancellation',
   'Refunded',
   'RefundingPending',
+  'Reserved', // TBG status set in Salesforce by Apex code, rather than by Charity Checkout hooks
 }
 
 // See https://www.typescriptlang.org/docs/handbook/enums.html#enums-at-compile-time

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -1,27 +1,121 @@
-import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { SESSION_STORAGE, StorageService } from 'ngx-webstorage-service';
 import { Observable } from 'rxjs';
 
 import { Donation } from './donation.model';
 import { DonationCreatedResponse } from './donation-created-response.model';
+import { DonationStartComponent } from './donation-start/donation-start.component';
 import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DonationService {
-  private apiPath = '/donations/services/apexrest/v1.0/donations';
+  /**
+   * For the purpose of this class, each `donationCouplet` is a pairing of a donation and its corresponding
+   * unique JWT. This token grants the donor who originally created a donation permission to get its current
+   * status & additional data, and to cancel it if it's Pending or Reserved.
+   */
+  private donationCouplets: Array<{ donation: Donation, jwt: string }> = [];
+
+  private readonly apiPath = '/donations/services/apexrest/v1.0/donations';
+  private readonly resumableStatuses = ['Pending', 'Reserved'];
+  private readonly storageKey = 'v1.donate.thebiggive.org.uk';
 
   constructor(
     private http: HttpClient,
-  ) {}
-
-  create(donation: Donation): Observable<DonationCreatedResponse> {
-    return this.http.post<DonationCreatedResponse>(`${environment.apiUriPrefix}${this.apiPath}`, donation);
+    @Inject(SESSION_STORAGE) private storage: StorageService,
+  ) {
+    this.donationCouplets = this.storage.get(this.storageKey) || [];
   }
 
-  saveToken(donationId, jwt) {
-    // TODO
-    console.log('Token for later donation usage is TODO! Would have saved JWT for ID ', donationId);
+  checkForExistingDonations(projectId: string, donationStartComponent: DonationStartComponent): void {
+    // TODO we should tidy up by deleting any locally saved donations too old to be useful as part of this process
+
+    const existingDonations = this.donationCouplets.filter(donationItem => {
+      const createdDate = donationItem.donation.createdTime instanceof Date
+        ? donationItem.donation.createdTime
+        : new Date(donationItem.donation.createdTime);
+
+      return (
+        donationItem.donation.projectId === projectId &&              // Only bring back donations to the same project/CCampaign...
+        createdDate.getTime() > ((new Date()).getTime() - 600000) &&  // ...from the past 10 minutes...
+        this.resumableStatuses.includes(donationItem.donation.status) // ...with a reusable last-known status.
+      );
+    });
+
+    if (existingDonations.length === 0) {
+      return; // No relevant donations to offer to resume.
+    }
+
+    // We have at least one existing donation that may be a candidate to re-try.
+    // We'll take an arbitrary 'first' matching donation since presenting multiple to the donor would be too confusing.
+    // But we first need to check with the server that it's still in a Pending or Reserved status ready to try again -
+    // and check any remaining local candidates if not.
+    let foundReusableDonation = false;
+    for (const existingDonation of existingDonations) {
+      if (foundReusableDonation) {
+        break;
+      }
+
+      this.get(existingDonation.donation)
+        .subscribe((donation: Donation) => {
+          if (!foundReusableDonation && this.resumableStatuses.includes(donation.status)) {
+            foundReusableDonation = true;
+            donationStartComponent.offerExistingDonation(donation);
+          }
+        });
+    }
+  }
+
+  cancel(donation: Donation): Observable<any> {
+    donation.status = 'Cancelled';
+
+    // TODO we should immediately remove the local copy from this.donationCouplets when doing this
+
+    return this.http.put<any>(
+      `${environment.apiUriPrefix}${this.apiPath}/${donation.donationId}`,
+      donation,
+      this.getAuthHttpOptions(donation),
+    );
+  }
+
+  create(donation: Donation): Observable<DonationCreatedResponse> {
+    return this.http.post<DonationCreatedResponse>(
+      `${environment.apiUriPrefix}${this.apiPath}`,
+      donation,
+    );
+  }
+
+  get(donation: Donation): Observable<Donation> {
+    return this.http.get<Donation>(
+      `${environment.apiUriPrefix}${this.apiPath}/${donation.donationId}`,
+      this.getAuthHttpOptions(donation),
+    );
+  }
+
+  saveDonation(donation: Donation, jwt: string) {
+    // Salesforce doesn't add this until after the async persist so we need to set it locally in order to later determine
+    // which donations are new and eligible for reuse.
+    donation.createdTime = new Date();
+
+    this.donationCouplets.push({ donation, jwt });
+    this.storage.set(this.storageKey, this.donationCouplets);
+  }
+
+  private getAuthHttpOptions(donation: Donation): { headers: HttpHeaders } {
+    const donationDataItems = this.donationCouplets.filter(donationItem => donationItem.donation.donationId === donation.donationId);
+
+    if (donationDataItems.length !== 1) {
+      // TODO log this, and handle it more elegantly if we can find any normal cases where users could encounter it.
+      throw new Error('Not authorised to work with that donation');
+    }
+
+    return {
+      headers: new HttpHeaders({
+        'X-Tbg-Auth': donationDataItems[0].jwt,
+      }),
+    };
   }
 }


### PR DESCRIPTION
* DON-10 - persist information about started donations, using local storage to persist information across app loads
* Complete JWT handling, to support getting up to date information about donations and cancelling them (both requiring authentication with the API)
* Implement `get()` and `cancel()` methods on `DonationService`
* DON-11 - warn if any found which are recent, still incomplete (after a GET check with the API) and match the project you're about to start a new donation to. Offer to resume the previous donation or cancel any reservation and start a new one
* DON-12 - process cancellations in Salesforce directly in the DON-11 case
* DON-14 - also cancel donations & reservations straight away when the incomplete matching warning has been shown and the donor chose to cancel without going to Charity Checkout