### PR TITLE
DON-95 - fix meta-campaign (e.g. CC19 landing) server rendering

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -58,7 +58,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "1.5mb",
+                  "maximumWarning": "2.3mb",
                   "maximumError": "3mb"
                 }
               ]
@@ -86,7 +86,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "1.5mb",
+                  "maximumWarning": "2.3mb",
                   "maximumError": "3mb"
                 }
               ]
@@ -114,7 +114,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "1.5mb",
+                  "maximumWarning": "2.3mb",
                   "maximumError": "3mb"
                 }
               ]

--- a/src/app/hero/hero.component.scss
+++ b/src/app/hero/hero.component.scss
@@ -1,11 +1,11 @@
 @import '../../styles';
 
 .webp-bg.hero {
-  background-image: url(../../assets/bg-hero-christmas.webp);
+  background-image: url(/assets/bg-hero-christmas.webp);
 }
 
 .nowebp-bg.hero {
-  background-image: url(../../assets/bg-hero-christmas.png);
+  background-image: url(/assets/bg-hero-christmas.png);
 }
 
 .hero {

--- a/src/app/hero/hero.component.ts
+++ b/src/app/hero/hero.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, EventEmitter, Inject, Input, OnInit, Output, PLATFORM_ID } from '@angular/core';
 
 @Component({
   selector: 'app-hero',
@@ -11,12 +12,22 @@ export class HeroComponent implements OnInit {
   @Input() public logoUri?: string;
   @Output() heroSearch: EventEmitter<any> = new EventEmitter();
 
-  public webp: boolean; // Dynamically use the smallest supported image format
+  /**
+   * Dynamically use the smallest supported image format. Default to true to optimise
+   * server-client handover for modern browsers that are likely to load the image itself
+   * faster. On the client side, Modernizr jumps in asynchroously in `ngOnInit()` and
+   * switches the background over to the png, on browsers that need it.
+   */
+  public webp = true;
 
-  constructor() { }
+  // tslint:disable-next-line:ban-types Angular types this ID as `Object` so we must follow suit.
+  constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
 
   ngOnInit() {
-    Modernizr.on('webp', browserSupportsWebp => this.webp = browserSupportsWebp);
+    // The server doesn't know what's rendering the page, so can't check for webp support
+    if (isPlatformBrowser(this.platformId)) {
+      Modernizr.on('webp', browserSupportsWebp => this.webp = browserSupportsWebp);
+    }
   }
 
   search(term: string) {


### PR DESCRIPTION
This should fix this page usually crashing until the client takes over, which resulted from the browser-targeting webp detection in `HeroComponent` trying to run on the server too.

On browsers that do support webp, the path update should also make the background load faster. Those which don't should switch to the PNG immediately after the main page load.