### PR TITLE
DON-536 – fix `document` global server bailouts

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,11 +38,15 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    document.fonts.ready.then(() => this.fontsLoaded = true);
-
     if (isPlatformBrowser(this.platformId)) {
       this.analyticsService.init();
       this.getSiteControlService.init();
+
+      this.fontsLoaded = false;
+      globalThis.document.fonts.ready.then(() => this.fontsLoaded = true);
+    } else {
+      // Server renders shouldn't hide elements regardless of this.
+      this.fontsLoaded = true;
     }
 
     // This service needs to be injected app-wide and this line is here, because

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ if (environment.productionLike) {
   enableProdMode();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+globalThis.document.addEventListener('DOMContentLoaded', () => {
   platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
 });


### PR DESCRIPTION
Locally I added console logging to this and did the SSR Docker builds described in the readme. It seemed that the browser was able to respond to loading events appropriately while the server no longer logs errors.