### PR TITLE
DON-487 - add promoted metacampaigns banner

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { environment } from '../environments/environment';
 
 import { CampaignDetailsComponent } from './campaign-details/campaign-details.component';
 import { CampaignListResolver } from './campaign-list.resolver';
+import { CampaignPromoted1Resolver } from './campaign-promoted-1.resolver';
+import { CampaignPromoted2Resolver } from './campaign-promoted-2.resolver';
 import { CampaignResolver } from './campaign.resolver';
 import { CharityCampaignsResolver } from './charity-campaigns.resolver';
 import { CharityComponent } from './charity/charity.component';
@@ -15,18 +16,6 @@ import { MetaCampaignComponent } from './meta-campaign/meta-campaign.component';
 import { MulticurrencyCampaignResolver } from './multicurrency-campaign.resolver';
 import { MulticurrencyCampaignListResolver } from './multicurrency-campaign-list.resolver';
 import { MulticurrencyLandingComponent } from './multicurrency-landing/multicurrency-landing.component';
-
-const rootPath = environment.redirectHomepageToChirstmasChallenge ? {
-  path: '',
-  redirectTo: 'christmas-challenge-2021',
-  pathMatch: 'full',
-} : {
-  path: '',
-  component: HomeComponent,
-  resolve: {
-    campaigns: CampaignListResolver,
-  },
-};
 
 const routes: Routes = [
   {
@@ -78,6 +67,11 @@ const routes: Routes = [
   {
     path: 'explore',
     component: ExploreComponent,
+    resolve: {
+      campaigns: CampaignListResolver,
+      promotedMetacampaign1: CampaignPromoted1Resolver,
+      promotedMetacampaign2: CampaignPromoted2Resolver,
+    },
   },
   {
     path: 'gogiveone',
@@ -99,7 +93,15 @@ const routes: Routes = [
       campaign: CampaignResolver,
     },
   },
-  rootPath,
+  {
+    path: '',
+    component: HomeComponent,
+    resolve: {
+      campaigns: CampaignListResolver,
+      promotedMetacampaign1: CampaignPromoted1Resolver,
+      promotedMetacampaign2: CampaignPromoted2Resolver,
+    },
+  },
   {
     path: '**',
     redirectTo: '',
@@ -115,6 +117,8 @@ const routes: Routes = [
   providers: [
     CampaignResolver,
     CampaignListResolver,
+    CampaignPromoted1Resolver,
+    CampaignPromoted2Resolver,
     CharityCampaignsResolver,
     MulticurrencyCampaignResolver,
     MulticurrencyCampaignListResolver,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { AppComponent } from './app.component';
 import { CampaignCardComponent } from './campaign-card/campaign-card.component';
 import { CampaignDetailsComponent } from './campaign-details/campaign-details.component';
 import { CampaignDetailsCardComponent } from './campaign-details-card/campaign-details-card.component';
+import { CampaignPromoCardComponent } from './campaign-promo-card/campaign-promo-card.component';
 import { CampaignSearchFormComponent } from './campaign-search-form/campaign-search-form.component';
 import { CharityComponent } from './charity/charity.component';
 import { TBG_DONATE_STORAGE } from './donation.service';
@@ -55,6 +56,7 @@ import { TimeLeftPipe } from './time-left.pipe';
 import { HomeComponent } from './home/home.component';
 import { MulticurrencyLandingComponent } from './multicurrency-landing/multicurrency-landing.component';
 import { MulticurrencyLocationPickComponent } from './multicurrency-location-pick/multicurrency-location-pick.component';
+import { PromotedCampaignsComponent } from './promoted-campaigns/promoted-campaigns.component';
 
 @NgModule({
   declarations: [
@@ -62,6 +64,7 @@ import { MulticurrencyLocationPickComponent } from './multicurrency-location-pic
     CampaignCardComponent,
     CampaignDetailsComponent,
     CampaignDetailsCardComponent,
+    CampaignPromoCardComponent,
     CampaignSearchFormComponent,
     CharityComponent,
     DonationCompleteComponent,
@@ -84,6 +87,7 @@ import { MulticurrencyLocationPickComponent } from './multicurrency-location-pic
     HomeComponent,
     MulticurrencyLandingComponent,
     MulticurrencyLocationPickComponent,
+    PromotedCampaignsComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/campaign-promo-card/campaign-promo-card.component.html
+++ b/src/app/campaign-promo-card/campaign-promo-card.component.html
@@ -1,0 +1,15 @@
+<div [routerLink]="campaignUri" class="c-promo-card" tabindex="0" [id]="'campaign-' + campaign.id">
+  <div class="c-banner">
+    <img
+      class="c-banner__image b-w-100"
+      *ngIf="bannerUri"
+      [src]="bannerUri"
+      alt=""
+      role="presentation"
+    >
+  </div>
+
+  <div class="c-header">
+    <a class="c-header__link"><h3 class="c-header__campaign-title">{{ campaign.title }}</h3></a>
+  </div>
+</div>

--- a/src/app/campaign-promo-card/campaign-promo-card.component.scss
+++ b/src/app/campaign-promo-card/campaign-promo-card.component.scss
@@ -1,0 +1,24 @@
+@import '../../abstract';
+
+.c-promo-card {
+  @include make-card;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c-banner__image {
+  height: auto;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.c-header__campaign-title {
+  @include size-lg;
+  color: $colour-teal-dark;
+  margin: 0.5rem auto 1rem auto;
+  text-align: center;
+}
+
+.c-header__link {
+  text-decoration: none;
+}

--- a/src/app/campaign-promo-card/campaign-promo-card.component.spec.ts
+++ b/src/app/campaign-promo-card/campaign-promo-card.component.spec.ts
@@ -1,0 +1,113 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { CampaignPromoCardComponent } from './campaign-promo-card.component';
+import { Campaign } from '../campaign.model';
+
+describe('CampaignPromoCardComponent', () => {
+  let component: CampaignPromoCardComponent;
+  let fixture: ComponentFixture<CampaignPromoCardComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CampaignPromoCardComponent ],
+      imports: [
+        FontAwesomeModule,
+        MatButtonModule,
+        MatIconModule,
+        MatProgressBarModule,
+        MatSelectModule,
+        RouterTestingModule,
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CampaignPromoCardComponent);
+    component = fixture.componentInstance;
+    component.campaign = new Campaign(
+      'a051r00001EywjpAAB',
+      ['Aim 1'],
+      200.00,
+      [
+        {
+          uri: 'https://example.com/some-additional-image.png',
+          order: 100,
+        },
+      ],
+      'https://example.com/some-banner.png',
+      ['Other'],
+      [
+        {
+          description: 'budget line 1',
+          amount: 2000.01,
+        },
+      ],
+      ['Animals'],
+      'The Big Give Match Fund',
+      {
+        id: 'sfCharityAsd1',
+        name: 'The Test Charity',
+        donateLinkId: 'SFIdOrLegacyId',
+        optInStatement: 'Opt in statement.',
+        website: 'https://www.awesomecharity.co.uk',
+        regulatorNumber: '123456',
+        regulatorRegion: 'Scotland',
+      },
+      ['United Kingdom'],
+      'GBP',
+      4,
+      new Date(),
+      'Impact reporting plan',
+      'Impact overview',
+      true,
+      987.00,
+      988.00,
+      'The situation',
+      [
+        {
+          quote: 'Some quote',
+          person: 'Someones quote',
+        },
+      ],
+      true,
+      'The solution',
+      new Date(),
+      'Active',
+      'Some long summary',
+      2000.01,
+      'The Test Campaign',
+      [],
+      'Some information about what happens if funds are not used',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        provider: 'youtube',
+        key: '1G_Abc2delF',
+      },
+    );
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load key data from test campaign', () => {
+    expect(component.campaign.title).toBe('The Test Campaign');
+    expect(component.campaign.isMatched).toBe(true);
+    expect(component.campaign.charity.name).toBe('The Test Charity');
+  });
+});

--- a/src/app/campaign-promo-card/campaign-promo-card.component.ts
+++ b/src/app/campaign-promo-card/campaign-promo-card.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+import { Campaign } from '../campaign.model';
+import { ImageService } from '../image.service';
+
+@Component({
+  selector: 'app-campaign-promo-card',
+  templateUrl: './campaign-promo-card.component.html',
+  styleUrls: ['./campaign-promo-card.component.scss'],
+})
+export class CampaignPromoCardComponent implements OnInit {
+  @Input() campaign: Campaign;
+  @Input() campaignUri: string;
+  bannerUri?: string;
+
+  constructor(private imageService: ImageService) {}
+
+  ngOnInit() {
+    this.imageService.getImageUri(this.campaign.bannerUri, 830).subscribe(uri => this.bannerUri = uri);
+  }
+}

--- a/src/app/campaign-promoted-1.resolver.ts
+++ b/src/app/campaign-promoted-1.resolver.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
 import { CampaignService } from './campaign.service';
+import { environment } from '../environments/environment';
 
 /**
  * One per campaign as this is a temporary workaround.
@@ -11,6 +12,6 @@ export class CampaignPromoted1Resolver implements Resolve<any> {
   constructor(private campaignService: CampaignService) {}
 
   resolve(route: ActivatedRouteSnapshot) {
-    return this.campaignService.getOneBySlug('women-and-girls-match-fund-2022');
+    return this.campaignService.getOneBySlug(environment.promotedMetacampaign1Slug);
   }
 }

--- a/src/app/campaign-promoted-1.resolver.ts
+++ b/src/app/campaign-promoted-1.resolver.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { CampaignService } from './campaign.service';
+
+/**
+ * One per campaign as this is a temporary workaround.
+ */
+@Injectable()
+export class CampaignPromoted1Resolver implements Resolve<any> {
+  constructor(private campaignService: CampaignService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.campaignService.getOneBySlug('women-and-girls-match-fund-2022');
+  }
+}

--- a/src/app/campaign-promoted-2.resolver.ts
+++ b/src/app/campaign-promoted-2.resolver.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
 import { CampaignService } from './campaign.service';
+import { environment } from '../environments/environment';
 
 /**
  * One per campaign as this is a temporary workaround.
@@ -11,6 +12,6 @@ export class CampaignPromoted2Resolver implements Resolve<any> {
   constructor(private campaignService: CampaignService) {}
 
   resolve(route: ActivatedRouteSnapshot) {
-    return this.campaignService.getOneBySlug('christmas-challenge-2021');
+    return this.campaignService.getOneBySlug(environment.promotedMetacampaign2Slug);
   }
 }

--- a/src/app/campaign-promoted-2.resolver.ts
+++ b/src/app/campaign-promoted-2.resolver.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { CampaignService } from './campaign.service';
+
+/**
+ * One per campaign as this is a temporary workaround.
+ */
+@Injectable()
+export class CampaignPromoted2Resolver implements Resolve<any> {
+  constructor(private campaignService: CampaignService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.campaignService.getOneBySlug('christmas-challenge-2021');
+  }
+}

--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -1,4 +1,9 @@
 <main>
+  <app-promoted-campaigns
+    [campaign1]="promotedCampaign1"
+    [campaign2]="promotedCampaign2"
+  ></app-promoted-campaigns>
+
   <div class="explore-hero">
     <div class="b-container-sm">
       <div fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center">

--- a/src/app/explore/explore.component.spec.ts
+++ b/src/app/explore/explore.component.spec.ts
@@ -12,6 +12,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
+import { CampaignPromoCardComponent } from '../campaign-promo-card/campaign-promo-card.component';
 import { CampaignSearchFormComponent } from '../campaign-search-form/campaign-search-form.component';
 import { ExploreComponent } from './explore.component';
 import { FiltersComponent } from '../filters/filters.component';
@@ -24,6 +25,7 @@ describe('ExploreComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         CampaignCardComponent,
+        CampaignPromoCardComponent,
         CampaignSearchFormComponent,
         ExploreComponent,
         FiltersComponent,

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { CampaignService, SearchQuery } from '../campaign.service';
+import { Campaign } from '../campaign.model';
 import { CampaignSummary } from '../campaign-summary.model';
 import { PageMetaService } from '../page-meta.service';
 import { SearchService } from '../search.service';
@@ -16,6 +17,8 @@ import { SearchService } from '../search.service';
 export class ExploreComponent implements OnDestroy, OnInit {
   campaigns: CampaignSummary[];
   loading = false; // Server render gets initial result set; set true when filters change.
+  promotedCampaign1: Campaign;
+  promotedCampaign2: Campaign;
   searched = false;
 
   private offset = 0;
@@ -41,6 +44,9 @@ export class ExploreComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
+    this.promotedCampaign1 = this.route.snapshot.data.promotedMetacampaign1;
+    this.promotedCampaign2 = this.route.snapshot.data.promotedMetacampaign2;
+
     this.pageMeta.setCommon(
       'The Big Give',
       'The Big Give &ndash; discover campaigns and donate',

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -20,6 +20,14 @@
     </div>
   </div>
 
+  <div class="promo-wrapper">
+    <app-promoted-campaigns
+      [campaign1]="promotedCampaign1"
+      [campaign2]="promotedCampaign2"
+    ></app-promoted-campaigns>
+  </div>
+
+  <h3 class="b-rh-1 b-bold" fxLayoutAlign="center">Charity campaigns</h3>
   <div class="b-container">
     <div class="c-grid">
       <div *ngFor="let campaign of campaigns">

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,5 +1,9 @@
 @import '../../abstract';
 
+.promo-wrapper {
+  margin-bottom: 6rem;
+}
+
 .home-hero {
   padding-top: 1rem;
   background-image: url(/assets/images/bg-hero-home.png);

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -12,6 +12,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { CampaignSearchFormComponent } from '../campaign-search-form/campaign-search-form.component';
 import { CampaignCardComponent } from '../campaign-card/campaign-card.component';
+import { CampaignPromoCardComponent } from '../campaign-promo-card/campaign-promo-card.component';
 import { HomeComponent } from './home.component';
 
 describe('HomeComponent', () => {
@@ -22,6 +23,7 @@ describe('HomeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         CampaignCardComponent,
+        CampaignPromoCardComponent,
         CampaignSearchFormComponent,
       ],
       imports: [

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
+import { Campaign } from '../campaign.model';
 import { CampaignSummary } from '../campaign-summary.model';
 import { PageMetaService } from '../page-meta.service';
 
@@ -11,11 +12,15 @@ import { PageMetaService } from '../page-meta.service';
 })
 export class HomeComponent implements OnInit {
   campaigns: CampaignSummary[];
+  promotedCampaign1: Campaign;
+  promotedCampaign2: Campaign;
 
   public constructor(private pageMeta: PageMetaService, private route: ActivatedRoute) {}
 
   ngOnInit() {
     this.campaigns = this.route.snapshot.data.campaigns;
+    this.promotedCampaign1 = this.route.snapshot.data.promotedMetacampaign1;
+    this.promotedCampaign2 = this.route.snapshot.data.promotedMetacampaign2;
     this.pageMeta.setCommon(
       'The Big Give',
       'The Big Give &ndash; discover campaigns and donate',

--- a/src/app/promoted-campaigns/promoted-campaigns.component.html
+++ b/src/app/promoted-campaigns/promoted-campaigns.component.html
@@ -1,0 +1,7 @@
+<aside class="b-container promo">
+  <h3 class="b-rh-1 b-bold" fxLayoutAlign="center">Featured campaigns</h3>
+  <div class="promo c-grid">
+    <app-campaign-promo-card [campaign]="campaign1" [campaignUri]="'/women-and-girls-match-fund-2022'"></app-campaign-promo-card>
+    <app-campaign-promo-card [campaign]="campaign2" [campaignUri]="'/christmas-challenge-2021'"></app-campaign-promo-card>
+  </div>
+</aside>

--- a/src/app/promoted-campaigns/promoted-campaigns.component.html
+++ b/src/app/promoted-campaigns/promoted-campaigns.component.html
@@ -1,7 +1,7 @@
 <aside class="b-container promo">
   <h3 class="b-rh-1 b-bold" fxLayoutAlign="center">Featured campaigns</h3>
   <div class="promo c-grid">
-    <app-campaign-promo-card [campaign]="campaign1" [campaignUri]="'/women-and-girls-match-fund-2022'"></app-campaign-promo-card>
-    <app-campaign-promo-card [campaign]="campaign2" [campaignUri]="'/christmas-challenge-2021'"></app-campaign-promo-card>
+    <app-campaign-promo-card [campaign]="campaign1" [campaignUri]="'/' + campaign1Slug"></app-campaign-promo-card>
+    <app-campaign-promo-card [campaign]="campaign2" [campaignUri]="'/' + campaign2Slug"></app-campaign-promo-card>
   </div>
 </aside>

--- a/src/app/promoted-campaigns/promoted-campaigns.component.scss
+++ b/src/app/promoted-campaigns/promoted-campaigns.component.scss
@@ -1,0 +1,9 @@
+@import '../../abstract';
+
+// Like the normal campaign grid but with max 2 cols.
+.c-grid {
+  @include campaign-grid;
+  @media #{$breakpoint-lg} {
+    grid-template-columns: calc((100% - 30px)/2) calc((100% - 30px)/2);
+  }
+}

--- a/src/app/promoted-campaigns/promoted-campaigns.component.spec.ts
+++ b/src/app/promoted-campaigns/promoted-campaigns.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PromotedCampaignsComponent } from './promoted-campaigns.component';
+
+describe('PromotedCampaignsComponent', () => {
+  let component: PromotedCampaignsComponent;
+  let fixture: ComponentFixture<PromotedCampaignsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PromotedCampaignsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PromotedCampaignsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/promoted-campaigns/promoted-campaigns.component.ts
+++ b/src/app/promoted-campaigns/promoted-campaigns.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+import { Campaign } from '../campaign.model';
+
+@Component({
+  selector: 'app-promoted-campaigns',
+  templateUrl: './promoted-campaigns.component.html',
+  styleUrls: ['./promoted-campaigns.component.scss']
+})
+export class PromotedCampaignsComponent {
+  @Input() campaign1: Campaign;
+  @Input() campaign2: Campaign;
+  constructor(
+  ) {}
+}

--- a/src/app/promoted-campaigns/promoted-campaigns.component.ts
+++ b/src/app/promoted-campaigns/promoted-campaigns.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 import { Campaign } from '../campaign.model';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-promoted-campaigns',
@@ -10,6 +11,9 @@ import { Campaign } from '../campaign.model';
 export class PromotedCampaignsComponent {
   @Input() campaign1: Campaign;
   @Input() campaign2: Campaign;
+  campaign1Slug = environment.promotedMetacampaign1Slug;
+  campaign2Slug = environment.promotedMetacampaign2Slug;
+
   constructor(
   ) {}
 }

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -14,6 +14,8 @@ export const environment: Environment = {
   maximumDonationAmount: 25000,
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
+  promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
+  promotedMetacampaign2Slug: 'christmas-challenge-2021',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -15,7 +15,7 @@ export const environment: Environment = {
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
   promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
-  promotedMetacampaign2Slug: 'christmas-challenge-2021',
+  promotedMetacampaign2Slug: 'ukraine-refugee-appeal',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.regression.ts
+++ b/src/environments/environment.regression.ts
@@ -20,7 +20,7 @@ export const environment: Environment = {
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
   promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
-  promotedMetacampaign2Slug: 'christmas-challenge-2021',
+  promotedMetacampaign2Slug: 'ukraine-refugee-appeal',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.regression.ts
+++ b/src/environments/environment.regression.ts
@@ -19,6 +19,8 @@ export const environment: Environment = {
   maximumDonationAmount: 25000,
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
+  promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
+  promotedMetacampaign2Slug: 'christmas-challenge-2021',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -19,7 +19,7 @@ export const environment: Environment = {
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
   promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
-  promotedMetacampaign2Slug: 'christmas-challenge-2021',
+  promotedMetacampaign2Slug: 'ukraine-refugee-appeal',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -18,6 +18,8 @@ export const environment: Environment = {
   maximumDonationAmount: 25000,
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
+  promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
+  promotedMetacampaign2Slug: 'christmas-challenge-2021',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment: Environment = {
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
   promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
-  promotedMetacampaign2Slug: 'christmas-challenge-2021',
+  promotedMetacampaign2Slug: 'ukraine-refugee-appeal',
   psps: {
     stripe: {
       enabled: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -18,6 +18,8 @@ export const environment: Environment = {
   maximumDonationAmount: 25000,
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',
   postcodeLookupUri: 'https://api.getAddress.io', // Full API base URI exc. trailing slash; undefined to switch off lookups.
+  promotedMetacampaign1Slug: 'women-and-girls-match-fund-2022',
+  promotedMetacampaign2Slug: 'christmas-challenge-2021',
   psps: {
     stripe: {
       enabled: true,


### PR DESCRIPTION
@alihejazi this is ready for an initial code review and I suggest we do that now. It should however remain in draft for right now as we're blocked on two points before it can be considered for live release:
1. Asset sizes should be consistent with past metacampaigns – this is why the CC21 banner doesn't quite align currently
2. The hard-coded slugs need to be changed from CC21's to the Ukraine one, but only once that campaign exists in Production and Full – until then the resolver will fail and block loading the Home and Explore pages