### PR TITLE
DON-223 - add route resolvers; improve Donation Start tests

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,11 +2,12 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { CampaignDetailsComponent } from './campaign-details/campaign-details.component';
+import { CampaignListResolver } from './campaign-list.resolver';
+import { CampaignResolver } from './campaign.resolver';
 import { CharityCampaignsResolver } from './charity-campaigns.resolver';
 import { CharityComponent } from './charity/charity.component';
 import { DonationCompleteComponent } from './donation-complete/donation-complete.component';
 import { DonationStartComponent } from './donation-start/donation-start.component';
-import { environment } from '../environments/environment';
 import { ExploreComponent } from './explore/explore.component';
 import { HomeComponent } from './home/home.component';
 import { MetaCampaignComponent } from './meta-campaign/meta-campaign.component';
@@ -15,6 +16,9 @@ const routes: Routes = [
   {
     path: 'campaign/:campaignId',
     component: CampaignDetailsComponent,
+    resolve: {
+      campaign: CampaignResolver,
+    },
   },
   {
     path: 'charity/:charityId',
@@ -26,14 +30,23 @@ const routes: Routes = [
   {
     path: 'donate/:campaignId',
     component: DonationStartComponent,
+    resolve: {
+      campaign: CampaignResolver,
+    },
   },
   {
     path: 'metacampaign/:campaignId',
     component: MetaCampaignComponent,
+    resolve: {
+      campaign: CampaignResolver,
+    },
   },
   {
     path: 'metacampaign/:campaignId/:fundSlug',
     component: MetaCampaignComponent,
+    resolve: {
+      campaign: CampaignResolver,
+    },
   },
   {
     path: 'thanks/:donationId',
@@ -42,6 +55,9 @@ const routes: Routes = [
   {
     path: ':campaignSlug/:fundSlug',
     component: MetaCampaignComponent,
+    resolve: {
+      campaign: CampaignResolver,
+    },
   },
   {
     path: 'explore',
@@ -50,10 +66,16 @@ const routes: Routes = [
   {
     path: ':campaignSlug',
     component: MetaCampaignComponent,
+    resolve: {
+      campaign: CampaignResolver,
+    },
   },
   {
     path: '',
     component: HomeComponent,
+    resolve: {
+      campaigns: CampaignListResolver,
+    },
   },
   {
     path: '**',
@@ -67,7 +89,11 @@ const routes: Routes = [
     onSameUrlNavigation: 'reload', // Allows Explore & home logo links to clear search filters in ExploreComponent
     scrollPositionRestoration: 'enabled',
   })],
-  providers: [CharityCampaignsResolver],
+  providers: [
+    CampaignResolver,
+    CampaignListResolver,
+    CharityCampaignsResolver,
+  ],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,3 @@
+<mat-spinner *ngIf="navigating" class="b-full-page" color="primary" diameter="30"></mat-spinner>
+
 <app-navigation></app-navigation>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,13 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import {
+  Event,
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
+  Router,
+} from '@angular/router';
 
 import { AnalyticsService } from './analytics.service';
 import { DonationService } from './donation.service';
@@ -12,14 +20,37 @@ import { StripeService } from './stripe.service';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
+  navigating = false;
+
   constructor(
     private analyticsService: AnalyticsService,
     private donationService: DonationService,
     private getSiteControlService: GetSiteControlService,
     // tslint:disable-next-line:ban-types Angular types this ID as `Object` so we must follow suit.
     @Inject(PLATFORM_ID) private platformId: Object,
+    private router: Router,
     private stripeService: StripeService,
-  ) {}
+  ) {
+    // https://www.amadousall.com/angular-routing-how-to-display-a-loading-indicator-when-navigating-between-routes/
+    this.router.events.subscribe((event: Event) => {
+      switch (true) {
+        case event instanceof NavigationStart: {
+          this.navigating = true;
+          break;
+        }
+
+        case event instanceof NavigationEnd:
+        case event instanceof NavigationCancel:
+        case event instanceof NavigationError: {
+          this.navigating = false;
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+  }
 
   ngOnInit() {
     if (isPlatformBrowser(this.platformId)) {

--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -1,6 +1,4 @@
-<mat-spinner *ngIf="!campaign" class="b-full-page" color="primary" diameter="30"></mat-spinner>
-
-<main class="b-container" *ngIf="campaign">
+<main class="b-container">
   <div class="b-back-button">
     <a *ngIf="campaign.parentRef && fromFund" mat-icon-button class="c-listing-button block" [routerLink]="'/' + campaign.parentRef + '/' + campaign.championRef">
       <mat-icon class="listing-button__icon" aria-hidden="false" aria-label="Back">keyboard_arrow_left</mat-icon>

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -1,6 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Component, Inject, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
-import { DomSanitizer, makeStateKey, SafeResourceUrl, TransferState } from '@angular/platform-browser';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Params } from '@angular/router';
 
 import { AnalyticsService } from '../analytics.service';
@@ -16,8 +16,7 @@ import { PageMetaService } from '../page-meta.service';
 })
 export class CampaignDetailsComponent implements OnInit, OnDestroy {
   additionalImageUris: Array<string|undefined> = [];
-  campaign?: Campaign;
-  campaignId: string;
+  campaign: Campaign;
   isPending = false;
   campaignInFuture = false;
   donateEnabled = true;
@@ -29,16 +28,13 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
 
   constructor(
     private analyticsService: AnalyticsService,
-    private campaignService: CampaignService,
     private pageMeta: PageMetaService,
     private imageService: ImageService,
     // tslint:disable-next-line:ban-types Angular types this ID as `Object` so we must follow suit.
     @Inject(PLATFORM_ID) private platformId: Object,
     private route: ActivatedRoute,
     private sanitizer: DomSanitizer,
-    private state: TransferState,
   ) {
-    route.params.pipe().subscribe(params => this.campaignId = params.campaignId);
     route.queryParams.forEach((params: Params) => {
       if (params.fromFund) {
         this.fromFund = true;
@@ -47,18 +43,8 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    const campaignKey = makeStateKey<Campaign>(`campaign-${this.campaignId}`);
-    this.campaign = this.state.get(campaignKey, undefined);
-
-    if (this.campaign) {
-      this.setSecondaryProps(this.campaign);
-    } else {
-      this.campaignService.getOneById(this.campaignId).subscribe(campaign => {
-        this.state.set(campaignKey, campaign);
-        this.campaign = campaign;
-        this.setSecondaryProps(campaign);
-      });
-    }
+    this.campaign = this.route.snapshot.data.campaign;
+    this.setSecondaryProps(this.campaign);
   }
 
   ngOnDestroy() {

--- a/src/app/campaign-list.resolver.ts
+++ b/src/app/campaign-list.resolver.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { CampaignService } from './campaign.service';
+
+@Injectable()
+export class CampaignListResolver implements Resolve<any> {
+  constructor(private campaignService: CampaignService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    const defaultListQuery = {
+      limit: CampaignService.perPage,
+      offset: 0,
+      sortDirection: 'desc',
+      sortField: 'matchFundsRemaining',
+    };
+
+    return this.campaignService.search(defaultListQuery);
+  }
+}

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { makeStateKey, TransferState } from '@angular/platform-browser';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { Observable, of } from 'rxjs';
+
+import { Campaign } from './campaign.model';
+import { CampaignService } from './campaign.service';
+
+@Injectable()
+export class CampaignResolver implements Resolve<any> {
+  constructor(
+    public campaignService: CampaignService,
+    private state: TransferState,
+  ) {}
+
+  resolve(route: ActivatedRouteSnapshot): Observable<Campaign> {
+    const campaignId = route.paramMap.get('campaignId');
+    const campaignSlug = route.paramMap.get('campaignSlug');
+
+    if (campaignId) {
+      return this.loadWithStateCache(
+        campaignId,
+        (identifier: string) => this.campaignService.getOneById(identifier),
+      );
+    }
+
+    return this.loadWithStateCache(
+      campaignSlug || '',
+      (identifier: string) => this.campaignService.getOneBySlug(identifier),
+    );
+  }
+
+  private loadWithStateCache(
+    identifier: string,
+    method: (identifier: string) => Observable<Campaign>,
+  ): Observable<Campaign> {
+    const campaignKey = makeStateKey<Campaign>(`campaign-${identifier}`);
+    const campaign = this.state.get(campaignKey, undefined);
+    if (campaign) {
+      return of(campaign);
+    }
+
+    const observable = method(identifier);
+    observable.subscribe(loadedCampaign => {
+      // Save in state for future routes, e.g. when moving between `CampaignDetailComponent`
+      // and `DonationStartComponent`.
+      this.state.set(campaignKey, loadedCampaign);
+    });
+
+    return observable;
+  }
+}

--- a/src/app/charity-campaigns.resolver.ts
+++ b/src/app/charity-campaigns.resolver.ts
@@ -2,13 +2,14 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
 import { CampaignService } from './campaign.service';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { CampaignSummary } from './campaign-summary.model';
 
 @Injectable()
 export class CharityCampaignsResolver implements Resolve<any> {
   constructor(private campaignService: CampaignService) {}
 
-  resolve(route: ActivatedRouteSnapshot) {
+  resolve(route: ActivatedRouteSnapshot): Observable<CampaignSummary[]> {
     const charityId = route.paramMap.get('charityId');
 
     // Edge case for our legacy redirector seems to have returned string 'null' as the

--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -1,6 +1,4 @@
-<mat-spinner *ngIf="!campaign" class="b-full-page" color="primary" diameter="30"></mat-spinner>
-
-<main class="b-container" *ngIf="campaign">
+<main class="b-container">
   <div class="b-back-button">
     <a mat-icon-button [routerLink]="'/campaign/' + campaign.id">
       <mat-icon class="campaign-icon" aria-hidden="false" aria-label="Back">keyboard_arrow_left</mat-icon>
@@ -17,9 +15,9 @@
         <h1 class="b-rh-1 b-bold">{{ campaign.title }}</h1>
       </div>
 
-      <p *ngIf="campaign && !campaignOpenOnLoad">Donations open {{ campaign.startDate | date : 'h:mm a, d LLLL yyyy' }} to {{ campaign.endDate | date : 'h:mm a, d LLLL yyyy' }}</p>
+      <p *ngIf="!campaignOpenOnLoad">Donations open {{ campaign.startDate | date : 'h:mm a, d LLLL yyyy' }} to {{ campaign.endDate | date : 'h:mm a, d LLLL yyyy' }}</p>
 
-      <form class="c-donate-form" (ngSubmit)="submit()" [formGroup]="donationForm" *ngIf="campaign && campaignOpenOnLoad">
+      <form class="c-donate-form" (ngSubmit)="submit()" [formGroup]="donationForm" *ngIf="campaignOpenOnLoad">
         <mat-vertical-stepper
           id="stepper"
           linear

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -20,13 +20,12 @@
     </div>
   </div>
 
-  <div class="b-container" *ngIf="campaigns">
+  <div class="b-container">
     <div class="c-grid">
       <div *ngFor="let campaign of campaigns">
         <app-campaign-card [campaign]="campaign"></app-campaign-card>
       </div>
     </div>
-    <mat-spinner *ngIf="loading" color="primary" diameter="30"></mat-spinner>
   </div>
 
   <div class="about-container">

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -7,10 +7,11 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 
-import { HomeComponent } from './home.component';
 import { CampaignSearchFormComponent } from '../campaign-search-form/campaign-search-form.component';
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
+import { HomeComponent } from './home.component';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -31,6 +32,9 @@ describe('HomeComponent', () => {
         MatSelectModule,
         NoopAnimationsModule,
         ReactiveFormsModule,
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { data: { campaigns: [] }} } },
       ],
     })
     .compileComponents();

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
-import { CampaignService, SearchQuery } from '../campaign.service';
 import { CampaignSummary } from '../campaign-summary.model';
 
 @Component({
@@ -9,17 +9,12 @@ import { CampaignSummary } from '../campaign-summary.model';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  public campaigns: CampaignSummary[];
-  public loading = false; // Server render gets initial result set; set true when filters change.
+  campaigns: CampaignSummary[];
 
-  private perPage = 6;
-  private query: {[key: string]: any};
-
-  constructor(private campaignService: CampaignService) {}
+  public constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
-    this.setDefaults();
-    this.run();
+    this.campaigns = this.route.snapshot.data.campaigns;
   }
 
   /**
@@ -27,27 +22,5 @@ export class HomeComponent implements OnInit {
    */
   getDefaultSort(): 'matchFundsRemaining' {
     return 'matchFundsRemaining';
-  }
-
-  setDefaults() {
-    this.query = {
-      limit: this.perPage,
-      offset: 0,
-      sortDirection: 'desc',
-      sortField: 'matchFundsRemaining',
-    };
-  }
-
-  private run() {
-    this.campaigns = [];
-    this.loading = true;
-
-    this.campaignService.search(this.query as SearchQuery).subscribe(campaignSummaries => {
-      this.campaigns = campaignSummaries; // Success
-      this.loading = false;
-    }, () => {
-        this.loading = false;
-      },
-    );
   }
 }

--- a/src/app/meta-campaign/meta-campaign.component.html
+++ b/src/app/meta-campaign/meta-campaign.component.html
@@ -1,13 +1,12 @@
 <main>
   <app-hero
-    *ngIf="campaign"
     [campaign]="campaign"
     [fund]="fund"
     [description]="fund && fund.description ? fund.description : campaign.summary"
     [getDefaultSort]="getDefaultSort"
   ></app-hero>
 
-  <div *ngIf="campaign && children">
+  <div *ngIf="children">
     <div class="b-container">
       <app-filters
         *ngIf="campaign.campaignCount && campaign.campaignCount > 1"
@@ -15,7 +14,7 @@
       ></app-filters>
 
       <div
-        *ngIf="campaign && children.length === 0 && !loading && !filterError"
+        *ngIf="children.length === 0 && !loading && !filterError"
       >
         <p class="error" aria-live="polite">
           We can't find any campaigns matching this search but there are lots

--- a/src/app/meta-campaign/meta-campaign.component.spec.ts
+++ b/src/app/meta-campaign/meta-campaign.component.spec.ts
@@ -10,7 +10,9 @@ import { MatSelectModule } from '@angular/material/select';
 import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { of } from 'rxjs';
 
 import { Campaign } from '../campaign.model';
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
@@ -22,9 +24,49 @@ import { MetaCampaignComponent } from './meta-campaign.component';
 import { TickerComponent } from './../ticker/ticker.component';
 import { TimeLeftPipe } from '../time-left.pipe';
 
+
 describe('MetaCampaignComponent', () => {
   let component: MetaCampaignComponent;
   let fixture: ComponentFixture<MetaCampaignComponent>;
+
+  const getDummyMasterCampaign = () => new Campaign(
+    'testMasterCampaignId',
+    ['Aim 1'],
+    123,
+    [],
+    'https://example.com/banner.png',
+    ['Other'],
+    [],
+    ['Animals'],
+    '',
+    {
+      id: 'tbgId',
+      name: 'The Big Give',
+      donateLinkId: 'SFIdOrLegacyId',
+      optInStatement: 'Opt in statement.',
+      website: 'https://www.thebiggive.org.uk',
+      regulatorNumber: '123456',
+      regulatorRegion: 'Scotland',
+    },
+    ['United Kingdom'],
+    'GBP',
+    4,
+    new Date(),
+    'Impact reporting plan',
+    'Impact overview',
+    true,
+    987,
+    988,
+    'The situation',
+    [],
+    'The solution',
+    new Date(),
+    'Active',
+    'Test Master Campaign detail',
+    15000,
+    'Test Master Campaign!',
+    [],
+  );
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -51,6 +93,18 @@ describe('MetaCampaignComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
       ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({}), // Let constructor pipe params without crashing.
+            queryParams: of({}), // Let `loadQueryParamsAndRun()` subscribe without crashing.
+            snapshot: {
+              data: { campaign: getDummyMasterCampaign() },
+            },
+          },
+        },
+      ],
     })
     .compileComponents();
   }));
@@ -59,44 +113,7 @@ describe('MetaCampaignComponent', () => {
     fixture = TestBed.createComponent(MetaCampaignComponent);
     component = fixture.componentInstance;
 
-    component.campaign = new Campaign(
-      'testMasterCampaignId',
-      ['Aim 1'],
-      123,
-      [],
-      'https://example.com/banner.png',
-      ['Other'],
-      [],
-      ['Animals'],
-      '',
-      {
-        id: 'tbgId',
-        name: 'The Big Give',
-        donateLinkId: 'SFIdOrLegacyId',
-        optInStatement: 'Opt in statement.',
-        website: 'https://www.thebiggive.org.uk',
-        regulatorNumber: '123456',
-        regulatorRegion: 'Scotland',
-      },
-      ['United Kingdom'],
-      'GBP',
-      4,
-      new Date(),
-      'Impact reporting plan',
-      'Impact overview',
-      true,
-      987,
-      988,
-      'The situation',
-      [],
-      'The solution',
-      new Date(),
-      'Active',
-      'Test Master Campaign detail',
-      15000,
-      'Test Master Campaign!',
-      [],
-    );
+    component.campaign = getDummyMasterCampaign();
     component.children = [
       new CampaignSummary(
         'testCampaignId',

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -17,7 +17,7 @@ import { SearchService } from '../search.service';
   styleUrls: ['./meta-campaign.component.scss'],
 })
 export class MetaCampaignComponent implements OnDestroy, OnInit {
-  public campaign?: Campaign;
+  public campaign: Campaign;
   public children: CampaignSummary[];
   public filterError = false;
   public fund?: Fund;
@@ -42,7 +42,6 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
     private state: TransferState,
   ) {
     route.params.pipe().subscribe(params => {
-      this.campaignId = params.campaignId;
       this.campaignSlug = params.campaignSlug;
       this.fundSlug = params.fundSlug;
     });
@@ -63,29 +62,17 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
+    this.campaign = this.route.snapshot.data.campaign;
+    this.campaignId = this.campaign.id;
+
     this.listenForRouteChanges();
-    let metacampaignKey: StateKey<string>;
-    if (this.campaignSlug) {
-      metacampaignKey = makeStateKey<Campaign>(`metacampaign-${this.campaignSlug}`);
-    } else {
-      metacampaignKey = makeStateKey<Campaign>(`metacampaign-${this.campaignId}`);
-    }
-    this.campaign = this.state.get<Campaign | undefined>(metacampaignKey, undefined);
+
+    this.setSecondaryPropsAndRun(this.campaign);
 
     let fundKey: StateKey<string>;
     if (this.fundSlug) {
       fundKey = makeStateKey<Fund>(`fund-${this.fundSlug}`);
       this.fund = this.state.get(fundKey, undefined);
-    }
-
-    if (this.campaign) { // app handed over from SSR to client-side JS
-      this.setSecondaryPropsAndRun(this.campaign);
-    } else {
-      if (this.campaignId) {
-        this.campaignService.getOneById(this.campaignId).subscribe(campaign => this.setCampaign(campaign, metacampaignKey));
-      } else {
-        this.campaignService.getOneBySlug(this.campaignSlug).subscribe(campaign => this.setCampaign(campaign, metacampaignKey));
-      }
     }
 
     if (!this.fund && this.fundSlug) {
@@ -164,15 +151,6 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
         this.loading = false;
       },
     );
-  }
-
-  /**
-   * Set the campaign for the service and page metadata.
-   */
-  private setCampaign(campaign: Campaign, metacampaignKey: StateKey<Campaign>) {
-    this.state.set(metacampaignKey, campaign); // Have data ready for client when handing over from SSR
-    this.campaign = campaign;
-    this.setSecondaryPropsAndRun(campaign);
   }
 
   private setSecondaryPropsAndRun(campaign: Campaign) {


### PR DESCRIPTION
Also simplify some stuff by not needing to check for `campaign[s]` presence so much, and having a general route changed spinner instead of route data specific ones.