### PR TITLE
DON-85 - give meta-campaigns a basic 'More' button

### DIFF
--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -27,6 +27,14 @@ export class CampaignService {
   search(searchQuery: SearchQuery): Observable<CampaignSummary[]> {
     let params = new HttpParams();
 
+    if (searchQuery.limit) {
+      params = params.append('limit', searchQuery.limit.toString());
+    }
+
+    if (searchQuery.offset) {
+      params = params.append('offset', searchQuery.offset.toString());
+    }
+
     if (searchQuery.beneficiary) {
       params = params.append('beneficiary', searchQuery.beneficiary);
     }
@@ -366,6 +374,8 @@ export class SearchQuery {
   public category?: string;
   public country?: string;
   public fundSlug?: string;
+  public limit?: number;
+  public offset?: number;
   public parentCampaignId?: string;
   public parentCampaignSlug?: string;
   public sortDirection?: string;

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -70,6 +70,8 @@
   </mat-grid-list>
 </div>
 
+<p *ngIf="moreMightExist()"><button (click)="more()">More Campaigns</button></p>
+
 <div *ngIf="filterError">
   <!-- e.g. campaign or fund slug is not recognised -->
   <p class="error">Could not load the campaign. You might have followed a broken link.</p>

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -31,6 +31,8 @@ export class MetaCampaignComponent implements OnInit {
   private query: SearchQuery;
   private viewportWidth: number; // In px. Used to vary `<mat-grid-list />`'s `cols`.
 
+  private perPage = 6;
+
   constructor(
     private campaignService: CampaignService,
     private fundService: FundService,
@@ -69,9 +71,25 @@ export class MetaCampaignComponent implements OnInit {
       parentCampaignId: this.campaignId,
       parentCampaignSlug: this.campaignSlug,
       fundSlug: this.fundSlug,
+      limit: this.perPage,
+      offset: 0,
     };
 
     this.run();
+  }
+
+  /**
+   * For now, just do a full search with more results requested. Not very efficient but does the job
+   * for now while we focus on other priorities.
+   * @todo use `offset` and load only campaigns not already likely to be on the page.
+   */
+  more() {
+    this.query.limit += this.perPage;
+    this.run();
+  }
+
+  moreMightExist(): boolean {
+    return (this.children.length === this.query.limit);
   }
 
   cols(): number {


### PR DESCRIPTION
Rudimentary button for now that just loads a new, larger chunk of child results each time it's clicked. Hack to support the new layout and allow pseudo-paging as quickly as possible pre-CC19.

This is certainly not the way we should load extra results eventually, but I'm suggesting it as a baseline so we can continue with the design work unblocked and have a passable paging solution for CC19 if we don't get time to do more on this.