### PR TITLE
Apply text shadow only where needed to improve contrast

### DIFF
--- a/src/app/hero/hero.component.scss
+++ b/src/app/hero/hero.component.scss
@@ -2,7 +2,6 @@
 
 .hero {
   color: $colour-black-contrast;
-  text-shadow: 1px 1px $colour-black;
   padding-top: 1rem;
   background-size: auto 150%;
   background-repeat: no-repeat;
@@ -43,6 +42,7 @@
 
 .c-hero__heading {
   margin-bottom: 0;
+  text-shadow: 1px 1px $colour-black;
   line-height: 1.2;
   @media #{$breakpoint-md} {
     font-size: 35px;
@@ -57,6 +57,7 @@
 
 .c-hero__description {
   margin-top: 1rem;
+  text-shadow: 1px 1px $colour-black;
 }
 
 .c-hero__image {


### PR DESCRIPTION
The previous rule was impacting e.g. the 'find a campaign' box's
copy too.