### PR TITLE
Add Stripe error message prefixes

### DIFF
--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -383,7 +383,9 @@ export class DonationStartComponent implements AfterContentChecked, OnDestroy, O
     this.stripePRBMethodReady = false; // Using card instead
 
     this.stripePaymentMethodReady = state.complete;
-    this.stripeError = state.error?.message;
+    if (state.error) {
+      this.stripeError = `Payment method update failed: ${state.error.message}`;
+    }
 
     // Jump back if we get an out of band message back that the card is *not* valid/ready.
     // Don't jump forward when the card *is* valid, as the donor might have been
@@ -403,7 +405,7 @@ export class DonationStartComponent implements AfterContentChecked, OnDestroy, O
     );
 
     if (paymentMethodResult.error) {
-      this.stripeError = paymentMethodResult.error.message;
+      this.stripeError = `Payment setup failed:  ${paymentMethodResult.error.message}`;
       this.submitting = false;
       this.analyticsService.logError('stripe_payment_method_error', paymentMethodResult.error.message ?? '[No message]');
 
@@ -489,7 +491,9 @@ export class DonationStartComponent implements AfterContentChecked, OnDestroy, O
     const result = await this.stripeService.confirmPayment(this.donation, this.card);
 
     if (!result || result.error) {
-      this.stripeError = result?.error.message;
+      if (result) {
+        this.stripeError = `Payment processing failed: ${result.error.message}`;
+      }
       this.submitting = false;
 
       return;


### PR DESCRIPTION
Provide more helpful feedback for donors and TBG support
to identify what has gone wrong in the different Stripe
failure modes.