### PR TITLE
DON-185 - fix redundant and type-breaking nav `events` use

### DIFF
--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -64,8 +64,6 @@
     role="navigation"
     mode="over"
     [(opened)]="opened"
-    (opened)="events.push('open!')"
-    (closed)="events.push('close!')"
     fixedInViewport="true"
   >
     <!-- <app-nav-search-form></app-nav-search-form> -->

--- a/src/app/navigation/navigation.component.ts
+++ b/src/app/navigation/navigation.component.ts
@@ -6,14 +6,10 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./navigation.component.scss'],
 })
 export class NavigationComponent implements OnInit {
-
-  events = [];
   opened = false;
 
-  constructor() {
-  }
+  constructor() {}
 
   ngOnInit() {
   }
-
 }


### PR DESCRIPTION
From an initial local check in Chrome, removing these event
hooks doesn't seem to impact on the navigation or the icon
swap behaviour at mobile sizes, and fixes the build.