### PR TITLE
DON-270 – card input + validation edge case fixes

### DIFF
--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -280,7 +280,10 @@
               </mat-checkbox>
             </div>
 
-            <div *ngIf="!stripePRBMethodReady && paymentGroup.value.useSavedCard === false">
+            <!-- We need the ElementRef to always be available for Stripe.js mounting as there are
+            a few dynamic ways the input can become or cease to be relevant. So just CSS-hide the
+            element when not needed, and always mount it. -->
+            <div [style.display]="!stripePRBMethodReady && !paymentGroup.value.useSavedCard ? 'block' : 'none'">
               <div class="sr-combo-inputs-row">
                 <mat-label for="card-info">Card</mat-label>
                 <div class="sr-input sr-card-element" id="card-info" #cardInfo></div>

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -506,14 +506,7 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
       }
 
       if (this.psp === 'stripe') {
-        // Card element is mounted the same way regardless of donation info. See
-        // this.createDonationAndMaybePerson().subscribe(...) for Payment Request Button mount, which needs donation info
-        // first and so happens in `preparePaymentRequestButton()`.
-        this.card = this.stripeService.getCard();
-        if (this.cardInfo && this.card) { // Ensure #cardInfo not hidden by PRB success.
-          this.card.mount(this.cardInfo.nativeElement);
-          this.card.on('change', this.cardHandler);
-        }
+        this.prepareCardInput();
       }
 
       return;
@@ -830,6 +823,8 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
 
     if (event.checked) {
       this.updateFormWithSavedCard();
+    } else {
+      this.prepareCardInput();
     }
   }
 
@@ -849,6 +844,22 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
       // is removed, so billing postcode doesn't show as invalid after a change
       this.addStripeCardBillingValidators();
       this.paymentGroup.controls.billingPostcode.updateValueAndValidity();
+    }
+  }
+
+  private prepareCardInput() {
+    if (this.cardInfo.nativeElement.children.length > 0) {
+      // Card input was already ready.
+      return;
+    }
+
+    // Card element is mounted the same way regardless of donation info. See
+    // this.createDonationAndMaybePerson().subscribe(...) for Payment Request Button mount, which needs donation info
+    // first and so happens in `preparePaymentRequestButton()`.
+    this.card = this.stripeService.getCard();
+    if (this.cardInfo && this.card) { // Ensure #cardInfo not hidden by PRB success.
+      this.card.mount(this.cardInfo.nativeElement);
+      this.card.on('change', this.cardHandler);
     }
   }
 

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -900,6 +900,8 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
       billingPostcode: billingDetails.address?.postal_code,
       useSavedCard: true,
     });
+
+    this.stripePaymentMethodReady = true;
   }
 
   /**

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -1634,7 +1634,10 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
             this.amountsGroup.patchValue({ tipPercentage: this.initialTipSuggestedPercentage });
             this.tipPercentageChanged = false;
             if (this.paymentGroup) {
-              this.paymentGroup.patchValue({ billingCountry: this.defaultCountryCode });
+              this.paymentGroup.patchValue({
+                billingCountry: this.defaultCountryCode,
+                useSavedCard: false,
+              });
             }
 
             if (this.personId) {


### PR DESCRIPTION
* [DON-270 – more stable Stripe.js card input renders](https://github.com/thebiggive/donate-frontend/commit/25103939bbebe808e683fa8c468c8059bbad58f7)
  1. Always have an `ElementRef` but hide the el when needed
  2. Show it on any non-`true` value for `useSavedCard` instead of only strictly `false`
* [DON-270 – ask Stripe.js to set up the card input more proactively](https://github.com/thebiggive/donate-frontend/commit/d3d7843bda63adfe5dad33b60daf74a9704ac6ec)
* [DON-270 – set stripePaymentMethodReady reliably when defaulting a saved card to on](https://github.com/thebiggive/donate-frontend/commit/7cb4f7afc9c4d20e17d3ae7466c218d451df8461)
* [DON-270 – set useSavedCard to false (not null) when doing a full form reset](https://github.com/thebiggive/donate-frontend/commit/f91c26d4f5a9ab9dbd709d2b97f526664598db5e)