### PR TITLE
DON-387 - detect country & set it as default

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 
 import { AnalyticsService } from './src/app/analytics.service';
 import { AppServerModule } from './src/main.server';
+import { COUNTRY_CODE } from './src/app/country-code.token';
 import { environment } from './src/environments/environment';
 import { GetSiteControlService } from './src/app/getsitecontrol.service';
 
@@ -123,7 +124,10 @@ export function app() {
     // Note that the file output as `index.html` is actually dynamic. See `index` config keys in `angular.json`.
     // See https://github.com/angular/angular-cli/issues/10881#issuecomment-530864193 for info on the undocumented use of
     // this key to work around `fileReplacements` ending index support in Angular 8.
-    res.render(indexHtml, { req, providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }] });
+    res.render(indexHtml, { req, providers: [
+      { provide: APP_BASE_HREF, useValue: req.baseUrl },
+      { provide: COUNTRY_CODE, useValue: req.header('CloudFront-Viewer-Country') || undefined },
+    ]});
   });
 
   return server;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -9,6 +9,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InMemoryStorageService } from 'ngx-webstorage-service';
@@ -24,6 +25,7 @@ describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
+        BrowserTransferStateModule,
         HttpClientTestingModule,
         MatButtonModule, // Not required but makes test DOM layout more realistic
         MatIconModule,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 
 import { AnalyticsService } from './analytics.service';
+import { DonationService } from './donation.service';
 import { GetSiteControlService } from './getsitecontrol.service';
 import { StripeService } from './stripe.service';
 
@@ -13,6 +14,7 @@ import { StripeService } from './stripe.service';
 export class AppComponent implements OnInit {
   constructor(
     private analyticsService: AnalyticsService,
+    private donationService: DonationService,
     private getSiteControlService: GetSiteControlService,
     // tslint:disable-next-line:ban-types Angular types this ID as `Object` so we must follow suit.
     @Inject(PLATFORM_ID) private platformId: Object,
@@ -25,5 +27,11 @@ export class AppComponent implements OnInit {
       this.getSiteControlService.init();
       this.stripeService.init();
     }
+
+    // This service needs to be injected app-wide and this line is here, because
+    // we need to be sure the server-detected `COUNTY_CODE` InjectionToken is
+    // always set up during the initial page load, regardless of whether the first
+    // page the donor lands on makes wider use of DonationService or not.
+    this.donationService.deriveDefaultCountry();
   }
 }

--- a/src/app/country-code.token.ts
+++ b/src/app/country-code.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const COUNTRY_CODE = new InjectionToken<string>('Default country code');

--- a/src/app/donation-complete/donation-complete.component.spec.ts
+++ b/src/app/donation-complete/donation-complete.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InMemoryStorageService } from 'ngx-webstorage-service';
@@ -19,6 +20,7 @@ describe('DonationCompleteComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ DonationCompleteComponent ],
       imports: [
+        BrowserTransferStateModule,
         HttpClientTestingModule,
         MatProgressSpinnerModule,
         RouterTestingModule.withRoutes([

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -13,8 +13,8 @@ import { Observer } from 'rxjs';
 
 import { AnalyticsService } from '../analytics.service';
 import { Campaign } from './../campaign.model';
-import { CharityCheckoutService } from '../charity-checkout.service';
 import { CampaignService } from '../campaign.service';
+import { CharityCheckoutService } from '../charity-checkout.service';
 import { Donation } from '../donation.model';
 import { DonationCreatedResponse } from '../donation-created-response.model';
 import { DonationService } from '../donation.service';
@@ -78,6 +78,7 @@ export class DonationStartComponent implements AfterContentChecked, OnDestroy, O
   triedToLeavePersonalAndMarketing = false;
 
   private campaignId: string;
+  private defaultCountryCode: string;
   private enthuseError?: string;  // Enthuse donation start error message
   private previousDonation?: Donation;
   private stepHeaderEventsSet = false;
@@ -107,6 +108,8 @@ export class DonationStartComponent implements AfterContentChecked, OnDestroy, O
     private state: TransferState,
     private stripeService: StripeService,
   ) {
+    this.defaultCountryCode = this.donationService.getDefaultCounty();
+
     route.params.pipe().subscribe(params => this.campaignId = params.campaignId);
     route.queryParams.forEach((params: Params) => {
       if (params.error) {
@@ -153,7 +156,7 @@ export class DonationStartComponent implements AfterContentChecked, OnDestroy, O
       }),
       // T&Cs agreement is implicit through submitting the form.
       paymentAndAgreement: this.formBuilder.group({
-        billingCountry: ['GB'], // See addStripeValidators().
+        billingCountry: [this.defaultCountryCode], // See addStripeValidators().
         billingPostcode: [null], // See addStripeValidators().
       }),
     });

--- a/src/app/donation.service.spec.ts
+++ b/src/app/donation.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
+import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InMemoryStorageService } from 'ngx-webstorage-service';
 
@@ -39,7 +40,11 @@ describe('DonationService', () => {
   };
 
   beforeEach(() => TestBed.configureTestingModule({
-    imports: [ HttpClientTestingModule, RouterTestingModule ],
+    imports: [
+      BrowserTransferStateModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+    ],
     providers: [
       // Inject in-memory storage for tests, in place of local storage.
       { provide: TBG_DONATE_STORAGE, useExisting: InMemoryStorageService },

--- a/src/app/stripe.service.spec.ts
+++ b/src/app/stripe.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InMemoryStorageService } from 'ngx-webstorage-service';
 
@@ -12,6 +13,7 @@ describe('StripeService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        BrowserTransferStateModule,
         HttpClientTestingModule,
         RouterTestingModule,
       ],


### PR DESCRIPTION
After many experiments and re-builds of the Docker-ised version of the app, I _think_ this should now successfully get the default country passed through at runtime to components that inject `DonationService`.

I mostly tested by temporarily replacing the fallback used in place of `req.header('CloudFront-Viewer-Country')` with a test alternative string.

Once it passes code review, I think the next step to get a good sense of whether this works in practice is to get it and the corresponding infra changes through to Staging, and the test using proxies or other ways to generated test traffic from different countries.