### PR TITLE
DON-329 - save & restore latest meta-campaign children

### DIFF
--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -168,7 +168,7 @@ export class SearchQuery implements SearchQueryInterface {
   public country?: string;
   public fundSlug?: string;
   public limit = 6;
-  public offset = 0;
+  public offset?: number|undefined = 0;
   public onlyMatching?: boolean;
   public parentId?: string;
   public parentSlug?: string;

--- a/src/app/meta-campaign/meta-campaign.component.spec.ts
+++ b/src/app/meta-campaign/meta-campaign.component.spec.ts
@@ -12,12 +12,14 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { InMemoryStorageService } from 'ngx-webstorage-service';
 import { of } from 'rxjs';
 
 import { Campaign } from '../campaign.model';
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
 import { CampaignSearchFormComponent } from '../campaign-search-form/campaign-search-form.component';
 import { CampaignSummary } from '../campaign-summary.model';
+import { TBG_DONATE_STORAGE } from '../donation.service';
 import { FiltersComponent } from './../filters/filters.component';
 import { HeroComponent } from '../hero/hero.component';
 import { MetaCampaignComponent } from './meta-campaign.component';
@@ -105,6 +107,9 @@ describe('MetaCampaignComponent', () => {
             },
           },
         },
+        // Inject in-memory storage for tests, in place of local storage.
+        { provide: TBG_DONATE_STORAGE, useExisting: InMemoryStorageService },
+        InMemoryStorageService,
       ],
     })
     .compileComponents();

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -1,11 +1,14 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { makeStateKey, StateKey, TransferState } from '@angular/platform-browser';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { StorageService } from 'ngx-webstorage-service';
 import { Subscription } from 'rxjs';
 
 import { Campaign } from '../campaign.model';
 import { CampaignSummary } from '../campaign-summary.model';
 import { CampaignService, SearchQuery } from '../campaign.service';
+import { TBG_DONATE_STORAGE } from '../donation.service';
+import { environment } from '../../environments/environment';
 import { Fund } from '../fund.model';
 import { FundService } from '../fund.service';
 import { PageMetaService } from '../page-meta.service';
@@ -18,7 +21,7 @@ import { SearchService } from '../search.service';
 })
 export class MetaCampaignComponent implements OnDestroy, OnInit {
   public campaign: Campaign;
-  public children: CampaignSummary[];
+  public children: CampaignSummary[] = [];
   public filterError = false;
   public fund?: Fund;
   public fundSlug: string;
@@ -32,6 +35,8 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
   private routeParamSubscription: Subscription;
   private searchServiceSubscription: Subscription;
 
+  private readonly recentChildrenKey = `${environment.donateUriPrefix}/children/v2`; // Key is per-domain/env
+
   constructor(
     private campaignService: CampaignService,
     private fundService: FundService,
@@ -40,6 +45,7 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
     private route: ActivatedRoute,
     public searchService: SearchService,
     private state: TransferState,
+    @Inject(TBG_DONATE_STORAGE) private storage: StorageService,
   ) {
     route.params.pipe().subscribe(params => {
       this.campaignSlug = params.campaignSlug;
@@ -123,10 +129,28 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
       this.campaignSlug,
       this.fundSlug,
     );
+
+    this.doCampaignSearch(query as SearchQuery, false);
+  }
+
+  /**
+   * Also saves results for imminent future navigation to the same meta-campaign + filters.
+   */
+  private doCampaignSearch(query: SearchQuery, clearExisting: boolean) {
     this.campaignService.search(query as SearchQuery).subscribe(campaignSummaries => {
       // Success
-      this.children = [...this.children, ...campaignSummaries];
+      this.children = clearExisting ? campaignSummaries : [...this.children, ...campaignSummaries];
       this.loading = false;
+
+      // Save children so we can go 'back' here in the browser and maintain scroll position.
+      // Only an exact query match should reinstate the same child campaigns on load.
+      const recentChildrenData = {
+        query: this.normaliseQueryForRecentChildrenComparison(query),
+        offset: this.offset,
+        children: this.children,
+      };
+
+      this.storage.set(this.recentChildrenKey, recentChildrenData);
     }, () => {
       this.filterError = true; // Error, e.g. slug not known
       this.loading = false;
@@ -140,17 +164,23 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
   private run() {
     this.offset = 0;
     const query = this.campaignService.buildQuery(this.searchService.selected, 0, this.campaignId, this.campaignSlug, this.fundSlug);
+
+    const recentChildrenData = this.storage.get(this.recentChildrenKey);
+    // Only an exact query match should reinstate the same child campaigns on load.
+    if (recentChildrenData && recentChildrenData.query === this.normaliseQueryForRecentChildrenComparison(query as SearchQuery)) {
+      this.children = recentChildrenData.children;
+      // We need to separately reinstate the offset, while excluding it from the normalised query params
+      // we use for equality comparison, so that moreMightExist() and therefore scrolling to load more
+      // campaigns still works after we reinstate the existing children.
+      this.offset = recentChildrenData.offset;
+
+      return;
+    }
+
+    // Else need to load children newly.
     this.children = [];
     this.loading = true;
-
-    this.campaignService.search(query as SearchQuery).subscribe(campaignSummaries => {
-        this.children = campaignSummaries; // Success
-        this.loading = false;
-      }, () => {
-        this.filterError = true; // Error, e.g. slug not known
-        this.loading = false;
-      },
-    );
+    this.doCampaignSearch(query as SearchQuery, true);
   }
 
   private setSecondaryPropsAndRun(campaign: Campaign) {
@@ -180,6 +210,12 @@ export class MetaCampaignComponent implements OnDestroy, OnInit {
 
       this.setQueryParams(); // Trigger a route change which in turn causes a `run()`.
     });
+  }
+
+  private normaliseQueryForRecentChildrenComparison(query: SearchQuery): string {
+    delete query.offset;
+
+    return JSON.stringify(query); // We don't want to get into object key / true equality comparisons, so just JSON it.
   }
 
   /**


### PR DESCRIPTION
This feature keeps the child campaigns for the last
viewed meta-campaign only, and metadata about which one
it is and what filters are applied, so that when donors use browser
'back' or otherwise return to a page like CC21 landing, we can
put back the campaigns they already loaded without further network
requests and maintain their previous scroll position without jumping
them down the page post-load.