### PR TITLE
DON-412 – handle resolver errors (e.g. missing slugs) without a server crash

### DIFF
--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { makeStateKey, TransferState } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { Campaign } from './campaign.model';
 import { CampaignService } from './campaign.service';
@@ -40,7 +41,12 @@ export class CampaignResolver implements Resolve<any> {
       return of(campaign);
     }
 
-    const observable = method(identifier);
+    const observable = method(identifier)
+      .pipe(catchError(error => {
+        console.log(`CampaignResolver load error: "${error.message}"`);
+        return EMPTY;
+      }));
+
     observable.subscribe(loadedCampaign => {
       // Save in state for future routes, e.g. when moving between `CampaignDetailComponent`
       // and `DonationStartComponent`.

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { makeStateKey, TransferState } from '@angular/platform-browser';
-import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 import { EMPTY, Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -11,6 +11,7 @@ import { CampaignService } from './campaign.service';
 export class CampaignResolver implements Resolve<any> {
   constructor(
     public campaignService: CampaignService,
+    private router: Router,
     private state: TransferState,
   ) {}
 
@@ -21,6 +22,9 @@ export class CampaignResolver implements Resolve<any> {
     // No . expected in slugs, and these are typically part of opportunistic junk requests.
     if (campaignSlug && campaignSlug.match(new RegExp('[.]+'))) {
       console.log(`CampaignResolver skipping load attempt for junk slug: "${campaignSlug}"`);
+      // Because it happens server side & before resolution, `replaceUrl` seems not to
+      // work, so just fall back to serving the Explore content on the requested path.
+      this.router.navigateByUrl('/explore');
       return EMPTY;
     }
 
@@ -50,6 +54,9 @@ export class CampaignResolver implements Resolve<any> {
     const observable = method(identifier)
       .pipe(catchError(error => {
         console.log(`CampaignResolver load error: "${error.message}"`);
+        // Because it happens server side & before resolution, `replaceUrl` seems not to
+        // work, so just fall back to serving the Explore content on the requested path.
+        this.router.navigateByUrl('/explore');
         return EMPTY;
       }));
 

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -18,6 +18,12 @@ export class CampaignResolver implements Resolve<any> {
     const campaignId = route.paramMap.get('campaignId');
     const campaignSlug = route.paramMap.get('campaignSlug');
 
+    // No . expected in slugs, and these are typically part of opportunistic junk requests.
+    if (campaignSlug && campaignSlug.match(new RegExp('[.]+'))) {
+      console.log(`CampaignResolver skipping load attempt for junk slug: "${campaignSlug}"`);
+      return EMPTY;
+    }
+
     if (campaignId) {
       return this.loadWithStateCache(
         campaignId,

--- a/src/app/charity-campaigns.resolver.ts
+++ b/src/app/charity-campaigns.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 
 import { CampaignService } from './campaign.service';
 import { EMPTY, Observable, of } from 'rxjs';
@@ -8,7 +8,7 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class CharityCampaignsResolver implements Resolve<any> {
-  constructor(private campaignService: CampaignService) {}
+  constructor(private campaignService: CampaignService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<CampaignSummary[]> {
     const charityId = route.paramMap.get('charityId');
@@ -22,6 +22,9 @@ export class CharityCampaignsResolver implements Resolve<any> {
     return this.campaignService.getForCharity(charityId)
       .pipe(catchError(error => {
         console.log(`CharityCampaignsResolver load error: "${error.message}"`);
+        // Because it happens server side & before resolution, `replaceUrl` seems not to
+        // work, so just fall back to serving the Explore content on the requested path.
+        this.router.navigateByUrl('/explore');
         return EMPTY;
       }));
   }

--- a/src/app/charity-campaigns.resolver.ts
+++ b/src/app/charity-campaigns.resolver.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
 import { CampaignService } from './campaign.service';
-import { Observable, of } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import { CampaignSummary } from './campaign-summary.model';
+import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class CharityCampaignsResolver implements Resolve<any> {
@@ -18,6 +19,10 @@ export class CharityCampaignsResolver implements Resolve<any> {
       return of([]);
     }
 
-    return this.campaignService.getForCharity(charityId);
+    return this.campaignService.getForCharity(charityId)
+      .pipe(catchError(error => {
+        console.log(`CharityCampaignsResolver load error: "${error.message}"`);
+        return EMPTY;
+      }));
   }
 }


### PR DESCRIPTION
Also try to avoid sending some invalid format slugs as requests to SF at all.