### PR TITLE
DON-198 - improve meta-campaign page for shared campaign emergency appeals

### DIFF
--- a/src/app/filters/filters.component.scss
+++ b/src/app/filters/filters.component.scss
@@ -1,7 +1,7 @@
 @import '../../styles';
 
 .c-filters {
-  margin: 1rem 0;
+  margin-top: 1rem;
   overflow: hidden;
   position: relative;
 }

--- a/src/app/hero/hero.component.html
+++ b/src/app/hero/hero.component.html
@@ -16,6 +16,7 @@
       </div>
       <div class="hero-flex__child" fxLayout="column" fxFlex.xs="100" fxFlex="50" fxLayoutAlign="center">
         <app-campaign-search-form
+          *ngIf="campaign && campaign.campaignCount && campaign.campaignCount > 1"
           [reset]="reset"
           (search)="search($event)"
         ></app-campaign-search-form>

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -9,6 +9,7 @@
 
 <div class="b-container" *ngIf="campaign && children">
   <app-filters
+    *ngIf="campaign && campaign.campaignCount && campaign.campaignCount > 1"
     [hasTerm]="hasTerm"
     [selectedSort]="selectedSort"
     [reset]="resetSubject.asObservable()"

--- a/src/app/meta-campaign/meta-campaign.component.scss
+++ b/src/app/meta-campaign/meta-campaign.component.scss
@@ -1,8 +1,8 @@
 @import '../../styles';
 
-
 .c-grid {
   width: 100%;
+  margin-top: 1rem;
   display: grid;
   grid-template-columns: 100%;
   gap: 15px;

--- a/src/app/ticker/ticker.component.html
+++ b/src/app/ticker/ticker.component.html
@@ -7,7 +7,7 @@
   <div class="c-ticker__lists">
     <ul class="c-ticker__list" *ngFor="let index of [0,1,2,3]">
       <li class="c-ticker__item" *ngIf="fund"><span class="c-ticker__value">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</span> raised across all funds</li>
-      <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.campaignCount | number }}</span> charities</li>
+      <li class="c-ticker__item" *ngIf="campaign.campaignCount && campaign.campaignCount > 1"><span class="c-ticker__value">{{ campaign.campaignCount | number }}</span> charities</li>
       <li class="c-ticker__item" *ngIf="campaign.donationCount > 0"><span class="c-ticker__value">{{ campaign.donationCount | number }}</span> donations</li>
       <li class="c-ticker__item"><span class="c-ticker__value">{{ campaign.matchFundsTotal | currency : '£' : 'symbol' : '1.0-0' }}</span> total match funds</li>
       <li class="c-ticker__item" *ngIf="campaignOpen"><span class="c-ticker__value">{{ campaign.matchFundsRemaining | currency : '£' : 'symbol' : '1.0-0' }}</span> match funds remaining</li>


### PR DESCRIPTION
* hide scoped search & filter bars when there's 1 participating campaign
* tweak layout so this looks OK in both cases
* don't show a 0 or 1 campaign count in the ticker