### PR TITLE
Campaign & donate page tidying & historic campaign loading fix

### DIFF
--- a/src/app/campaign-details-card/campaign-details-card.component.html
+++ b/src/app/campaign-details-card/campaign-details-card.component.html
@@ -10,9 +10,11 @@
   </div>
 
   <div class="card-body">
-    <h3 class="campaign-target">Campaign target</h3>
-    <p class="campaign-target-value" *ngIf="campaign.target > 0">{{ campaign.target | currency : '£' : 'symbol' : '1.0-0' }}</p>
-    <mat-progress-bar [value]="percentRaised"></mat-progress-bar>
+    <div *ngIf="campaign.target > 0">
+      <h3 class="campaign-target">Campaign target</h3>
+      <p class="campaign-target-value">{{ campaign.target | currency : '£' : 'symbol' : '1.0-0' }}</p>
+      <mat-progress-bar [value]="percentRaised"></mat-progress-bar>
+    </div>
     <h3 class="campaign-target" *ngIf="campaign.amountRaised > 0">Amount raised (inc. Gift Aid)</h3>
     <p class="campaign-target-value" *ngIf="campaign.amountRaised > 0">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</p>
     <div fxLayout="row">

--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -15,9 +15,9 @@
       <button mat-raised-button class="donate-button" [routerLink]="'/donate/' + campaign.id" *ngIf="donateEnabled">
         Donate
       </button>
-      <p *ngIf="!donateEnabled">Donations open {{ campaign.startDate | date : 'h:mm a, d LLLL' }} to {{ campaign.endDate | date : 'h:mm a, d LLLL' }}</p>
+      <p *ngIf="!donateEnabled">Donations open {{ campaign.startDate | date : 'h:mm a, d LLLL yyyy' }} to {{ campaign.endDate | date : 'h:mm a, d LLLL yyyy' }}</p>
 
-      <p><a [href]="campaign.charity.website" target="_blank"
+      <p><a *ngIf="campaign.charity.website" [href]="campaign.charity.website" target="_blank"
         ><mat-icon aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
         <strong>{{ campaign.charity.website }}</strong></a>
       </p>

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -41,8 +41,14 @@ export class CampaignDetailsComponent implements OnInit {
         this.campaign = campaign;
         this.donateEnabled = CampaignService.isOpenForDonations(campaign);
         this.percentRaised = CampaignService.percentRaised(campaign);
-        // First 20 word-like things followed by …
-        const summaryStart = campaign.summary.replace(new RegExp('^(([\\w\',."-]+ ){20}).*$'), '$1') + '…';
+
+        let summaryStart;
+        if (campaign.summary) {
+          // First 20 word-like things followed by …
+          summaryStart = campaign.summary.replace(new RegExp('^(([\\w\',."-]+ ){20}).*$'), '$1') + '…';
+        } else {
+          summaryStart = `${campaign.charity.name}'s campaign, ${campaign.title}`;
+        }
         this.pageMeta.setCommon(campaign.title, summaryStart, campaign.bannerUri);
 
         // As per https://angular.io/guide/security#bypass-security-apis constructing `SafeResourceUrl`s with these appends should be safe.

--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -20,7 +20,7 @@ export class Campaign {
     public solution: string,
     public startDate: Date,
     public status: 'Active' | 'Expired' | 'Preview',
-    public summary: string,
+    public summary: string | null,
     public target: number,
     public title: string,
     public updates: Array<{content: string, modifiedDate: Date}>,

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -21,11 +21,11 @@ export class CampaignService {
       return true;
     }
 
-    if (campaign.startDate > new Date()) {
+    if (new Date(campaign.startDate) > new Date()) {
       return false;
     }
 
-    return (campaign.endDate >= new Date());
+    return (new Date(campaign.endDate) >= new Date());
   }
 
   static percentRaised(campaign: (Campaign | CampaignSummary)): number | null {

--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -11,7 +11,7 @@
       <div class="page-header">
         <h3 class="rt-2">You are donating to:</h3>
         <h1 class="rt-3">{{ campaign.charity.name }}!</h1>
-        <h3 class="rt-2">For the:</h3>
+        <h3 class="rt-2">For:</h3>
         <h2 class="rt-3">{{ campaign.title }}</h2>
         <p class="campaign-summary rt-1">{{ campaign.summary }}</p>
       </div>

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -1,5 +1,5 @@
 <app-hero *ngIf="campaign"
-  [title]="fund ? fund.name + ' // ' + campaign.title : campaign.title"
+  [title]="fund ? fund.name + ' / ' + campaign.title : campaign.title"
   [description]="fund ? fund.description : campaign.summary"
   (heroSearch)="onMetacampaignSearch($event)"
   [logoUri]="fund && fund.logoUri ? fund.logoUri : null"


### PR DESCRIPTION
* Opening donations: fix date override allowing donations to campaigns with a non-Active status, when they should have opened
* Campaign detail page: fix loading and sharing metadata when there's no `summary`
* Campaign detail card: hide all target elements when there isn't one
* Campaign detail page: tidy donations closed copy & don't show empty website links
* Donate start page: tweak copy intro'ing campaign title