### PR TITLE
DON-506 – "downgrade" ECR orb to v7.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@8.0.0
+  aws-ecr: circleci/aws-ecr@7.3.0
   aws-ecs: circleci/aws-ecs@2.2.1
   aws-s3: circleci/aws-s3@3.0.0
   docker: circleci/docker@2.0.3
@@ -177,7 +177,7 @@ workflows:
             - deploy-regression-static
           extra-build-args: '--build-arg BUILD_ENV=regression --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'
-          region: '${AWS_REGION}'
+          region: AWS_REGION
           tag: 'regression,regression-${CIRCLE_SHA1}'
       - aws-ecs/deploy-service-update:
           context:
@@ -210,7 +210,7 @@ workflows:
             - deploy-staging-static
           extra-build-args: '--build-arg BUILD_ENV=staging --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'
-          region: '${AWS_REGION}'
+          region: AWS_REGION
           tag: 'staging,staging-${CIRCLE_SHA1}'
       - aws-ecs/deploy-service-update:
           context:
@@ -262,7 +262,7 @@ workflows:
             - deploy-production-static
           extra-build-args: '--build-arg BUILD_ENV=production --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'
-          region: '${AWS_REGION}'
+          region: AWS_REGION
           tag: 'production,production-${CIRCLE_SHA1}'
       - aws-ecs/deploy-service-update:
           context:


### PR DESCRIPTION
Trying a major version we use elsewhere, that should be new
enough not to break with old base image removals, and not so
new as to not be working as documented!