### PR TITLE
More realistic meta-campaign search

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,15 @@
 <div class="header">
   <h1><a routerLink="/"><img src="/assets/logo.png" alt="The Big Give" width="200"></a> Donations</h1>
 
-  <h3>Try a Meta-campaign</h3>
-  <a routerLink="/metacampaign/a051r00001CGEpoAAH">Summer Give 2019</a>
+  <div class="demo">
+    <p class="demo-note">This demo block will be removed from the app for the 2019 Challenge.</p>
 
-  <h3>Find a Campaign</h3>
-  <app-campaign-search-form></app-campaign-search-form>
+    <h3>CC19 Shortcut</h3>
+    <a routerLink="/christmas-challenge-2019">Christmas Challenge 2019</a>
+
+    <h3>Global Campaign search</h3>
+    <app-campaign-search-form (search)="onGlobalSearch($event)"></app-campaign-search-form>
+  </div>
 </div>
 
 <hr>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -3,3 +3,12 @@
 .header {
   padding: 1rem;
 }
+
+.demo {
+  border: solid 3px purple;
+  padding: 0 1em;
+}
+
+.demo-note {
+  color: purple;
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,7 +4,6 @@ import {
   MatButtonModule,
   MatCardModule,
   MatInputModule,
-  MatSlideToggleModule,
 } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -19,7 +18,6 @@ describe('AppComponent', () => {
         MatButtonModule, // Not required but makes test DOM layout more realistic
         MatCardModule,
         MatInputModule,
-        MatSlideToggleModule,
         NoopAnimationsModule,
         ReactiveFormsModule,
         RouterTestingModule,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { AnalyticsService } from './analytics.service';
 
@@ -13,11 +14,16 @@ export class AppComponent implements OnInit {
     private analyticsService: AnalyticsService,
     // tslint:disable-next-line:ban-types Angular types this ID as `Object` so we must follow suit.
     @Inject(PLATFORM_ID) private platformId: Object,
+    private router: Router,
   ) {}
 
   ngOnInit() {
     if (isPlatformBrowser(this.platformId)) {
       this.analyticsService.init();
     }
+  }
+
+  public onGlobalSearch(term: string) {
+    this.router.navigateByUrl(`/search?term=${term}`);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,6 @@ import {
   MatProgressSpinnerModule,
   MatRadioModule,
   MatSelectModule,
-  MatSlideToggleModule,
 } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -64,7 +63,6 @@ import { DonationCompleteComponent } from './donation-complete/donation-complete
     MatProgressBarModule,
     MatRadioModule,
     MatSelectModule,
-    MatSlideToggleModule,
     MatProgressSpinnerModule,
     ReactiveFormsModule,
     MatCarouselModule,

--- a/src/app/campaign-search-form/campaign-search-form.component.html
+++ b/src/app/campaign-search-form/campaign-search-form.component.html
@@ -1,14 +1,8 @@
-<form (ngSubmit)="search()" [formGroup]="searchForm">
+<form (ngSubmit)="submit()" [formGroup]="searchForm">
   <mat-form-field color="accent">
     <mat-label for="term">Campaign or Charity</mat-label>
     <input matInput formControlName="term" id="term" type="text">
   </mat-form-field>
-
-  <p>
-    <mat-slide-toggle formControlName="summerGive19" id="summerGive19">
-      Limit to Summer Give 2019
-    </mat-slide-toggle>
-  </p>
 
   <p>
     <button

--- a/src/app/campaign-search-form/campaign-search-form.component.spec.ts
+++ b/src/app/campaign-search-form/campaign-search-form.component.spec.ts
@@ -1,8 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { MatButtonModule, MatInputModule, MatSlideToggleModule } from '@angular/material';
+import { MatButtonModule, MatInputModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { RouterTestingModule } from '@angular/router/testing';
 
 import { CampaignSearchFormComponent } from './campaign-search-form.component';
 
@@ -16,10 +15,8 @@ describe('CampaignSearchFormComponent', () => {
       imports: [
         MatButtonModule, // Not required but makes test DOM layout more realistic
         MatInputModule,
-        MatSlideToggleModule,
         NoopAnimationsModule,
         ReactiveFormsModule,
-        RouterTestingModule,
       ],
     })
     .compileComponents();
@@ -37,13 +34,13 @@ describe('CampaignSearchFormComponent', () => {
   });
 
   it('should still have search button disabled after 1 character entered', () => {
-    component.searchForm.setValue({summerGive19: false, term: 'T'});
+    component.searchForm.setValue({term: 'T'});
 
     expect(component.searchForm.valid).toBe(false);
   });
 
   it('should have search button enabled after 2 characters entered', () => {
-    component.searchForm.setValue({summerGive19: false, term: 'Te'});
+    component.searchForm.setValue({term: 'Te'});
 
     expect(component.searchForm.valid).toBe(true);
   });

--- a/src/app/campaign-search-form/campaign-search-form.component.ts
+++ b/src/app/campaign-search-form/campaign-search-form.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-campaign-search-form',
@@ -8,16 +7,17 @@ import { Router } from '@angular/router';
   styleUrls: ['./campaign-search-form.component.scss'],
 })
 export class CampaignSearchFormComponent implements OnInit {
+  @Input() campaignId: string;
+  @Output() search: EventEmitter<any> = new EventEmitter();
+
   public searchForm: FormGroup;
 
   constructor(
     private formBuilder: FormBuilder,
-    private router: Router,
   ) {}
 
   ngOnInit() {
     this.searchForm = this.formBuilder.group({
-      summerGive19: [false],
       term: [null, [
         Validators.required,
         Validators.minLength(2),
@@ -25,13 +25,7 @@ export class CampaignSearchFormComponent implements OnInit {
     });
   }
 
-  public search() {
-    let url = `/search?term=${this.searchForm.value.term}`;
-
-    if (this.searchForm.value.summerGive19) {
-      url = `${url}&parent=a051r00001CGEpoAAH`;
-    }
-
-    this.router.navigateByUrl(url);
+  submit() {
+    this.search.emit(this.searchForm.value.term);
   }
 }

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -9,8 +9,10 @@
   </mat-card-content>
 </mat-card>
 
-<div *ngIf="children">
+<div *ngIf="campaign && children">
   <h2>Participating Campaigns</h2>
+  <h3>Search in {{ campaign.title }}</h3>
+  <app-campaign-search-form [campaignId]="campaign.id" (search)="onMetacampaignSearch($event)"></app-campaign-search-form>
 
   <h3>Filters</h3>
   <mat-form-field>

--- a/src/app/meta-campaign/meta-campaign.component.spec.ts
+++ b/src/app/meta-campaign/meta-campaign.component.spec.ts
@@ -1,11 +1,20 @@
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatCardModule, MatGridListModule, MatProgressBarModule, MatSelectModule } from '@angular/material';
+import { ReactiveFormsModule } from '@angular/forms';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatGridListModule,
+  MatInputModule,
+  MatProgressBarModule,
+  MatSelectModule,
+} from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { Campaign } from '../campaign.model';
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
+import { CampaignSearchFormComponent } from '../campaign-search-form/campaign-search-form.component';
 import { CampaignSummary } from '../campaign-summary.model';
 import { MetaCampaignComponent } from './meta-campaign.component';
 import { TimeLeftPipe } from '../time-left.pipe';
@@ -18,16 +27,20 @@ describe('MetaCampaignComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         CampaignCardComponent,
+        CampaignSearchFormComponent,
         MetaCampaignComponent,
         TimeLeftPipe,
       ],
       imports: [
         HttpClientTestingModule,
+        MatButtonModule, // Not required but makes test DOM layout more realistic
         MatCardModule,
         MatGridListModule,
+        MatInputModule,
         MatProgressBarModule,
         MatSelectModule,
         NoopAnimationsModule,
+        ReactiveFormsModule,
         RouterTestingModule,
       ],
     })

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -75,10 +75,6 @@ export class MetaCampaignComponent implements OnInit {
    */
   setQueryProperty(property, event) {
     this.query[property] = event.value;
-
-    console.log('new query:');
-    console.log(this.query);
-
     this.run();
   }
 

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -75,6 +75,10 @@ export class MetaCampaignComponent implements OnInit {
    */
   setQueryProperty(property, event) {
     this.query[property] = event.value;
+
+    console.log('new query:');
+    console.log(this.query);
+
     this.run();
   }
 
@@ -89,6 +93,11 @@ export class MetaCampaignComponent implements OnInit {
       this.sortDirectionEnabled = true;
       this.query.sortDirection = this.sortDirection;
     }
+    this.run();
+  }
+
+  onMetacampaignSearch(term: string) {
+    this.query.term = term;
     this.run();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import 'hammerjs'; // Used for Angular Material slide toggles' gesture support
+// import 'hammerjs'; // Used for Angular Material slide toggles' gesture support
+// TODO bring back if using any inputs requiring touch support again.
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';


### PR DESCRIPTION
* Add general purpose in-metacampaign search
* Remove SG19-specific search demo toggle

For now, this keeps global search logic using linkable URIs but
keeps search within a meta-campaign stateful. This will mean
anybody copy/pasting from meta-campaign page would share the
base (e.g.) CC19 URI rather than a filtered view