### PR TITLE
DON-307 donation input field prominence

### DIFF
--- a/src/app/donation-start/donation-start.component.scss
+++ b/src/app/donation-start/donation-start.component.scss
@@ -98,6 +98,15 @@
   display: block;
   font-size: 24px;
   font-weight: 700;
+  @media #{$breakpoint-md} {
+    font-size: 18px;
+  }
+  @media #{$breakpoint-lg} {
+    font-size: 24px;
+  }
+  @media #{$breakpoint-xl} {
+    font-size: 24px;
+  }
 }
 
 .c-suggested-amount__button {

--- a/src/app/donation-start/donation-start.component.scss
+++ b/src/app/donation-start/donation-start.component.scss
@@ -96,7 +96,6 @@
   max-width: 600px;
   margin: 0 auto;
   display: block;
-  font-size: 24px;
   font-weight: 700;
   @media #{$breakpoint-md} {
     font-size: 18px;

--- a/src/assets/scss/_overwrite-mat.scss
+++ b/src/assets/scss/_overwrite-mat.scss
@@ -83,7 +83,7 @@ app-campaign-card {
 
 .mat-form-field-appearance-legacy .mat-form-field-infix {
   margin-bottom: 0.5rem;
-  margin-top: 1.4rem;
+  margin-top: 3rem;
   border: 2px mat-color($donate-primary) solid;
   border-radius: 1rem;
 }

--- a/src/assets/scss/_overwrite-mat.scss
+++ b/src/assets/scss/_overwrite-mat.scss
@@ -80,3 +80,18 @@ app-campaign-card {
 .mat-form-field-appearance-outline .mat-form-field-infix {
   padding: 0.3em 0 0.7em 0;
 }
+
+.mat-form-field-appearance-legacy .mat-form-field-infix {
+  margin-bottom: 0.5rem;
+  margin-top: 1.4rem;
+  border: 2px mat-color($donate-primary) solid;
+  border-radius: 1rem;
+}
+
+.mat-form-field-prefix, .mat-form-field-suffix {
+  padding-right: 1rem;
+}
+
+.mat-form-field-appearance-legacy .mat-form-field-underline {
+  height: 0 !important;
+}


### PR DESCRIPTION
Make mat form field inputs more prominent + add override border and lose underline when not focused

![image](https://user-images.githubusercontent.com/47176130/98021542-55993480-1dfc-11eb-8500-3f118ad95e86.png)
