### PR TITLE
Fix GG1 asset paths breaking SSR loads

### DIFF
--- a/src/app/multicurrency-landing/multicurrency-landing.component.html
+++ b/src/app/multicurrency-landing/multicurrency-landing.component.html
@@ -20,13 +20,13 @@
       <h3>Match Funded By</h3>
 
       <div class="logo-wrapper">
-        <img src="../../assets/images/white-square.JPG">
-        <img src="../../assets/images/white-square.JPG">
-        <img src="../../assets/images/white-square.JPG">
-        <img src="../../assets/images/white-square.JPG">
-        <img src="../../assets/images/white-square.JPG">
-        <img src="../../assets/images/white-square.JPG">
-        <img src="../../assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
+        <img src="/assets/images/white-square.JPG">
       </div>
   
       <a href="">Companies, join the campaign</a>

--- a/src/app/multicurrency-landing/multicurrency-landing.component.scss
+++ b/src/app/multicurrency-landing/multicurrency-landing.component.scss
@@ -4,7 +4,7 @@ $dark-grey: #333333;
 .hero {
     width: 100%;
     height: 375px;
-    background-image: url('../../assets/images/gogiveonebg.JPG');
+    background-image: url('/assets/images/gogiveonebg.JPG');
     background-position: center;
     background-size: cover;
     background-repeat: no-repeat;


### PR DESCRIPTION
@alihejazi I noticed Staging GG1 glitching on server load (big blank space) and looked at the server logs. This PR updates the asset paths refs to use the same approach as the rest of the app, which should make asset path refs work in both the Express server / dynamic ECS version of the app, and the client-side bundle.