### PR TITLE
DON-388 - support any donor country

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@nguniversal/express-engine": "^11.2.0",
         "@stripe/stripe-js": "^1.13.2",
         "compression": "^1.7.4",
+        "country-code-lookup": "^0.0.19",
         "express": "^4.17.1",
         "helmet": "^4.4.1",
         "material-icons-font": "^2.1.0",
@@ -5248,6 +5249,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/country-code-lookup": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/country-code-lookup/-/country-code-lookup-0.0.19.tgz",
+      "integrity": "sha512-lpvgdPyj8RuP0CSZhACNf5ueKlLbv/IQUAQfg7yr/qJbFrdcWV7Y+aDN9K/u/bx3MXRfcsjuW+TdIc0AEj7kDw=="
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -21035,9 +21041,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1"
@@ -25813,6 +25819,11 @@
         "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
       }
+    },
+    "country-code-lookup": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/country-code-lookup/-/country-code-lookup-0.0.19.tgz",
+      "integrity": "sha512-lpvgdPyj8RuP0CSZhACNf5ueKlLbv/IQUAQfg7yr/qJbFrdcWV7Y+aDN9K/u/bx3MXRfcsjuW+TdIc0AEj7kDw=="
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -37600,9 +37611,9 @@
           "dev": true
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@nguniversal/express-engine": "^11.2.0",
     "@stripe/stripe-js": "^1.13.2",
     "compression": "^1.7.4",
+    "country-code-lookup": "^0.0.19",
     "express": "^4.17.1",
     "helmet": "^4.4.1",
     "material-icons-font": "^2.1.0",

--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -281,6 +281,15 @@
               <p *ngIf="requestButtonShown" class="b-center b-grey b-rt-sm">Or</p>
 
               <mat-form-field>
+                <mat-label for="billingCountry">Billing country</mat-label>
+                <mat-select formControlName="billingCountry" id="billingCountry">
+                  <mat-option *ngFor="let country of countryOptions" [value]="country.iso2">
+                    {{ country.country }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+
+              <mat-form-field>
                 <mat-label for="billingPostcode">Billing postcode</mat-label>
                 <input formControlName="billingPostcode" id="billingPostcode" matInput>
               </mat-form-field>

--- a/src/app/donation-start/donation-start.component.spec.ts
+++ b/src/app/donation-start/donation-start.component.spec.ts
@@ -162,6 +162,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: 'GB',
         billingPostcode: 'N1 1AA',
       },
     });
@@ -194,6 +195,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: null,
         billingPostcode: null,
       },
     });
@@ -236,6 +238,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: null,
         billingPostcode: null,
       },
     });
@@ -272,6 +275,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: null,
         billingPostcode: null,
       },
     });
@@ -308,6 +312,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: null,
         billingPostcode: null,
       },
     });
@@ -344,6 +349,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: 'GB',
         billingPostcode: 'N1 1AA',
       },
     });
@@ -362,7 +368,7 @@ describe('DonationStartComponent', () => {
     expect(component.donationForm.controls.personalAndMarketing.get('optInTbgEmail')?.errors).toBeNull();
   });
 
-  it('should have missing postcode error in Stripe mode', () => {
+  it('should have missing country & postcode errors in Stripe mode', () => {
     // Need to override the default fixture in beforeEach() to set a realistic `campaign`.
     fixture = TestBed.createComponent(DonationStartComponent);
     component = fixture.componentInstance;
@@ -389,11 +395,16 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: null,
         billingPostcode: null,
       },
     });
 
     expect(component.donationForm.valid).toBe(false);
+
+    const billingCountryErrors: any = component.donationForm.controls.paymentAndAgreement.get('billingPostcode')?.errors;
+    expect(Object.keys(billingCountryErrors).length).toBe(1);
+    expect(billingCountryErrors.required).toBe(true);
 
     const billingPostcodeErrors: any = component.donationForm.controls.paymentAndAgreement.get('billingPostcode')?.errors;
     expect(Object.keys(billingPostcodeErrors).length).toBe(1);
@@ -429,6 +440,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: true,
       },
       paymentAndAgreement: {
+        billingCountry: 'GB',
         billingPostcode: 'N1 1AA',
       },
     });
@@ -469,6 +481,7 @@ describe('DonationStartComponent', () => {
         optInChampionEmail: false,
       },
       paymentAndAgreement: {
+        billingCountry: 'GB',
         billingPostcode: 'N1 1AA',
       },
     });

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -71,6 +71,7 @@ export class StripeService {
   async confirmCardPayment(
     clientSecret: string,
     cardElement: StripeCardElement,
+    donorCountry: string,
     donorEmail: string,
     donorName?: string,
     donorPostcode?: string,
@@ -87,7 +88,7 @@ export class StripeService {
 
     if (donorPostcode) {
       billingDetails.address = {
-        country: 'GB',
+        country: donorCountry,
         postal_code: donorPostcode,
       };
     }


### PR DESCRIPTION
* expose a required billing country field, defaulting to GB, for Stripe
* use this in place of fixed 'GB' for data passed to Donate API & Stripe
* use a simplified, looser pattern requirement for billing postcode