### PR TITLE
DON-211 - hide match funds remaining for finished campaigns' cards

### DIFF
--- a/src/app/campaign-card/campaign-card.component.html
+++ b/src/app/campaign-card/campaign-card.component.html
@@ -21,7 +21,7 @@
   </div>
 
   <div class="c-funds" fxLayout="row">
-    <div class="c-funds__matched" *ngIf="campaign.isMatched" fxFlex="50">
+    <div class="c-funds__matched" *ngIf="campaign.isMatched && !isFinished" fxFlex="50">
       <p class="c-funds__description">Match funds remaining</p>
       <h4 class="c-funds__amount">{{ campaign.matchFundsRemaining | currency : '£' : 'symbol' : '1.0-0' }}</h4>
     </div>

--- a/src/app/campaign-card/campaign-card.component.ts
+++ b/src/app/campaign-card/campaign-card.component.ts
@@ -12,10 +12,12 @@ export class CampaignCardComponent implements OnInit {
   @Input() campaign: CampaignSummary;
   @Input() inFundContext: boolean;
   bannerUri: string;
+  isFinished: boolean;
 
   constructor(private imageService: ImageService) {}
 
   ngOnInit() {
     this.imageService.getImageUri(this.campaign.imageUri, 830).subscribe(uri => this.bannerUri = uri);
+    this.isFinished = (new Date(this.campaign.endDate) < new Date());
   }
 }


### PR DESCRIPTION
This should apply in MetaCampaign and Explore page contexts