### PR TITLE
DON-157, DON-173 -  improve empty search term UX

### DIFF
--- a/src/app/campaign-search-form/campaign-search-form.component.html
+++ b/src/app/campaign-search-form/campaign-search-form.component.html
@@ -3,12 +3,11 @@
   <form class="c-form" (ngSubmit)="submit()" [formGroup]="searchForm">
     <mat-form-field class="b-w-100" color="accent">
       <mat-label for="term">Enter a keyword...</mat-label>
-      <input matInput formControlName="term" id="term" type="text">
+      <input #term matInput formControlName="term" id="term" type="text">
     </mat-form-field>
 
     <button
       class="c-form__button b-w-100 b-db b-light"
-      [disabled]="!this.searchForm.valid"
       mat-raised-button
       color="accent"
       type="submit"

--- a/src/app/campaign-search-form/campaign-search-form.component.spec.ts
+++ b/src/app/campaign-search-form/campaign-search-form.component.spec.ts
@@ -31,18 +31,18 @@ describe('CampaignSearchFormComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create with search button disabled', () => {
+  it('should create with search button enabled', () => {
     expect(component).toBeTruthy();
-    expect(component.searchForm.valid).toBe(false);
+    expect(component.searchForm.valid).toBe(true);
   });
 
-  it('should still have search button disabled after 1 character entered', () => {
+  it('should be considered invalid after 1 character entered', () => {
     component.searchForm.setValue({term: 'T'});
 
     expect(component.searchForm.valid).toBe(false);
   });
 
-  it('should have search button enabled after 2 characters entered', () => {
+  it('should be considered valid again after 2 characters entered', () => {
     component.searchForm.setValue({term: 'Te'});
 
     expect(component.searchForm.valid).toBe(true);

--- a/src/app/campaign-search-form/campaign-search-form.component.ts
+++ b/src/app/campaign-search-form/campaign-search-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Observable, Subscription } from 'rxjs';
 
@@ -8,6 +8,7 @@ import { Observable, Subscription } from 'rxjs';
   styleUrls: ['./campaign-search-form.component.scss'],
 })
 export class CampaignSearchFormComponent implements OnInit, OnDestroy {
+  @ViewChild('term', {static: false}) termField: ElementRef;
   @Input() campaignId: string;
   @Input() reset: Observable<void>;
   @Output() search: EventEmitter<any> = new EventEmitter();
@@ -23,7 +24,6 @@ export class CampaignSearchFormComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.searchForm = this.formBuilder.group({
       term: [null, [
-        Validators.required,
         Validators.minLength(2),
       ]],
     });
@@ -38,6 +38,15 @@ export class CampaignSearchFormComponent implements OnInit, OnDestroy {
   }
 
   submit() {
+    // If the donor hasn't ever clicked/tapped the 'term' field yet, they probably didn't mean to start a search,
+    // so in this case only treat empty input like an invalid form and point their focus to the field. Otherwise,
+    // do this only if the term is invalid based on length (exactly 1 character).
+    if (!this.searchForm.touched || !this.searchForm.valid) {
+      this.termField.nativeElement.focus();
+      return;
+    }
+
+    // In all valid cases, including an empty term, update the results.
     this.search.emit(this.searchForm.value.term);
   }
 }


### PR DESCRIPTION
* Never disable the Search button - just make it focus the term field when the situation suggests the user hasn't finished populating it
* Treat an empty term as valid, and treat it as a clearing of the term if the box has been focused on this app load