### PR TITLE
Add a line to indicate what's going on outside campaign dates

### DIFF
--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -17,164 +17,164 @@
         <h2 class="b-rh-1 b-bold">{{ campaign.title }}</h2>
       </div>
 
-      <form class="c-donate-form" (ngSubmit)="submit()" [formGroup]="donationForm" *ngIf="campaign">
-        <div *ngIf="campaignIsOpen()">
-          <mat-accordion multi="true">
-            <mat-expansion-panel class="c-your-donation" expanded="true">
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  <h3 class="b-rh-2">Your donation</h3>
-                </mat-panel-title>
-              </mat-expansion-panel-header>
-              <p *ngIf="campaign.matchFundsRemaining > 0" class="c-your-donation__highlight">
-                <img src="/assets/images/icon-tick.png" height="11" alt="Check mark">
-                Match funds are currently available!
-              </p>
-              <mat-form-field class="c-your-donation__form-field b-center size-lg" color="accent">
-                <mat-label for="donationAmount">Enter an amount (£)</mat-label>
-                <input formControlName="donationAmount" id="donationAmount" matInput>
-              </mat-form-field>
-              <p *ngIf="suggestedAmounts && suggestedAmounts.length > 0" class="b-center b-grey b-rt-0">Or, choose</p>
-              <div *ngIf="suggestedAmounts && suggestedAmounts.length > 0" class="c-suggested-amount" fxLayout="row">
-                <button
-                  class="c-suggested-amount__button b-rh-2 b-bold"
-                  type="button"
-                  *ngFor="let suggestedAmount of suggestedAmounts"
-                  (click)="setAmount(suggestedAmount)"
-                >{{ suggestedAmount | currency : '£' : 'symbol' : '1.0-0' }}</button>
-              </div>
+      <p *ngIf="campaign && !campaignIsOpen()">Donations open {{ campaign.startDate | date : 'h:mm a, d LLLL yyyy' }} to {{ campaign.endDate | date : 'h:mm a, d LLLL yyyy' }}</p>
 
-              <div class="error" *ngIf="f.donationAmount.invalid && (f.donationAmount.dirty || f.donationAmount.touched)">
-                <div *ngIf="f.donationAmount.errors.min">Sorry, the minimum donation is currently £5.</div>
-                <div *ngIf="f.donationAmount.errors.max">Your donation must be £25,000 or less to proceed. You can make multiple matched donations of £25,000 if match funds are available.</div>
-                <div *ngIf="f.donationAmount.errors.pattern">Please enter a whole number of pounds (£) without commas or pence.</div>
-                <div *ngIf="f.donationAmount.errors.required">Please enter how much you would like to donate.</div>
-              </div>
-            </mat-expansion-panel>
+      <form class="c-donate-form" (ngSubmit)="submit()" [formGroup]="donationForm" *ngIf="campaign && campaignIsOpen()">
+        <mat-accordion multi="true">
+          <mat-expansion-panel class="c-your-donation" expanded="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <h3 class="b-rh-2">Your donation</h3>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <p *ngIf="campaign.matchFundsRemaining > 0" class="c-your-donation__highlight">
+              <img src="/assets/images/icon-tick.png" height="11" alt="Check mark">
+              Match funds are currently available!
+            </p>
+            <mat-form-field class="c-your-donation__form-field b-center size-lg" color="accent">
+              <mat-label for="donationAmount">Enter an amount (£)</mat-label>
+              <input formControlName="donationAmount" id="donationAmount" matInput>
+            </mat-form-field>
+            <p *ngIf="suggestedAmounts && suggestedAmounts.length > 0" class="b-center b-grey b-rt-0">Or, choose</p>
+            <div *ngIf="suggestedAmounts && suggestedAmounts.length > 0" class="c-suggested-amount" fxLayout="row">
+              <button
+                class="c-suggested-amount__button b-rh-2 b-bold"
+                type="button"
+                *ngFor="let suggestedAmount of suggestedAmounts"
+                (click)="setAmount(suggestedAmount)"
+              >{{ suggestedAmount | currency : '£' : 'symbol' : '1.0-0' }}</button>
+            </div>
 
-            <mat-expansion-panel expanded="true">
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  <h3 class="b-rh-2" id="giftAid-label">Gift Aid</h3>
-                </mat-panel-title>
-              </mat-expansion-panel-header>
-              <p class="no-margin-top b-rt-1 b-bold">Boost your donation by 25p of Gift Aid for every £1 you donate.</p>
-              <p class="b-rt-0">'I confirm that I am a UK tax payer and I understand that if I pay less income tax and/or capital gains tax in the current tax year than the amount of Gift Aid claimed on all my donations it is my responsibility to pay the difference'.</p>
-              <p class="b-rt-0">Gift Aid is a government scheme for UK charities to reclaim the tax you have paid and gain 25% more at no cost or hassle to you.
-                <a href="https://www.thebiggive.org.uk/s/terms-and-conditions" target="_blank">
-                  <mat-icon class="b-va-mid" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-                   Find out more about Gift Aid</a>.
-              </p>
-              <mat-radio-group aria-labelledby="giftAid-label" formControlName="giftAid">
-                <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Yes, I am a UK tax payer and would like Gift Aid claimed on my donations</mat-radio-button>
-                <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">No, I am not a UK tax payer and do not want Gift Aid claimed on my donations</mat-radio-button>
-              </mat-radio-group>
-            </mat-expansion-panel>
+            <div class="error" *ngIf="f.donationAmount.invalid && (f.donationAmount.dirty || f.donationAmount.touched)">
+              <div *ngIf="f.donationAmount.errors.min">Sorry, the minimum donation is currently £5.</div>
+              <div *ngIf="f.donationAmount.errors.max">Your donation must be £25,000 or less to proceed. You can make multiple matched donations of £25,000 if match funds are available.</div>
+              <div *ngIf="f.donationAmount.errors.pattern">Please enter a whole number of pounds (£) without commas or pence.</div>
+              <div *ngIf="f.donationAmount.errors.required">Please enter how much you would like to donate.</div>
+            </div>
+          </mat-expansion-panel>
 
-            <mat-expansion-panel expanded="true">
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  <h3 class="b-rh-2" id="optInCharityEmail-label">Contact from charity</h3>
-                </mat-panel-title>
-              </mat-expansion-panel-header>
-              <p class="no-margin-top b-rt-1 b-bold">Would you be happy to receive emails from {{ campaign.charity.name }}?</p>
-              <p class="b-rt-0">This may include thanks for your donation, updates on how it is being used, newsletters and future campaigns. If you select no, we will pass on your details as these may be required for Gift Aid purposes, but the charity will be informed that you do not wish to receive communications.</p>
-              <p class="b-rt-0">Please note that you might continue to receive communications from {{ campaign.charity.name }} if you have already shared your details with them via other methods.</p>
-              <mat-radio-group aria-labelledby="optInCharityEmail-label" formControlName="optInCharityEmail">
-                <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Yes, I’m happy to receive emails from {{ campaign.charity.name }}</mat-radio-button>
-                <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">No, I would not like to receive emails from {{ campaign.charity.name }}</mat-radio-button>
-              </mat-radio-group>
-            </mat-expansion-panel>
+          <mat-expansion-panel expanded="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <h3 class="b-rh-2" id="giftAid-label">Gift Aid</h3>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <p class="no-margin-top b-rt-1 b-bold">Boost your donation by 25p of Gift Aid for every £1 you donate.</p>
+            <p class="b-rt-0">'I confirm that I am a UK tax payer and I understand that if I pay less income tax and/or capital gains tax in the current tax year than the amount of Gift Aid claimed on all my donations it is my responsibility to pay the difference'.</p>
+            <p class="b-rt-0">Gift Aid is a government scheme for UK charities to reclaim the tax you have paid and gain 25% more at no cost or hassle to you.
+              <a href="https://www.thebiggive.org.uk/s/terms-and-conditions" target="_blank">
+                <mat-icon class="b-va-mid" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                  Find out more about Gift Aid</a>.
+            </p>
+            <mat-radio-group aria-labelledby="giftAid-label" formControlName="giftAid">
+              <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Yes, I am a UK tax payer and would like Gift Aid claimed on my donations</mat-radio-button>
+              <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">No, I am not a UK tax payer and do not want Gift Aid claimed on my donations</mat-radio-button>
+            </mat-radio-group>
+          </mat-expansion-panel>
 
-            <mat-expansion-panel expanded="true">
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  <h3 class="b-rh-2" id="optInTbgEmail-label">Contact from The Big Give</h3>
-                </mat-panel-title>
-              </mat-expansion-panel-header>
-              <p class="no-margin-top b-rt-1 b-bold">Would you be happy to receive emails from The Big Give?</p>
-              <p class="b-rt-0">By selecting 'no', we will no longer be able to email you about opportunities to double your donation.</p>
-              <mat-radio-group aria-labelledby="optInTbgEmail-label" formControlName="optInTbgEmail">
-                <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Yes, I’m happy to receive emails from The Big Give</mat-radio-button>
-                <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">No, I would not like to receive emails from The Big Give</mat-radio-button>
-              </mat-radio-group>
-            </mat-expansion-panel>
+          <mat-expansion-panel expanded="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <h3 class="b-rh-2" id="optInCharityEmail-label">Contact from charity</h3>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <p class="no-margin-top b-rt-1 b-bold">Would you be happy to receive emails from {{ campaign.charity.name }}?</p>
+            <p class="b-rt-0">This may include thanks for your donation, updates on how it is being used, newsletters and future campaigns. If you select no, we will pass on your details as these may be required for Gift Aid purposes, but the charity will be informed that you do not wish to receive communications.</p>
+            <p class="b-rt-0">Please note that you might continue to receive communications from {{ campaign.charity.name }} if you have already shared your details with them via other methods.</p>
+            <mat-radio-group aria-labelledby="optInCharityEmail-label" formControlName="optInCharityEmail">
+              <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Yes, I’m happy to receive emails from {{ campaign.charity.name }}</mat-radio-button>
+              <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">No, I would not like to receive emails from {{ campaign.charity.name }}</mat-radio-button>
+            </mat-radio-group>
+          </mat-expansion-panel>
 
-            <mat-expansion-panel class="c-make-your-donation" expanded="true" disabled="true">
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  <h3 class="b-rh-2">Make your donation</h3>
-                </mat-panel-title>
-              </mat-expansion-panel-header>
+          <mat-expansion-panel expanded="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <h3 class="b-rh-2" id="optInTbgEmail-label">Contact from The Big Give</h3>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <p class="no-margin-top b-rt-1 b-bold">Would you be happy to receive emails from The Big Give?</p>
+            <p class="b-rt-0">By selecting 'no', we will no longer be able to email you about opportunities to double your donation.</p>
+            <mat-radio-group aria-labelledby="optInTbgEmail-label" formControlName="optInTbgEmail">
+              <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Yes, I’m happy to receive emails from The Big Give</mat-radio-button>
+              <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">No, I would not like to receive emails from The Big Give</mat-radio-button>
+            </mat-radio-group>
+          </mat-expansion-panel>
 
-              <p class="b-rt-0 b-m-0">By clicking on the <em>Donate</em> button, you agree to the Big Give's
-                <a href="https://www.thebiggive.org.uk/s/terms-and-conditions" target="_blank">
-                  <mat-icon class="b-va-mid" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-                   Terms and Conditions
+          <mat-expansion-panel class="c-make-your-donation" expanded="true" disabled="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <h3 class="b-rh-2">Make your donation</h3>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+
+            <p class="b-rt-0 b-m-0">By clicking on the <em>Donate</em> button, you agree to the Big Give's
+              <a href="https://www.thebiggive.org.uk/s/terms-and-conditions" target="_blank">
+                <mat-icon class="b-va-mid" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                  Terms and Conditions
+              </a>
+                and
+              <a href="https://www.thebiggive.org.uk/s/privacy-policy" target="_blank">
+                <mat-icon class="b-va-mid" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                  Privacy Policy
                 </a>
-                  and
-                <a href="https://www.thebiggive.org.uk/s/privacy-policy" target="_blank">
-                  <mat-icon class="b-va-mid" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-                   Privacy Policy
-                  </a>
-                  .
-              </p>
+                .
+            </p>
 
-              <div class="c-donation-summary">
-                <p class="error" *ngIf="sfApiError">
-                  Sorry, we can't submit your donation right now. Please try again in a moment
-                  or <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">
-                    <mat-icon aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-                     contact us</a>
-                  if this message persists.
-                </p>
-                <p class="error" *ngIf="validationError">
-                  Please complete all fields above to proceed with your donation.
-                </p>
-                <mat-spinner *ngIf="submitting" color="accent" diameter="30"></mat-spinner>
-                <p *ngIf="retrying" class="warning">
-                  It looks like our system is a bit busy, one moment please&hellip;
-                </p>
-                <button
-                  class="c-donate-button b-donate-button b-w-100 b-rt-1"
-                  mat-raised-button
-                  type="submit"
-                  [disabled]="submitting || f.donationAmount.invalid"
-                >
-                  Donate
-                  <span class="b-bold b-va-bas">
-                    {{ donationForm.value.donationAmount | currency : '£' : 'symbol' : '1.0-0' }}
-                  </span>
-                </button>
-                <div *ngIf="!f.donationAmount.invalid" class="c-donation-receipt" fxLayout="row">
-                  <div [fxFlex]="(expectedMatchAmount() > 0) ? 26 : 39">
-                    <p class="b-center b-grey b-rt-sm b-m-0">Your donation</p>
-                    <p class="b-center b-grey b-rt-0 b-bold b-m-0">{{ donationForm.value.donationAmount | currency : '£' : 'symbol' : '1.0-0' }}</p>
-                  </div>
-                  <div fxFlex="11" fxLayout="row" fxLayoutAlign="center end">
-                    <mat-icon class="c-donation-receipt__icon b-grey b-bold b-center" aria-hidden="false" aria-label="Plus">add</mat-icon>
-                  </div>
-                  <div fxFlex="26" *ngIf="expectedMatchAmount() > 0">
-                    <p class="b-center b-grey b-rt-sm b-m-0">Matched funds</p>
-                    <p class="b-center b-grey b-rt-0 b-bold b-m-0">{{ expectedMatchAmount() | currency : '£' : 'symbol' : '1.0-0' }}</p>
-                  </div>
-                  <div fxFlex="11" fxLayout="row" fxLayoutAlign="center end" *ngIf="expectedMatchAmount() > 0">
-                    <mat-icon class="c-donation-receipt__icon b-grey b-bold b-center" aria-hidden="false" aria-label="Plus">add</mat-icon>
-                  </div>
-                  <div class="c-donation-receipt__gift-aid" [fxFlex]="(expectedMatchAmount() > 0) ? 26 : 39">
-                    <p class="b-center b-grey b-rt-sm b-m-0">Gift Aid</p>
-                    <p class="b-center b-grey b-rt-0 b-bold b-m-0">{{ giftAidAmount() | currency : '£' : 'symbol' : '1.2-2' }}</p>
-                  </div>
+            <div class="c-donation-summary">
+              <p class="error" *ngIf="sfApiError">
+                Sorry, we can't submit your donation right now. Please try again in a moment
+                or <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">
+                  <mat-icon aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                    contact us</a>
+                if this message persists.
+              </p>
+              <p class="error" *ngIf="validationError">
+                Please complete all fields above to proceed with your donation.
+              </p>
+              <mat-spinner *ngIf="submitting" color="accent" diameter="30"></mat-spinner>
+              <p *ngIf="retrying" class="warning">
+                It looks like our system is a bit busy, one moment please&hellip;
+              </p>
+              <button
+                class="c-donate-button b-donate-button b-w-100 b-rt-1"
+                mat-raised-button
+                type="submit"
+                [disabled]="submitting || f.donationAmount.invalid"
+              >
+                Donate
+                <span class="b-bold b-va-bas">
+                  {{ donationForm.value.donationAmount | currency : '£' : 'symbol' : '1.0-0' }}
+                </span>
+              </button>
+              <div *ngIf="!f.donationAmount.invalid" class="c-donation-receipt" fxLayout="row">
+                <div [fxFlex]="(expectedMatchAmount() > 0) ? 26 : 39">
+                  <p class="b-center b-grey b-rt-sm b-m-0">Your donation</p>
+                  <p class="b-center b-grey b-rt-0 b-bold b-m-0">{{ donationForm.value.donationAmount | currency : '£' : 'symbol' : '1.0-0' }}</p>
                 </div>
-                <div *ngIf="!f.donationAmount.invalid" class="c-receipt-total b-grey" fxLayout="row" fxLayoutAlign="space-around center">
-                  <p class="b-rt-0 b-m-0">Total for {{ campaign.charity.name }}:</p>
-                  <p class="b-rt-1 b-bold b-m-0">{{ expectedTotalAmount() | currency : '£' : 'symbol' : '1.2-2' }}</p>
+                <div fxFlex="11" fxLayout="row" fxLayoutAlign="center end">
+                  <mat-icon class="c-donation-receipt__icon b-grey b-bold b-center" aria-hidden="false" aria-label="Plus">add</mat-icon>
+                </div>
+                <div fxFlex="26" *ngIf="expectedMatchAmount() > 0">
+                  <p class="b-center b-grey b-rt-sm b-m-0">Matched funds</p>
+                  <p class="b-center b-grey b-rt-0 b-bold b-m-0">{{ expectedMatchAmount() | currency : '£' : 'symbol' : '1.0-0' }}</p>
+                </div>
+                <div fxFlex="11" fxLayout="row" fxLayoutAlign="center end" *ngIf="expectedMatchAmount() > 0">
+                  <mat-icon class="c-donation-receipt__icon b-grey b-bold b-center" aria-hidden="false" aria-label="Plus">add</mat-icon>
+                </div>
+                <div class="c-donation-receipt__gift-aid" [fxFlex]="(expectedMatchAmount() > 0) ? 26 : 39">
+                  <p class="b-center b-grey b-rt-sm b-m-0">Gift Aid</p>
+                  <p class="b-center b-grey b-rt-0 b-bold b-m-0">{{ giftAidAmount() | currency : '£' : 'symbol' : '1.2-2' }}</p>
                 </div>
               </div>
+              <div *ngIf="!f.donationAmount.invalid" class="c-receipt-total b-grey" fxLayout="row" fxLayoutAlign="space-around center">
+                <p class="b-rt-0 b-m-0">Total for {{ campaign.charity.name }}:</p>
+                <p class="b-rt-1 b-bold b-m-0">{{ expectedTotalAmount() | currency : '£' : 'symbol' : '1.2-2' }}</p>
+              </div>
+            </div>
 
-            </mat-expansion-panel>
-          </mat-accordion>
-        </div>
+          </mat-expansion-panel>
+        </mat-accordion>
       </form>
     </div>
 


### PR DESCRIPTION
This should only be seen if a campaign's status and dates do not agree, as we redirect Donate to the Campaign page when it's expected to be closed based on the status