### PR TITLE
DON-214 - have ticker count down until formal start time

### DIFF
--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -102,6 +102,7 @@ describe('CampaignService', () => {
     campaign.status = 'Active';
 
     expect(CampaignService.isOpenForDonations(campaign)).toBe(true);
+    expect(CampaignService.isInFuture(campaign)).toBe(false);
   });
 
   it ('should allow donation attempts to any campaign in active date range, even if Status gets stuck in Preview', () => {
@@ -111,6 +112,7 @@ describe('CampaignService', () => {
     campaign.status = 'Preview';
 
     expect(CampaignService.isOpenForDonations(campaign)).toBe(true);
+    expect(CampaignService.isInFuture(campaign)).toBe(false);
   });
 
   it ('should allow not allow donation attempts to Preview campaigns with future start dates', () => {
@@ -120,6 +122,7 @@ describe('CampaignService', () => {
     campaign.status = 'Preview';
 
     expect(CampaignService.isOpenForDonations(campaign)).toBe(false);
+    expect(CampaignService.isInFuture(campaign)).toBe(true);
   });
 
   it ('should allow not allow donation attempts to Expired campaigns with past end dates', () => {
@@ -129,5 +132,6 @@ describe('CampaignService', () => {
     campaign.status = 'Expired';
 
     expect(CampaignService.isOpenForDonations(campaign)).toBe(false);
+    expect(CampaignService.isInFuture(campaign)).toBe(false);
   });
 });

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -28,6 +28,14 @@ export class CampaignService {
     return (new Date(campaign.endDate) >= new Date());
   }
 
+  static isInFuture(campaign: Campaign): boolean {
+    if (campaign.status === 'Active' || campaign.status === 'Expired') {
+      return false;
+    }
+
+    return (new Date(campaign.startDate) > new Date());
+  }
+
   static percentRaised(campaign: (Campaign | CampaignSummary)): number | undefined {
     if (!campaign.target) {
       return undefined;

--- a/src/app/ticker/ticker.component.html
+++ b/src/app/ticker/ticker.component.html
@@ -1,8 +1,12 @@
 <div class="c-ticker">
   <div class="c-ticker__total">
     <span *ngIf="fund"><em class="c-ticker__value c-ticker__value--emphasised">{{ fund.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</em> raised inc. Gift Aid</span>
-    <span *ngIf="!fund && campaign.amountRaised > 0" ><em class="c-ticker__value c-ticker__value--emphasised">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</em> raised inc. Gift Aid</span>
-    <span *ngIf="!fund && campaign.amountRaised == 0">Opens in <em  class="c-ticker__value c-ticker__value--emphasised">{{ campaign.startDate | timeLeft }}</em></span>
+
+    <!-- We occasionally open child campaigns before their parents, so it
+    is possible for the parent `campaign` here to raise more than £0 before
+    it formally opens. -->
+    <span *ngIf="!fund && campaign.amountRaised > 0 && !campaignInFuture" ><em class="c-ticker__value c-ticker__value--emphasised">{{ campaign.amountRaised | currency : '£' : 'symbol' : '1.0-0' }}</em> raised inc. Gift Aid</span>
+    <span *ngIf="!fund && (campaign.amountRaised == 0 || campaignInFuture)">Opens in <em  class="c-ticker__value c-ticker__value--emphasised">{{ campaign.startDate | timeLeft }}</em></span>
   </div>
   <div class="c-ticker__lists">
     <ul class="c-ticker__list" *ngFor="let index of [0,1,2,3]">

--- a/src/app/ticker/ticker.component.ts
+++ b/src/app/ticker/ticker.component.ts
@@ -12,12 +12,14 @@ import { Fund } from '../fund.model';
 export class TickerComponent implements OnInit {
   @Input() public campaign: Campaign;
   @Input() public fund?: Fund;
+  public campaignInFuture: boolean; // Does not imply £0 raised, see HTML comment.
   public campaignOpen: boolean;
   public durationInDays: number;
 
   constructor() { }
 
   ngOnInit() {
+    this.campaignInFuture = CampaignService.isInFuture(this.campaign);
     this.campaignOpen = CampaignService.isOpenForDonations(this.campaign);
     this.durationInDays = Math.floor((new Date(this.campaign.endDate).getTime() - new Date(this.campaign.startDate).getTime()) / 86400000);
   }


### PR DESCRIPTION
This should now happen even when a master campaign has donations before its stated start time