### PR TITLE
DON-142 - IE11 fixes + bug mitigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run the app locally:
 
 * clone it from GitHub
 * `npm install`
-* `npm start`
+* `npm run start`
 
 The app should be running at [localhost:4200](http://localhost:4200).
 
@@ -59,6 +59,18 @@ Although it would be good to extend support for Internet Explorer
 9 and 10, they are unsupported by both Charity Checkout and
 Angular Material so this is not an option. We use user agent
 detection to explain the situation to users of these browsers.
+
+### Debugging Internet Explorer
+
+It is possible, though fiddly, to test Internet Explorer 11 complete with live reload. These steps were used on macOS but should work cross-platform:
+
+* Temporarily target ES5 for local builds - makes output less optimised but this is necessary to use the local server with IE11: in the project root `tsconfig.json` change the config to `... "target": "es5", ...`. Do not commit this change outside of a debug branch!
+* Get the latest [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and a free [test image from Microsoft](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
+* In the VirtualBox Network config, choose the Bridged Adapter and the host network you connect to the internet with
+* Boot the app with `npm run start-dangerously` to open up the development server to anyone on your local network(!)
+* Check your IP on the local network, e.g. with `ifconfig | grep inet` - you typically want a `192....` or `10....` one
+* Access in the Virtual Machine's IE11 browser at `http://{local IP from previous step}`
+* If using this approach rather than port forwarding to `127.0.0.1` you will also need to temporarily CORS whitelist your current local IP as an origin with any APIs you need to test from IE, in their staging environments
 
 ## Docker configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,16 +1188,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-      "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+      "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.0",
+        "@babel/types": "^7.7.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -1215,32 +1214,32 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/highlight": {
@@ -1263,34 +1262,34 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
+      "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0"
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-      "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0",
+        "@babel/generator": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -1320,9 +1319,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1464,9 +1463,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.4.6.tgz",
-      "integrity": "sha512-hpQHs+lmZ0uuCrGyqypdI1Ho7jRFolOBT6OkNdZPFziLSSEKvWu+VxWU6bGdNEA/hoV4jV8pdDeNx8EWlmfNAw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.0.tgz",
+      "integrity": "sha512-kGCRI9oiCxFS6soGKlyzhMzDydfcPix9PpTkr7h11huxOxhWwP37Tg7DYBaQ18eQTNreZEuLkhpbGSqVNZPnnw==",
       "dev": true
     },
     "@types/jasminewd2": {
@@ -6676,9 +6675,9 @@
       }
     },
     "karma-coverage-istanbul-reporter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-2.1.0.tgz",
-      "integrity": "sha512-UH0mXPJFJyK5uiK7EkwGtQ8f30lCBAfqRResnZ4pzLJ04SOp4SPlYkmwbbZ6iVJ6sQFVzlDUXlntBEsLRdgZpg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-2.1.1.tgz",
+      "integrity": "sha512-CH8lTi8+kKXGvrhy94+EkEMldLCiUA0xMOiL31vvli9qK0T+qcXJAwWBRVJWnVWxYkTmyWar8lPz63dxX6/z1A==",
       "dev": true,
       "requires": {
         "istanbul-api": "^2.1.6",
@@ -10554,9 +10553,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
+      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11579,11 +11578,6 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "web-animations-js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.2.tgz",
-      "integrity": "sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA=="
     },
     "webdriver-js-extender": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ngx-webstorage-service": "^4.1.0",
     "rxjs": "^6.5.3",
     "tslib": "^1.9.0",
-    "web-animations-js": "^2.3.2",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
@@ -58,7 +57,7 @@
     "@angular/cli": "^8.3.19",
     "@angular/compiler-cli": "^8.2.14",
     "@angular/language-service": "^8.2.14",
-    "@types/jasmine": "^3.4.6",
+    "@types/jasmine": "^3.5.0",
     "@types/jasminewd2": "^2.0.8",
     "@types/node": "~8.9.4",
     "codelyzer": "^5.2.0",
@@ -66,7 +65,7 @@
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~4.1.0",
     "karma-chrome-launcher": "~3.1.0",
-    "karma-coverage-istanbul-reporter": "^2.1.0",
+    "karma-coverage-istanbul-reporter": "^2.1.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "protractor": "~5.4.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start-dangerously": "ng serve --host 0.0.0.0",
     "test": "ng test",
     "test-ci": "ng test --karma-config ./karma-ci.conf.js --browsers=ChromeHeadlessNoSandbox",
     "lint": "ng lint",

--- a/src/app/campaign-card/campaign-card.component.html
+++ b/src/app/campaign-card/campaign-card.component.html
@@ -21,13 +21,13 @@
   </div>
 
   <div class="funds" fxLayout="row">
-    <div class="matched-funds" *ngIf="campaign.isMatched" fxFlex="50" fxLayout="column">
-      <p class="rt-sm" fxFlex="50">Matched funds remaining</p>
-      <h4 class="matched-funds__amount" fxFlex="50">{{ campaign.matchFundsRemaining | currency : '£' : 'symbol' : '1.0-0' }}</h4>
+    <div class="matched-funds" *ngIf="campaign.isMatched" fxFlex="50">
+      <p class="rt-sm">Matched funds remaining</p>
+      <h4 class="matched-funds__amount">{{ campaign.matchFundsRemaining | currency : '£' : 'symbol' : '1.0-0' }}</h4>
     </div>
-    <div class="total-funds" *ngIf="campaign.isMatched" fxFlex="50" fxLayout="column">
-      <p class="rt-sm" fxFlex="50">Total funds raised</p>
-      <h4 class="total-funds__amount" fxFlex="50">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</h4>
+    <div class="total-funds" *ngIf="campaign.isMatched" fxFlex="50">
+      <p class="rt-sm">Total funds raised</p>
+      <h4 class="total-funds__amount">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</h4>
     </div>
   </div>
 

--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -35,7 +35,6 @@
               <p class="centered-p rt-0">Or, choose</p>
               <div class="suggested-amount" fxLayout="row">
                 <button
-                  fxFlex="calc((100 - 1rem)/3)"
                   class="suggested-amount__button"
                   type="button"
                   *ngFor="let suggestedAmount of suggestedAmounts"

--- a/src/app/donation-start/donation-start.component.scss
+++ b/src/app/donation-start/donation-start.component.scss
@@ -84,13 +84,15 @@ p.rt-0 mat-icon {
 }
 
 .suggested-amount__button {
+  flex: 1 0 auto;
+  width: calc((100 - 1rem) / 3);
   background-color: $colour-teal-light;
   box-shadow: inset 0px 1px 4px rgba(0, 131, 143, 0.2);
   padding: 1rem;
   border: none;
   border-radius: 4px;
   margin-right: 0.5rem;
-  color:$colour-teal;
+  color: $colour-teal;
   font-family: "Maven Pro", sans-serif;
   font-weight: 500;
   @include rt-2;
@@ -148,10 +150,10 @@ a {
   }
 
   div {
-    display:flex;
-    flex-direction:column;
+    display: flex;
+    flex-direction: column;
     justify-content: flex-end;
-    align-items:center;
+    align-items: center;
     .strong-p {
       margin-top: auto;
     }

--- a/src/app/meta-campaign/meta-campaign.component.scss
+++ b/src/app/meta-campaign/meta-campaign.component.scss
@@ -6,18 +6,14 @@
 
 .cards-grid {
   width: 100%;
-  display: -ms-grid;
   display: grid;
-  -ms-grid-columns: 100%;
   grid-template-columns: 100%;
   gap: 15px;
   row-gap: 15px;
   @media #{$breakpoint-md} {
-    -ms-grid-columns: calc((100% - 15px)/2) calc((100% - 15px)/2);
     grid-template-columns: calc((100% - 15px)/2) calc((100% - 15px)/2);
   }
   @media #{$breakpoint-lg} {
-    -ms-grid-columns: calc((100% - 60px)/3) calc((100% - 60px)/3) calc((100% - 60px)/3);
     grid-template-columns: calc((100% - 60px)/3) calc((100% - 60px)/3) calc((100% - 60px)/3);
     gap: 30px;
     row-gap: 30px;

--- a/src/app/ticker/ticker.component.html
+++ b/src/app/ticker/ticker.component.html
@@ -4,13 +4,15 @@
     <span *ngIf="!fund && campaign.amountRaised > 0" ><em class="c-ticker__value c-ticker__value--emphasised">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</em> raised</span>
     <span *ngIf="!fund && campaign.amountRaised == 0">Opens in <em  class="c-ticker__value c-ticker__value--emphasised">{{ campaign.startDate | timeLeft }}</em></span>
   </div>
-  <ul class="c-ticker__list" *ngFor="let index of [0,1,2]">
-    <li class="c-ticker__item" *ngIf="fund"><span class="c-ticker__value">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</span> raised across all funds</li>
-    <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.campaignCount | number }}</span> charities</li>
-    <li class="c-ticker__item" *ngIf="campaign.donationCount > 0"><span class="c-ticker__value">{{ campaign.donationCount | number }}</span> donations</li>
-    <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.matchFundsTotal | currency : '£' : 'symbol' : '1.0-0' }}</span> total match funds</li>
-    <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.matchFundsRemaining | currency : '£' : 'symbol' : '1.0-0' }}</span> match funds remaining</li>
-    <li class="c-ticker__item"><span class="c-ticker__value">{{ durationInDays | number }}</span> days</li>
-    <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.target | currency : '£' : 'symbol' : '1.0-0' }}</span> target</li>
-  </ul>
+  <div class="c-ticker__lists">
+    <ul class="c-ticker__list" *ngFor="let index of [0,1,2]">
+      <li class="c-ticker__item" *ngIf="fund"><span class="c-ticker__value">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</span> raised across all funds</li>
+      <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.campaignCount | number }}</span> charities</li>
+      <li class="c-ticker__item" *ngIf="campaign.donationCount > 0"><span class="c-ticker__value">{{ campaign.donationCount | number }}</span> donations</li>
+      <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.matchFundsTotal | currency : '£' : 'symbol' : '1.0-0' }}</span> total match funds</li>
+      <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.matchFundsRemaining | currency : '£' : 'symbol' : '1.0-0' }}</span> match funds remaining</li>
+      <li class="c-ticker__item"><span class="c-ticker__value">{{ durationInDays | number }}</span> days</li>
+      <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.target | currency : '£' : 'symbol' : '1.0-0' }}</span> target</li>
+    </ul>
+  </div>
 </div>

--- a/src/app/ticker/ticker.component.scss
+++ b/src/app/ticker/ticker.component.scss
@@ -1,12 +1,7 @@
 @import '../../styles';
 
 .c-ticker {
-  background-color: #333;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  position: relative;
-  overflow: hidden;
+  height: 40px; // Make height explicit; avoids e.g. heading overlap on IE11
 }
 
 .c-ticker__total {
@@ -32,6 +27,19 @@
   }
 }
 
+.c-ticker__lists {
+  background-color: #333;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  top: 1px;
+  @media #{$breakpoint-md} {
+    top: 4px;
+  }
+}
+
 .c-ticker__list {
   animation: ticker 15s infinite linear;
   display: inline-flex;
@@ -46,6 +54,12 @@
   }
   @media #{$breakpoint-xl} {
     animation-duration: 20s;
+  }
+
+  // IE11 really can't handle the moving bar's layout, so to keep the basics usable, for now
+  // we're unfortunately hiding it with a vendor-specific hack.
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    display: none;
   }
 }
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -28,7 +28,7 @@
  */
 
 // Seemingly also needed by Angular Material for IE11, see https://stackoverflow.com/a/51442855/2803757
-import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 /**
  * By default, zone.js will patch all possible macroTask and DomEvents
@@ -66,20 +66,3 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 
  // Support `includes(...)` for arrays in IE11 etc. Not polyfilled for Angular core.
 import 'core-js/modules/es.array.includes';
-
-// Try kitchen sync polyfills to see if any combination gets IE11 working for now.
-// See WIP DON-142 and https://stackoverflow.com/a/46037724/2803757
-import 'core-js/es/symbol';
-import 'core-js/es/object';
-import 'core-js/es/function';
-import 'core-js/es/parse-int';
-import 'core-js/es/parse-float';
-import 'core-js/es/number';
-import 'core-js/es/math';
-import 'core-js/es/string';
-import 'core-js/es/date';
-import 'core-js/es/array';
-import 'core-js/es/regexp';
-import 'core-js/es/map';
-import 'core-js/es/weak-map';
-import 'core-js/es/set';


### PR DESCRIPTION
* lay out suggested amounts in an IE11-safe way (fix donate page crash)
* remove flex column within cards
* metacampaign: have IE11 show 1 usable column instead of a completely broken layout
* make ticker IE11-friendly, hiding the animated part there with a vendor hack
* drop extra polyfills which no longer appear necessary for IE11
* document local IE debugging