### PR TITLE
DON-159 - replace URL state on 'not open' redirect

### DIFF
--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -241,7 +241,7 @@ export class DonationStartComponent implements OnInit {
    */
   private handleCampaign(campaign: Campaign) {
     if (!CampaignService.isOpenForDonations(campaign)) {
-      this.router.navigateByUrl(`/campaign/${campaign.id}`);
+      this.router.navigateByUrl(`/campaign/${campaign.id}`, { replaceUrl: true });
       return;
     }
 


### PR DESCRIPTION
This maintains the expected back button / browser history behaviour when a donor is redirect to the campaign page because the campaign's not yet opened.