### PR TITLE
DON-73 - use Funds API on metacampaign page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -33,6 +33,10 @@ const routes: Routes = [
     component: DonationCompleteComponent,
   },
   {
+    path: ':campaignSlug/:fundSlug',
+    component: MetaCampaignComponent,
+  },
+  {
     path: ':campaignSlug',
     component: MetaCampaignComponent,
   },

--- a/src/app/fund.model.ts
+++ b/src/app/fund.model.ts
@@ -7,11 +7,11 @@ export class Fund {
      * Unique ID for a fund assigned by the Big Give, in Salesforce case-insensitive format. 18 character string.
      */
     public id: string,
-    public amountRaised: number,
-    public description: string,
+    public type: string,
     public name: string,
     public totalAmount: number,
-    public type: string,
-    public logoUri: string,
+    public amountRaised?: number,
+    public description?: string,
+    public logoUri?: string,
     ) {}
 }

--- a/src/app/fund.model.ts
+++ b/src/app/fund.model.ts
@@ -1,0 +1,17 @@
+/**
+ * Only Champion Fundings are used in the app thus far, not Pledges.
+ */
+export class Fund {
+  constructor(
+    /**
+     * Unique ID for a fund assigned by the Big Give, in Salesforce case-insensitive format. 18 character string.
+     */
+    public id: string,
+    public amountRaised: number,
+    public description: string,
+    public name: string,
+    public totalAmount: number,
+    public type: string,
+    public logoUri: string,
+    ) {}
+}

--- a/src/app/fund.service.spec.ts
+++ b/src/app/fund.service.spec.ts
@@ -1,0 +1,37 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { environment } from '../environments/environment';
+import { Fund } from './fund.model';
+import { FundService } from './fund.service';
+
+describe('FundService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [ HttpClientTestingModule ],
+    providers: [ FundService ],
+  }));
+
+  it('should retrieve Champion Funding details from API', () => {
+    const service: FundService = TestBed.get(FundService);
+    const httpMock: HttpTestingController = TestBed.get(HttpTestingController);
+
+    const dummyFund: Fund = {
+      id: 'asdfasdfasdfasdf12',
+      type: 'championFund',
+      name: 'Dummy Unit Test Fund',
+      amountRaised: 204.67,
+      totalAmount: 150.00,
+      logoUri: 'https://example.com/an-image.png',
+    };
+
+    service.getOneBySlug('champion-fund-test-slug').subscribe(fund => {
+      expect(fund).toEqual(dummyFund);
+    }, () => {
+      expect(false).toBe(true); // Always fail if observable errors
+    });
+
+    const request = httpMock.expectOne(`${environment.apiUriPrefix}/funds/services/apexrest/v1.0/funds/slug/champion-fund-test-slug`);
+    expect(request.request.method).toBe('GET');
+    request.flush(dummyFund);
+  });
+});

--- a/src/app/fund.service.spec.ts
+++ b/src/app/fund.service.spec.ts
@@ -18,9 +18,10 @@ describe('FundService', () => {
     const dummyFund: Fund = {
       id: 'asdfasdfasdfasdf12',
       type: 'championFund',
-      name: 'Dummy Unit Test Fund',
+      name: 'Dummy unit test fund',
       amountRaised: 204.67,
       totalAmount: 150.00,
+      description: 'Dummy unit test descriptoin of the Champion',
       logoUri: 'https://example.com/an-image.png',
     };
 

--- a/src/app/fund.service.ts
+++ b/src/app/fund.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../environments/environment';
+import { Fund } from './fund.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FundService {
+  private apiPath = '/funds/services/apexrest/v1.0/funds';
+
+  constructor(private http: HttpClient) {}
+
+  getOneBySlug(fundSlug: string): Observable<Fund> {
+    return this.http.get<Fund>(`${environment.apiUriPrefix}${this.apiPath}/slug/${fundSlug}`);
+  }
+}

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -1,11 +1,20 @@
 <mat-card *ngIf="campaign">
-  <mat-card-header>
+  <mat-card-header *ngIf="fund">
+    <mat-card-title>{{ fund.name }} &ndash; {{ campaign.title }}</mat-card-title>
+    <mat-card-subtitle *ngIf="campaign.status == 'Preview'">Opens in {{ campaign.startDate | timeLeft }}</mat-card-subtitle>
+    <mat-card-subtitle *ngIf="campaign.status != 'Preview'">{{ fund.amountRaised | currency : '£' : 'symbol' : '1.0-0' }} raised</mat-card-subtitle>
+    <img *ngIf="fund.logoUri" mat-card-image [src]="fund.logoUri" [alt]="fund.name + ' logo'">
+  </mat-card-header>
+
+  <mat-card-header *ngIf="!fund">
     <mat-card-title>{{ campaign.title }}</mat-card-title>
     <mat-card-subtitle *ngIf="campaign.status == 'Preview'">Opens in {{ campaign.startDate | timeLeft }}</mat-card-subtitle>
     <mat-card-subtitle *ngIf="campaign.status != 'Preview'">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }} raised</mat-card-subtitle>
   </mat-card-header>
+
   <mat-card-content>
-    <p>{{ campaign.summary }}</p>
+    <p *ngIf="fund">{{ fund.description }}</p>
+    <p *ngIf="!fund">{{ campaign.summary }}</p>
   </mat-card-content>
 </mat-card>
 

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -5,6 +5,8 @@ import { ActivatedRoute } from '@angular/router';
 import { Campaign } from '../campaign.model';
 import { CampaignSummary } from '../campaign-summary.model';
 import { CampaignService, SearchQuery } from '../campaign.service';
+import { Fund } from '../fund.model';
+import { FundService } from '../fund.service';
 import { PageMetaService } from '../page-meta.service';
 
 @Component({
@@ -19,6 +21,7 @@ export class MetaCampaignComponent implements OnInit {
   public children: CampaignSummary[];
   public countryOptions: string[];
   public filterError = false;
+  public fund: Fund;
   public sortDirection = 'asc';
   public sortDirectionEnabled = false; // Default sort field is relevance
 
@@ -30,6 +33,7 @@ export class MetaCampaignComponent implements OnInit {
 
   constructor(
     private campaignService: CampaignService,
+    private fundService: FundService,
     private pageMeta: PageMetaService,
     // tslint:disable-next-line:ban-types Angular types this ID as `Object` so we must follow suit.
     @Inject(PLATFORM_ID) private platformId: Object,
@@ -55,6 +59,10 @@ export class MetaCampaignComponent implements OnInit {
       this.campaignService.getOneById(this.campaignId).subscribe(campaign => this.setCampaign(campaign));
     } else {
       this.campaignService.getOneBySlug(this.campaignSlug).subscribe(campaign => this.setCampaign(campaign));
+    }
+
+    if (this.fundSlug) {
+      this.fundService.getOneBySlug(this.fundSlug).subscribe(fund => this.fund = fund);
     }
 
     this.query = {


### PR DESCRIPTION
* DON-74 - look up Fund details by their slugs
* DON-75 - add the champion Account's logo where set
* DON-76 - show the fund's contributed running total (when set in SF)
* DON-77 - show funds' title & description