### PR TITLE
DON-113 - fix mobile menu layout + Safari jump

### DIFF
--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -65,7 +65,9 @@
     mode="over"
     [(opened)]="opened"
     (opened)="events.push('open!')"
-    (closed)="events.push('close!')">
+    (closed)="events.push('close!')"
+    fixedInViewport="true"
+  >
     <!-- <app-nav-search-form></app-nav-search-form> -->
     <mat-nav-list class="mat-nav-list nav-links__wrap"><div class="nav-links">
         <button mat-icon-button (click)="sidenav.open()" [matMenuTriggerFor]="about">

--- a/src/app/navigation/navigation.component.scss
+++ b/src/app/navigation/navigation.component.scss
@@ -6,11 +6,26 @@ mat-sidenav-container {
 
 mat-sidenav {
   width:100%;
+  margin-top: 56px;
   @media #{$breakpoint-md} {
     max-width: 300px;
   }
   @media (min-width: 960px) {
     display: none;
+  }
+
+  .nav-links {
+    display: block;
+  }
+
+  .mat-icon-button,
+  .mat-button {
+    font-size: 16px;
+  }
+
+  .mat-icon-button {
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }
 
@@ -86,22 +101,6 @@ mat-sidenav {
   padding-right: 16px;
 }
 
-mat-sidenav {
-  .nav-links {
-    display: block;
-  }
-
-  .mat-icon-button,
-  .mat-button {
-    font-size: 16px;
-  }
-
-  .mat-icon-button {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-}
-
 .charity-login__wrap {
   display:flex;
   align-items: center;
@@ -142,4 +141,3 @@ mat-sidenav {
     display: none;
   }
 }
-


### PR DESCRIPTION
* Stop scrolling past menu content, in all browsers
* Fix position glitch on open in Safari

Applied the equivalent of the [suggestions here](https://stackoverflow.com/a/52704311/2803757) and it seems to have resolved both issues. Tested mobile Safari in the Simulator (iPhone 11 Pro).