### PR TITLE
DON-533 – credit use QA fixes

### DIFF
--- a/src/app/donation-start/donation-start.component.html
+++ b/src/app/donation-start/donation-start.component.html
@@ -263,7 +263,7 @@
                 confirm it's you in case you have any queries.</mat-hint>
             </mat-form-field>
 
-            <div *ngIf="creditPenceToUse === 0" id="payment-request-button" #paymentRequestButton></div>
+            <div [style.display]="creditPenceToUse === 0 ? 'block' : 'none'" id="payment-request-button" #paymentRequestButton></div>
             <p *ngIf="requestButtonShown && !stripePRBMethodReady" class="b-center b-grey b-rt-sm">Or</p>
 
             <div *ngIf="creditPenceToUse > 0">

--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -385,6 +385,7 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
     this.personId = undefined;
     this.personIsLoginReady = false;
     this.stripeFirstSavedMethod = undefined;
+    this.stripePaymentMethodReady = false;
     this.donationForm.reset();
     this.identityService.clearJWT();
     this.idCaptcha.reset();
@@ -911,7 +912,11 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
       this.personIsLoginReady = true;
 
       if (environment.creditDonationsEnabled && person.cash_balance && person.cash_balance[this.campaign.currencyCode.toLowerCase()] > 0) {
-        this.creditPenceToUse = person.cash_balance[this.campaign.currencyCode.toLowerCase()];
+        this.creditPenceToUse = parseInt(
+          person.cash_balance[this.campaign.currencyCode.toLowerCase()].toString() as string,
+          10
+        );
+        this.stripePaymentMethodReady = true;
         this.setConditionalValidators();
       }
 
@@ -1591,7 +1596,11 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
       this.giftAidGroup.controls.homeAddress.updateValueAndValidity();
     });
 
-    this.addStripeCardBillingValidators();
+    if (this.creditPenceToUse > 0) {
+      this.removeStripeCardBillingValidators();
+    } else {
+      this.addStripeCardBillingValidators();
+    }
   }
 
   private getHomePostcodeValidatorsWhenClaimingGiftAid(homeOutsideUK: boolean) {


### PR DESCRIPTION
* Resolve JS crash from missing Payment Request Button element under some conditions
* Ensure amount is always loaded as an int, so that `===` checks work as intended
* Don't require billing address or country when using credit as no new