### PR TITLE
DON-354 relax flag which stopped route updates from re-querying old search results

### DIFF
--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -17,7 +17,6 @@ export class ExploreComponent implements OnDestroy, OnInit {
   loading = false; // Server render gets initial result set; set true when filters change.
   searched = false;
 
-  private initDone = false;
   private offset = 0;
   private routeParamSubscription: Subscription;
   private searchServiceSubscription: Subscription;
@@ -110,11 +109,7 @@ export class ExploreComponent implements OnDestroy, OnInit {
    */
   private loadQueryParamsAndRun() {
     this.routeParamSubscription = this.route.queryParams.subscribe(params => {
-      if (!this.initDone) {
-        this.initDone = true;
-        this.searchService.loadQueryParams(params, this.getDefaultSort());
-      }
-
+      this.searchService.loadQueryParams(params, this.getDefaultSort());
       this.run();
     });
 

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -27,7 +27,6 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
 
   private campaignId: string;
   private campaignSlug: string;
-  private initDone = false;
   private offset = 0;
   private routeChangeListener: Subscription;
   private routeParamSubscription: Subscription;
@@ -191,12 +190,8 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
    */
   private loadQueryParamsAndRun() {
     this.routeParamSubscription = this.route.queryParams.subscribe(params => {
-      if (!this.initDone) {
-        this.initDone = true;
         this.searchService.loadQueryParams(params, this.getDefaultSort());
-      }
-
-      this.run();
+        this.run();
     });
 
     this.searchServiceSubscription = this.searchService.changed.subscribe((interactive: boolean) => {


### PR DESCRIPTION
DON-354 relax flag which stopped route updates from re-querying old search results

I think this flag was part of this [379](https://github.com/thebiggive/donate-frontend/pull/379/files) which addressed [DON-348](https://thebiggive.atlassian.net/browse/DON-348) - this flag shouldn't affect the the unexpected filter logic behaviour and I can't seem to replicate that location filter issue locally whilst the flag was removed.