### PR TITLE
DON-171 - temporarily hide "Match funds are currently available!" banner

### DIFF
--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -26,10 +26,11 @@
                   <h3 class="b-rh-2">Your donation</h3>
                 </mat-panel-title>
               </mat-expansion-panel-header>
-              <p *ngIf="campaign.matchFundsRemaining > 0" class="c-your-donation__highlight">
+              <!-- Temporarily hiding this banner due to delays in the campaign view of matchFundsRemaining -->
+              <!-- <p *ngIf="campaign.matchFundsRemaining > 0" class="c-your-donation__highlight">
                 <img src="/assets/images/icon-tick.png" height="11" alt="Check mark">
                 Match funds are currently available!
-              </p>
+              </p> -->
               <mat-form-field class="c-your-donation__form-field b-center size-lg" color="accent">
                 <mat-label for="donationAmount">Enter an amount (£)</mat-label>
                 <input formControlName="donationAmount" id="donationAmount" matInput>


### PR DESCRIPTION
We want to reduce confusion from unexpectedly long delays in the campaign object view of the `matchFundsRemaining`.

We'll reinstate this when we're pulling campaign data close-to-live as planned.