### PR TITLE
DON-356 - fix crash when old donation thanks page viewed

### DIFF
--- a/src/app/donation-complete/donation-complete.component.html
+++ b/src/app/donation-complete/donation-complete.component.html
@@ -3,7 +3,8 @@
 
   <p *ngIf="noAccess" class="error">
     We can only show your receipt on the device where you donated, in order to keep your information secure. Don't worry
-    though, we'll email you a receipt within a few minutes confirming if your donation was processed.
+    though, we'll email you a receipt within a few minutes confirming if your donation was processed. If you donated more than 30 days ago,
+    please check your email for your receipt.
   </p>
 
   <p *ngIf="timedOut" class="error" aria-live="assertive">

--- a/src/app/donation-complete/donation-complete.component.ts
+++ b/src/app/donation-complete/donation-complete.component.ts
@@ -46,6 +46,8 @@ export class DonationCompleteComponent {
    * Must be public in order for re-tries to invoke it in an anonymous context.
    */
   checkDonation(): void {
+    this.donationService.removeOldLocalDonations();
+
     this.tries++;
     const donationLocalCopy = this.donationService.getDonation(this.donationId);
 

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -195,6 +195,16 @@ export class DonationService {
     this.storage.set(this.storageKey, donationCouplets);
   }
 
+  removeOldLocalDonations() {
+    let donationsOlderThan30Days: Array<{ donation: Donation, jwt: string }>;
+    donationsOlderThan30Days = this.getDonationCouplets().filter(donationItem => {
+      return (!donationItem.donation.createdTime || this.getCreatedTime(donationItem.donation) < (Date.now() - 2592000000));
+    });
+    for (const oldDonationCouplet of donationsOlderThan30Days) {
+      this.removeLocalDonation(oldDonationCouplet.donation);
+    }
+  }
+
   /**
    * Safely get created date from a Donation, whether the local data has it as a Date (e.g. when set locally) or
    * a string (when just derived from an HTTP response), and return it as a JavaScript Unix epoch milliseconds value.
@@ -205,16 +215,6 @@ export class DonationService {
     }
 
     return 0;
-  }
-
-  private removeOldLocalDonations() {
-    let donationsOlderThan30Days: Array<{ donation: Donation, jwt: string }>;
-    donationsOlderThan30Days = this.getDonationCouplets().filter(donationItem => {
-      return (!donationItem.donation.createdTime || this.getCreatedTime(donationItem.donation) < (Date.now() - 2592000000));
-    });
-    for (const oldDonationCouplet of donationsOlderThan30Days) {
-      this.removeLocalDonation(oldDonationCouplet.donation);
-    }
   }
 
   private getAuthHttpOptions(donation: Donation): { headers: HttpHeaders } {


### PR DESCRIPTION
* make Donation service `removeOldLocalDonations()` public
* use it on thanks page prior to trying to load donation data from the API
* account for this case in no access error message copy