### PR TITLE
Fix the hour in various `getRelevantDateAsStr()`s

### DIFF
--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -77,7 +77,7 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
 
   getRelevantDateAsStr(campaign: Campaign) {
     const date = CampaignService.getRelevantDate(campaign);
-    return date ? this.datePipe.transform(date, 'dd/MM/yyyy, hh:mm') : null;
+    return date ? this.datePipe.transform(date, 'dd/MM/yyyy, HH:mm') : null;
   }
 
   private setSecondaryProps(campaign: Campaign) {

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -90,7 +90,7 @@ export class ExploreComponent implements OnDestroy, OnInit {
 
   getRelevantDateAsStr(campaign: CampaignSummary) {
     const date = CampaignService.getRelevantDate(campaign);
-    return date ? this.datePipe.transform(date, 'dd/MM/yyyy, hh:mm') : null;
+    return date ? this.datePipe.transform(date, 'dd/MM/yyyy, HH:mm') : null;
   };
 
   /**

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -206,7 +206,7 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
 
   getRelevantDateAsStr(campaign: CampaignSummary) {
     const date = CampaignService.getRelevantDate(campaign);
-    return date ? this.datePipe.transform(date, 'dd/MM/yyyy, hh:mm') : null;
+    return date ? this.datePipe.transform(date, 'dd/MM/yyyy, HH:mm') : null;
   }
 
   private loadMoreForCurrentSearch() {


### PR DESCRIPTION
As discussed, I think shortly after CC22 we should refactor this so we don't have so much extra logic in `<biggive-button/>`. But for now, we should sort out the existing prop approach so that close times are factually correct.