### PR TITLE
DON-199 - fix meta-campaign state when using slugs

### DIFF
--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -46,7 +46,12 @@ export class MetaCampaignComponent implements OnInit {
   }
 
   ngOnInit() {
-    const metacampaignKey = makeStateKey<Campaign>(`metacampaign-${this.campaignId}`);
+    let metacampaignKey: StateKey<string>;
+    if (this.campaignSlug) {
+      metacampaignKey = makeStateKey<Campaign>(`metacampaign-${this.campaignSlug}`);
+    } else {
+      metacampaignKey = makeStateKey<Campaign>(`metacampaign-${this.campaignId}`);
+    }
     this.campaign = this.state.get<Campaign | undefined>(metacampaignKey, undefined);
 
     let fundKey: StateKey<string>;


### PR DESCRIPTION
This should fix the case where navigating between
two meta-campaign pages, both of which have URL slugs
set, in the same session, causes the main campaign
data to be shown from the wrong one.