### PR TITLE
Pin container build to Node 16.18

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,7 +1,7 @@
 # Customised version of CircleCI Node image, published to Docker Hub as `thebiggive/donate-frontend-ci:latest` so it can be cached.
 # This avoids CI runs having to install lots of packages on every build.
 
-FROM cimg/node:lts
+FROM cimg/node:16.18
 
 # Dependencies for Chrome + Puppeteer. See https://medium.com/ramsatt/gitlab-ci-cd-with-angular-7-firebase-779bf040bb82
 # See https://stackoverflow.com/a/27273543/2803757 re requiring update –


### PR DESCRIPTION
Latest `lts` tag as of this week (presumably newer) fails to run `apt-get` updates with lock file permission errors, which we don't have time to dig into right now.