### PR TITLE
DON-417 - fix `init()` loading Stripe 2 different ways

### DIFF
--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -12,7 +12,6 @@ import {
   StripeElements,
   StripeError,
   StripePaymentRequestButtonElement,
-  PaymentRequestCompleteStatus,
 } from '@stripe/stripe-js';
 import { Observer } from 'rxjs';
 
@@ -46,10 +45,6 @@ export class StripeService {
     this.didInit = true;
 
     this.paymentMethodIds = new Map();
-
-    const stripeTag = document.createElement('script');
-    stripeTag.src = 'https://js.stripe.com/v3/';
-    document.head.appendChild(stripeTag);
 
     // Initialising through the ES Module like this is not required, but is made available by
     // an official Stripe-maintained package and gives us TypeScript types for


### PR DESCRIPTION
Note that the remaining `await loadStripe(...)` is designed to do the library load that the head tag was doing. When I removed the fixed Stripe load from the `index.html`s it looks like it could/should actually have been a clean removal because of this, and there was no need to do DIY script tag loading in the TS like we do for Analytics and Get Site Control.