### PR TITLE
DON-120, DON-139 - back to fund-specific metacampaign links

### DIFF
--- a/src/app/campaign-card/campaign-card.component.html
+++ b/src/app/campaign-card/campaign-card.component.html
@@ -11,7 +11,7 @@
 
   <div class="card-header">
     <h4 class="charity-name">{{ campaign.charity.name }}</h4>
-    <h3 class="campaign-title"><a [routerLink]="'/campaign/' + campaign.id">{{ campaign.title }}</a></h3>
+    <h3 class="campaign-title"><a [routerLink]="'/campaign/' + campaign.id" [queryParams]="inFundContext ? {fromFund: 1} : {}">{{ campaign.title }}</a></h3>
   </div>
 
   <div class="campaign-categories__wrap">
@@ -37,6 +37,7 @@
       color="accent"
       class="more-button"
       [routerLink]="'/campaign/' + campaign.id"
+      [queryParams]="inFundContext ? {fromFund: 1} : {}"
     >
       More info
       <mat-icon aria-hidden="false" aria-label="Plus">add</mat-icon>

--- a/src/app/campaign-card/campaign-card.component.ts
+++ b/src/app/campaign-card/campaign-card.component.ts
@@ -9,6 +9,7 @@ import { CampaignSummary } from '../campaign-summary.model';
 })
 export class CampaignCardComponent implements OnInit {
   @Input() public campaign: CampaignSummary;
+  @Input() public inFundContext: boolean;
 
   constructor() {}
 

--- a/src/app/campaign-details-card/campaign-details-card.component.html
+++ b/src/app/campaign-details-card/campaign-details-card.component.html
@@ -27,7 +27,6 @@
         <p class="campaign-target-value sm">{{ campaign.donationCount | number:'1.0-0' }}</p>
       </div>
     </div>
-    <p class="championed-by" *ngIf="campaign.championName">Championed by <strong>{{campaign.championName}}</strong></p>
+    <p class="championed-by" *ngIf="campaign.championName"><a [routerLink]="'/' + campaign.parentRef + '/' + campaign.championRef">Championed by <strong>{{campaign.championName}}</strong></a></p>
   </div>
-
 </div>

--- a/src/app/campaign-details-card/campaign-details-card.component.scss
+++ b/src/app/campaign-details-card/campaign-details-card.component.scss
@@ -33,8 +33,12 @@
 }
 
 .championed-by {
-  color:$colour-teal;
+  color: $colour-teal;
   margin-bottom: 0;
+
+  a {
+    text-decoration: none;
+  }
 }
 
 mat-progress-bar {

--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -1,5 +1,9 @@
 <div class="details" *ngIf="campaign">
   <div class="listing-button">
+    <button *ngIf="campaign.parentRef && fromFund" mat-icon-button class="listing-button__button block" [routerLink]="'/' + campaign.parentRef + '/' + campaign.championRef">
+      <mat-icon class="listing-button__icon" aria-hidden="false" aria-label="Back">keyboard_arrow_left</mat-icon>
+      All {{ campaign.championName }} campaigns<br>
+    </button>
     <button *ngIf="campaign.parentRef" mat-icon-button class="listing-button__button" [routerLink]="'/' + campaign.parentRef">
       <mat-icon class="listing-button__icon" aria-hidden="false" aria-label="Back">keyboard_arrow_left</mat-icon>
       All participating campaigns

--- a/src/app/campaign-details/campaign-details.component.scss
+++ b/src/app/campaign-details/campaign-details.component.scss
@@ -8,6 +8,11 @@
   @include make-back-button;
 }
 
+.listing-button__button.block {
+  display: block;
+  margin-bottom: 0;
+}
+
 .campaign-header {
   @include make-primary-column;
 

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DomSanitizer, makeStateKey, SafeResourceUrl, TransferState } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Params } from '@angular/router';
 
 import { Campaign } from '../campaign.model';
 import { CampaignService } from '../campaign.service';
@@ -16,6 +16,7 @@ export class CampaignDetailsComponent implements OnInit {
   public campaignId: string;
   public clientSide: boolean;
   public donateEnabled = true;
+  public fromFund = false;
   public percentRaised?: number;
   public videoEmbedUrl?: SafeResourceUrl;
 
@@ -27,6 +28,11 @@ export class CampaignDetailsComponent implements OnInit {
     private state: TransferState,
   ) {
     route.params.pipe().subscribe(params => this.campaignId = params.campaignId);
+    route.queryParams.forEach((params: Params) => {
+      if (params.fromFund) {
+        this.fromFund = true;
+      }
+    });
   }
 
   ngOnInit() {

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -18,7 +18,7 @@
 
   <mat-spinner *ngIf="loading" color="accent" diameter="30"></mat-spinner>
 
-  <div *ngIf="campaign && children.length === 0 && !loading">
+  <div *ngIf="campaign && children.length === 0 && !loading && !filterError">
     <p class="error">
       We can't find any campaigns matching this search but there are lots more to choose from.
       <a (click)="setDefaultFilters()">View all participating campaigns here</a>.
@@ -27,7 +27,7 @@
 
   <div class="cards-grid">
     <div class="cards-grid__card" *ngFor="let campaign of children">
-      <app-campaign-card [campaign]="campaign"></app-campaign-card>
+      <app-campaign-card [campaign]="campaign" [inFundContext]="!!fund"></app-campaign-card>
     </div>
   </div>
 
@@ -40,6 +40,6 @@
 
 <div *ngIf="filterError">
   <!-- e.g. campaign or fund slug is not recognised -->
-  <p class="error">Could not load the campaign. You might have followed a broken link.</p>
-  <p>Not to worry, you can <a routerLink="/">browse all active campaigns here</a>!</p>
+  <p class="error">Could not load the campaign. You might have followed a broken link.<br>
+    Not to worry, you can <a routerLink="/">browse all active campaigns here</a>!</p>
 </div>

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -48,11 +48,14 @@ export class MetaCampaignComponent implements OnInit {
   }
 
   ngOnInit() {
-    const fundKey = makeStateKey<Fund>(`fund-for-${this.campaignId}`);
     const metacampaignKey = makeStateKey<Campaign>(`metacampaign-${this.campaignId}`);
-
     this.campaign = this.state.get(metacampaignKey, undefined);
-    this.fund = this.state.get(fundKey, undefined);
+
+    let fundKey;
+    if (this.fundSlug) {
+      fundKey = makeStateKey<Fund>(`fund-${this.fundSlug}`);
+      this.fund = this.state.get(fundKey, undefined);
+    }
 
     if (!this.campaign) {
       if (this.campaignId) {


### PR DESCRIPTION
* DON-139 - link _Championed By..._ copy through to the champion fund-specific landing page
* DON-120 - add an extra link back to the champion fund-specific landing page when a donor clicked a card from that page
* Fix a state management bug when toggling between the fund-specific and general landing pages