### PR TITLE
DON-467 - avoid donation re-create blips

### DIFF
--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -748,6 +748,10 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
     if (this.donationCreateError && this.stepper.selected?.label === 'Your donation') {
       if (this.donation) {
         this.clearDonation(this.donation, true);
+        this.analyticsService.logEvent(
+          'create_retry',
+          `Donation cleared ahead of creation retry for campaign ${this.campaignId}`,
+        );
       }
       this.donationCreateError = false;
       this.stepper.next();

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -746,6 +746,9 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
     // error elements are still present. So the safest fix for now is to skip it
     // when we know we have only just hidden the error in this call.
     if (this.donationCreateError && this.stepper.selected?.label === 'Your donation') {
+      if (this.donation) {
+        this.clearDonation(this.donation, true);
+      }
       this.donationCreateError = false;
       this.stepper.next();
       return;


### PR DESCRIPTION
Shaky new logic is possibly implicated in an uptick today
in live edge case blips from API calls getting through in unexpected
orders.