### PR TITLE
DON-72 - fix tab-dependent thank you page; fix unstable unit test

### DIFF
--- a/src/app/donation-complete/donation-complete.component.spec.ts
+++ b/src/app/donation-complete/donation-complete.component.spec.ts
@@ -5,9 +5,11 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
+import { AnalyticsService } from '../analytics.service';
 import { DonationCompleteComponent } from './donation-complete.component';
 
 describe('DonationCompleteComponent', () => {
+  let analyticsService;
   let component: DonationCompleteComponent;
   let fixture: ComponentFixture<DonationCompleteComponent>;
 
@@ -25,6 +27,7 @@ describe('DonationCompleteComponent', () => {
         ]),
       ],
       providers: [
+        AnalyticsService,
         {
           provide: ActivatedRoute,
           useValue: {
@@ -32,8 +35,14 @@ describe('DonationCompleteComponent', () => {
           },
         },
       ],
-    })
-    .compileComponents();
+    });
+
+    // We must mock AnalyticsService so we don't touch the window/global var which is unavailable.
+    // This also lets the test assert that a specific GA method call is made.
+    analyticsService = TestBed.get(AnalyticsService);
+    spyOn(analyticsService, 'logError');
+
+    TestBed.compileComponents();
   }));
 
   beforeEach(() => {
@@ -43,11 +52,9 @@ describe('DonationCompleteComponent', () => {
   });
 
   it('should create', () => {
-    // Hack to ensure calls to the global from AnalyticsService as the component loads don't cause test
-    // errors. TODO - ideally, we should have a mock of the AnalyticsService for tests which doesn't touch
-    // the global and allows us to assert that specific GA calls are made.
-    const gtag = () => {};
-
     expect(component).toBeTruthy();
+    // We bootstrap with a fake, unknown donation ID. So the thanks page should error out on load
+    // and log that error to GA.
+    expect(analyticsService.logError).toHaveBeenCalled();
   });
 });

--- a/src/app/donation-complete/donation-complete.component.ts
+++ b/src/app/donation-complete/donation-complete.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 
@@ -11,7 +11,7 @@ import { DonationService } from '../donation.service';
   templateUrl: './donation-complete.component.html',
   styleUrls: ['./donation-complete.component.scss'],
 })
-export class DonationCompleteComponent implements OnInit {
+export class DonationCompleteComponent {
   public complete = false;
   public donation: Donation;
   public noAccess = false;
@@ -27,11 +27,10 @@ export class DonationCompleteComponent implements OnInit {
     private donationService: DonationService,
     private route: ActivatedRoute,
   ) {
-    route.params.pipe().subscribe(params => this.donationId = params.donationId);
-  }
-
-  ngOnInit() {
-    this.checkDonation();
+    route.params.pipe().subscribe(params => {
+      this.donationId = params.donationId;
+      this.checkDonation();
+    });
   }
 
   /**


### PR DESCRIPTION
* Use localStorage + stabilise component bootstrapping
* Fix unstable test: By mocking the AnalyticsService properly, the new thank you page's tests passing no longer relies on luck. This should fix the test race condition properly and also lets us actually verify that the right Analytics method is called.