### PR TITLE
DON-132 - make campaign detail pages auto-activate

### DIFF
--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -228,6 +228,10 @@ export class DonationStartComponent implements OnInit {
     return parseFloat(this.donationForm.value.donationAmount) + this.giftAidAmount() + this.expectedMatchAmount();
   }
 
+  /**
+   * Unlike the CampaignService method which is more forgiving if the status gets stuck Active (we don't trust
+   * these to be right in Salesforce yet), this check relies solely on campaign dates.
+   */
   campaignIsOpen(): boolean {
     return (
       this.campaign


### PR DESCRIPTION
When donations aren't open yet but will open within 24 hours, this sets a timer for the campaign detail page to automatically switch from the dates text to the Donate button when donations open.