### PR TITLE
DON-104 - fix donation state updates trashing other tokens

### DIFF
--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -130,6 +130,7 @@ export class DonationService {
     const donationCouplets = this.getDonationCouplets();
     donationCouplets.splice(
       donationCouplets.findIndex(donationItem => donationItem.donation.donationId === donation.donationId),
+      1,
     );
     this.storage.set(this.storageKey, donationCouplets);
   }


### PR DESCRIPTION
With the previous bogus `splice(...)` call, anything leading to a removal - including the state update on the thank you page which removes and re-adds your copy of the complete donation - could lead to other donation tokens being removed from state