### PR TITLE
[DO NOT MERGE] Production config change: disable all suggested amounts

### DIFF
--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -6,13 +6,8 @@ export const environment = {
   donationsApiPrefix: 'https://matchbot-production.thebiggive.org.uk/v1',
   googleAnalyticsId: 'UA-2979952-1',
   maximumDonationAmount: 25000,
-  // Each of 4x suggestion sets for 5% of donors each, no suggestions for the other 80%.
   suggestedAmounts: [
-    { weight: 1,  values: [30, 100, 250] },
-    { weight: 1,  values: [50, 200, 500] },
-    { weight: 1,  values: [20,  50, 100] },
-    { weight: 1,  values: [20, 100, 500] },
-    { weight: 16, values: [] },
+    { weight: 1, values: [] },
   ],
   thanksUriPrefix: 'https://donate.thebiggive.org.uk/thanks/',
 };


### PR DESCRIPTION
This PR is ready as a contingency plan if we find from Analytics data that the new suggested donation amounts feature is having an adverse effect on donations.

We should merge it only after allowing enough time and analysing data to a point where we are convinced this is the case.