### PR TITLE
Fix 'null' metacampaign meta description

### DIFF
--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -196,7 +196,7 @@ export class MetaCampaignComponent implements OnInit {
   private setSecondaryProps(campaign: Campaign) {
     this.pageMeta.setCommon(
       campaign.title,
-      campaign.summary,
+      campaign.summary || 'A match funded campaign with the Big Give',
       campaign.bannerUri,
     );
   }


### PR DESCRIPTION
When campaign desc is not set in SF