### PR TITLE
Fix page metadata for charity landing page

### DIFF
--- a/src/app/charity/charity.component.ts
+++ b/src/app/charity/charity.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { CampaignSummary } from '../campaign-summary.model';
+import { PageMetaService } from '../page-meta.service';
 
 @Component({
   selector: 'app-charity',
@@ -11,9 +12,19 @@ import { CampaignSummary } from '../campaign-summary.model';
 export class CharityComponent implements OnInit {
   campaigns: CampaignSummary[];
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(
+    private pageMeta: PageMetaService,
+    private route: ActivatedRoute,
+  ) {}
 
   ngOnInit(): void {
     this.campaigns = this.route.snapshot.data.campaigns;
+
+    this.pageMeta.setCommon(
+      this.campaigns.length > 0 ? `${this.campaigns[0].charity.name} Campaigns` : 'Campaigns Archive',
+      'Archive of Big Give match funded campaigns',
+      this.campaigns[0]?.currencyCode !== 'GBP',
+      null,
+    );
   }
 }


### PR DESCRIPTION
This page was added largely to give search engines a meaningful "charity index" as we moved from legacy – but it has no title! Quick short-term fix for that here, ahead of us spending a bit more time making the page more useful for humans.