### PR TITLE
DON-303 explore search query params

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,8 +28,4 @@ export class AppComponent implements OnInit {
       this.stripeService.init();
     }
   }
-
-  public onGlobalSearch(term: string) {
-    this.router.navigateByUrl(`/search?term=${term}`);
-  }
 }

--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -10,6 +10,7 @@
         <div class="explore-hero-flex__child" fxLayout="column" fxFlex.xs="100" fxFlex="50" fxLayoutAlign="center">
           <app-campaign-search-form
             [reset]="resetSubject.asObservable()"
+            [term]="query.term"
             (search)="search($event)"
           ></app-campaign-search-form>
         </div>
@@ -20,17 +21,19 @@
   <div class="b-container" *ngIf="campaigns">
     <app-filters
       [hasTerm]="hasTerm"
-      [showClearFilters]="false"
+      [showClearFilters]="showClearFilters"
       [selectedSort]="selectedSort"
+      [selectedFilters]="query"
       [reset]="resetSubject.asObservable()"
       (filterApplied)="onFilterApplied($event)"
       (sortApplied)="onSortApplied($event)"
+      (clearFiltersApplied)="onClearFiltersApplied()"
     ></app-filters>
 
     <div *ngIf="campaigns.length === 0 && !loading">
       <p class="error" aria-live="polite">
         We can't find any campaigns matching this search but there are lots more to choose from.
-        <a tabindex="0" (click)="resetFilters()">View all campaigns here</a>.
+        <a tabindex="0" (click)="onClearFiltersApplied()">View all campaigns here</a>.
       </p>
     </div>
 

--- a/src/app/filters/filters.component.ts
+++ b/src/app/filters/filters.component.ts
@@ -22,7 +22,6 @@ export class FiltersComponent implements OnInit, OnDestroy {
   @Input() @Output() selectedSort: string;
   @Output() filterApplied: EventEmitter<any> = new EventEmitter();
   @Output() sortApplied: EventEmitter<any> = new EventEmitter();
-  @Output() numberOfCardsApplied: EventEmitter<any> = new EventEmitter();
   @Output() clearFiltersApplied: EventEmitter<any> = new EventEmitter();
 
   // Listen for filter changes and set them accordingly.

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -10,6 +10,12 @@
             <p class="home-hero__description">The Big Give brings charities, philanthropists and the public together to multiply their impact.</p>
           </div>
         </div>
+        <div class="home-hero-flex__child" fxLayout="column" fxFlex.xs="100" fxFlex="50" fxLayoutAlign="center">
+          <app-campaign-search-form
+            [reset]="resetSubject.asObservable()"
+            (search)="search($event)"
+          ></app-campaign-search-form>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 
 import { CampaignService, SearchQuery } from '../campaign.service';
@@ -19,6 +20,7 @@ export class HomeComponent implements OnInit {
 
   constructor(
     private campaignService: CampaignService,
+    private router: Router,
   ) {
   }
 
@@ -34,6 +36,10 @@ export class HomeComponent implements OnInit {
       sortDirection: 'desc',
       sortField: 'matchFundsRemaining',
     };
+  }
+
+  search(term: string) {
+    this.router.navigateByUrl(`/explore?term=${encodeURI(term)}`);
   }
 
   private run() {

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -22,7 +22,6 @@
         [reset]="resetSubject.asObservable()"
         (filterApplied)="onFilterApplied($event)"
         (sortApplied)="onSortApplied($event)"
-        (numberOfCardsApplied)="onNumberOfCardsApplied($event)"
         (clearFiltersApplied)="onClearFiltersApplied()"
       ></app-filters>
 

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -16,7 +16,7 @@
       <app-filters
         *ngIf="campaign.campaignCount && campaign.campaignCount > 1"
         [hasTerm]="hasTerm"
-        [showClearFilters]="true"
+        [showClearFilters]="showClearFilters"
         [selectedSort]="selectedSort"
         [selectedFilters]="query"
         [reset]="resetSubject.asObservable()"

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -27,6 +27,7 @@ export class MetaCampaignComponent implements OnInit {
   public query: {[key: string]: any};
   public resetSubject: Subject<void> = new Subject<void>();
   public selectedSort: string;
+  public showClearFilters = false;
 
   private campaignId: string;
   private campaignSlug: string;
@@ -155,6 +156,7 @@ export class MetaCampaignComponent implements OnInit {
       replaceUrl: true,
     });
 
+    this.showClearFilters = false;
     this.setDefaultFilters();
     this.run();
     this.resetSubject.next();
@@ -232,6 +234,7 @@ export class MetaCampaignComponent implements OnInit {
   private setQueryParams() {
       this.route.queryParams.subscribe(params => {
         if (Object.keys(params).length > 0) {
+          this.showClearFilters = true;
           for (const key of Object.keys(params)) {
             if (key === 'onlyMatching') {
               // convert URL query param string to boolean
@@ -248,6 +251,7 @@ export class MetaCampaignComponent implements OnInit {
    * Dynamically update the URL route each time a sort, filter or limit is applied.
    */
   private updateRoute() {
+    this.showClearFilters = true;
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams:

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -147,12 +147,6 @@ export class MetaCampaignComponent implements OnInit {
     this.run();
   }
 
-  onNumberOfCardsApplied(selectedNumber: number) {
-    this.query.limit = selectedNumber;
-    this.updateRoute();
-    this.run();
-  }
-
   onClearFiltersApplied() {
     // Remove any query params from URL
     this.router.navigate([], {


### PR DESCRIPTION
- Remove unused number of cards applied event emitter
- DON-303 mimic meta-campaign query params approach on explore component + conditionally show clear filters button
- Conditionally show clear filters button on meta campaign component
- DON-303 reinstate search component on home page which now navigates to /explore page + remove globalSearch method