### PR TITLE
DON-170 - remove extra modules; fix superfluous @imports; theme only the components we use

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,7 +2,6 @@ import { TestBed, async } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import {
   MatButtonModule,
-  MatCardModule,
   MatIconModule,
   MatInputModule,
   MatListModule,
@@ -24,7 +23,6 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         MatButtonModule, // Not required but makes test DOM layout more realistic
-        MatCardModule,
         MatIconModule,
         MatInputModule,
         MatListModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,10 +4,8 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { ReactiveFormsModule } from '@angular/forms';
 import {
   MatButtonModule,
-  MatCardModule,
   MatDialogModule,
   MatExpansionModule,
-  MatGridListModule,
   MatIconModule,
   MatInputModule,
   MatListModule,
@@ -83,10 +81,8 @@ import { TimeLeftPipe } from './time-left.pipe';
     HttpClientModule,
     InfiniteScrollModule,
     MatButtonModule,
-    MatCardModule,
     MatDialogModule,
     MatExpansionModule,
-    MatGridListModule,
     MatIconModule,
     MatInputModule,
     MatListModule,

--- a/src/app/campaign-card/campaign-card.component.scss
+++ b/src/app/campaign-card/campaign-card.component.scss
@@ -1,10 +1,5 @@
 @import '../../styles';
 
-// If we somehow end up with an unexpected-ratio image, let Angular Material do its
-// thing with `mat-card-image` on the `img` itself (can't set a max height as this
-// would stretch it when combined with that) but use this to ensure the card can't
-// grow to a height that breaks the layout.
-
 .c-card {
   @include make-card;
   display:flex;

--- a/src/app/campaign-card/campaign-card.component.spec.ts
+++ b/src/app/campaign-card/campaign-card.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonModule, MatCardModule, MatIconModule, MatSelectModule, MatProgressBarModule } from '@angular/material';
+import { MatButtonModule, MatIconModule, MatSelectModule, MatProgressBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { CampaignCardComponent } from './campaign-card.component';
@@ -14,7 +14,6 @@ describe('CampaignCardComponent', () => {
       declarations: [ CampaignCardComponent ],
       imports: [
         MatButtonModule,
-        MatCardModule,
         MatIconModule,
         MatProgressBarModule,
         MatSelectModule,

--- a/src/app/campaign-details-card/campaign-details-card.component.spec.ts
+++ b/src/app/campaign-details-card/campaign-details-card.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonModule, MatCardModule, MatIconModule, MatSelectModule, MatProgressBarModule } from '@angular/material';
+import { MatButtonModule, MatIconModule, MatSelectModule, MatProgressBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { Campaign } from '../campaign.model';
@@ -15,7 +15,6 @@ describe('CampaignDetailsCardComponent', () => {
       declarations: [ CampaignDetailsCardComponent, TimeLeftPipe ],
       imports: [
         MatButtonModule,
-        MatCardModule,
         MatIconModule,
         MatProgressBarModule,
         MatSelectModule,

--- a/src/app/hero/hero.component.spec.ts
+++ b/src/app/hero/hero.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { MatButtonModule, MatCardModule, MatInputModule, MatSelectModule, MatProgressBarModule } from '@angular/material';
+import { MatButtonModule, MatInputModule, MatSelectModule, MatProgressBarModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Observable } from 'rxjs';
 
@@ -25,7 +25,6 @@ describe('HeroComponent', () => {
       imports: [
         MatButtonModule,
         MatInputModule,
-        MatCardModule,
         MatProgressBarModule,
         MatSelectModule,
         NoopAnimationsModule,

--- a/src/app/meta-campaign/meta-campaign.component.spec.ts
+++ b/src/app/meta-campaign/meta-campaign.component.spec.ts
@@ -3,8 +3,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import {
   MatButtonModule,
-  MatCardModule,
-  MatGridListModule,
   MatIconModule,
   MatInputModule,
   MatProgressBarModule,
@@ -46,8 +44,6 @@ describe('MetaCampaignComponent', () => {
         HttpClientTestingModule,
         InfiniteScrollModule,
         MatButtonModule, // Not required but makes test DOM layout more realistic
-        MatCardModule,
-        MatGridListModule,
         MatIconModule,
         MatInputModule,
         MatProgressBarModule,

--- a/src/app/search-results/search-results.component.html
+++ b/src/app/search-results/search-results.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="searched && campaigns.length == 0">No results :( Please try another search term</mat-card>
+<p *ngIf="searched && campaigns.length == 0">No results :( Please try another search term</p>
 
 <div class="cards-grid">
   <div class="cards-grid__card" *ngFor="let campaign of campaigns">

--- a/src/app/search-results/search-results.component.scss
+++ b/src/app/search-results/search-results.component.scss
@@ -3,7 +3,3 @@
 app-campaign-card {
   width: 100%;
 }
-
-mat-grid-list {
-  margin: 1rem;
-}

--- a/src/app/search-results/search-results.component.spec.ts
+++ b/src/app/search-results/search-results.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatCardModule, MatIconModule, MatGridListModule, MatProgressBarModule } from '@angular/material';
+import { MatIconModule, MatProgressBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
@@ -18,9 +18,7 @@ describe('SearchResultsComponent', () => {
       ],
       imports: [
         HttpClientTestingModule,
-        MatCardModule,
         MatIconModule,
-        MatGridListModule,
         MatProgressBarModule,
         RouterTestingModule.withRoutes([
           {

--- a/src/assets/scss/_mat-theme.scss
+++ b/src/assets/scss/_mat-theme.scss
@@ -59,7 +59,15 @@ $app-typography: mat-typography-config(
 
 @include mat-core($app-typography);
 
-// Include theme styles for core and each component used in your app.
-// Alternatively, you can import and @include the theme mixins for each component
-// that you are using.
-@include angular-material-theme($donate-theme);
+// Include styles only for core + the components we use. SSR currently preloads the lot so it's important to keep
+// this as light (for page weight) as we can.
+// See https://github.com/angular/components/blob/master/guides/theming.md#theming-only-certain-components
+@include mat-core-theme($donate-theme);
+
+@include mat-button-theme($donate-theme);
+@include mat-dialog-theme($donate-theme);
+@include mat-form-field-theme($donate-theme);
+@include mat-menu-theme($donate-theme);
+@include mat-radio-theme($donate-theme);
+@include mat-select-theme($donate-theme);
+@include mat-tabs-theme($donate-theme);

--- a/src/assets/scss/_mat-theme.scss
+++ b/src/assets/scss/_mat-theme.scss
@@ -1,7 +1,5 @@
 @import '~@angular/material/theming';
 
-@include mat-core();
-
 $tbg-red: (
   500: #f0423b,
   800: #c1211a,
@@ -65,6 +63,3 @@ $app-typography: mat-typography-config(
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
 @include angular-material-theme($donate-theme);
-@include mat-core-theme($donate-theme);
-@include mat-button-theme($donate-theme);
-@include mat-checkbox-theme($donate-theme);

--- a/src/assets/scss/_overwrite-mat.scss
+++ b/src/assets/scss/_overwrite-mat.scss
@@ -79,12 +79,6 @@ mat-expansion-panel {
   }
 }
 
-mat-form-field {
-  .mat-form-field-label {
-
-  }
-}
-
 mat-toolbar {
   position: sticky;
   position: -webkit-sticky;

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <link rel="preconnect" href="https://full-biggive.cs128.force.com">
+  <link rel="preconnect" href="https://sf-api-staging.thebiggivetest.org.uk">
   <link rel="preconnect" href="https://matchbot-staging.thebiggivetest.org.uk">
   <meta charset="utf-8">
   <title>The Big Give</title>
@@ -12,7 +12,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <script src="/assets/custom-libs/modernizr.js"></script> <!-- Just webp support detection -->
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root id="app"></app-root>

--- a/src/index.production.html
+++ b/src/index.production.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <link rel="preconnect" href="https://biggive.secure.force.com">
+  <link rel="preconnect" href="https://sf-api-production.thebiggive.org.uk">
   <link rel="preconnect" href="https://images-production.thebiggive.org.uk">
   <link rel="preconnect" href="https://matchbot-production.thebiggive.org.uk">
   <meta charset="utf-8">

--- a/src/index.staging.html
+++ b/src/index.staging.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <link rel="preconnect" href="https://full-biggive.cs128.force.com">
+  <link rel="preconnect" href="https://sf-api-staging.thebiggivetest.org.uk">
   <link rel="preconnect" href="https://images-staging.thebiggivetest.org.uk">
   <link rel="preconnect" href="https://matchbot-staging.thebiggivetest.org.uk">
   <meta charset="utf-8">


### PR DESCRIPTION
This is one of a _lot_ of things I've tried tonight to get the bundled page weight down, especially for the initial CC19 landing page, which bots are refusing to parse because of the size.

I don't think it's by any means going to get rid of a majority of the page weight, but it does take out some styles that shouldn't be there (there is a warning in a guide I read specifically about not having the `mat-core` mixin included more than once) so should at least help a bit, and I think it's reasonably low risk.