### PR TITLE
DON-690 – fix float value errors in some PRB cases

### DIFF
--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -292,9 +292,9 @@ export class StripeService {
       label,
       // In pence/cents, inc. tip
       amount:
-        (100 * donation.donationAmount) +
-        (100 * donation.tipAmount) +
-        (100 * donation.feeCoverAmount),
+        parseInt((100 * donation.donationAmount).toString(), 10) +
+        parseInt((100 * donation.tipAmount).toString(), 10) +
+        parseInt((100 * donation.feeCoverAmount).toString(), 10),
     };
   }
 
@@ -308,14 +308,14 @@ export class StripeService {
 
     if (donation.tipAmount > 0) {
       items.push({
-        amount: 100 * donation.tipAmount,
+        amount: parseInt((100 * donation.tipAmount).toString(), 10),
         label: 'Donation to Big Give',
       });
     }
 
     if (donation.feeCoverAmount > 0) {
       items.push({
-        amount: 100 * donation.feeCoverAmount,
+        amount: parseInt((100 * donation.feeCoverAmount).toString(), 10),
         label: 'Fee cover',
       });
     }


### PR DESCRIPTION
We have to do a slightly weird type dance because TS needs its `parseInt()` inputs to be strings.

This should stop Stripe PRB logic crashing because it's given 8099.9999999 pence or similar.