### PR TITLE
DON-285 - match badge positioning

### DIFF
--- a/src/app/campaign-details-card/campaign-details-card.component.scss
+++ b/src/app/campaign-details-card/campaign-details-card.component.scss
@@ -11,11 +11,11 @@
 }
 
 .c-badge {
-  @include make-match-badge(true);
+  @include make-match-badge;
 }
 
 .c-contour {
-  @include make-badge-contour(true);
+  @include make-badge-contour;
 }
 
 .c-card-body {

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -159,13 +159,9 @@
   }
 }
 
-@mixin make-match-badge($high: false) {
+@mixin make-match-badge {
   position: relative;
-  @if $high {
-    top: -80px;
-  } @else {
-    top: -19px;
-  }
+  top: -19px;
   left: -4px;
   background: $colour-highlight;
   color: $colour-teal-darkest;
@@ -173,13 +169,9 @@
   padding: 0.25rem 0.5rem;
 }
 
-@mixin make-badge-contour($high: false) {
+@mixin make-badge-contour {
   position: relative;
-  @if $high {
-    top: -82px;
-  } @else {
-    top: -21px;
-  }
+  top: -21px;
   left: -5px;
   width: 5px;
   height: 5px;


### PR DESCRIPTION
Align match badge on detail page same as in campaign grids,
just overlapping with the bottom of the feature image