### PR TITLE
DON-273: Show error instead of password reset form if token invalid

### DIFF
--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -49,6 +49,13 @@ export class IdentityService {
     );
   };
 
+
+  checkTokenValid(token: string): Observable<object> {
+    return this.http.get(
+      `${environment.identityApiPrefix}${this.resetPasswordTokenPath}/${token}`,
+    );
+  }
+
   resetPassword(password: string, token: string) {
     return this.http.post<{ jwt: string}>(
       `${environment.identityApiPrefix}${this.resetPasswordPath}`,

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -10,7 +10,7 @@
     ></biggive-heading>
     <!-- Note: check explicitly for `undefined` here, not for `!saveSuccessful`, because
     `saveSuccessful` has can be undefined, false, or true, all with a unique meaning. -->
-    <div *ngIf="saveSuccessful === undefined && !savingNewPassword">
+    <div *ngIf="saveSuccessful === undefined && !savingNewPassword && tokenValid">
       <mat-dialog-content class="mat-typography">
         <form [formGroup]="passwordForm">
           <p class="b-rt-0">Please enter your new password (min 10 characters)</p>
@@ -51,5 +51,9 @@
     <p *ngIf="saveSuccessful === false" class="error">
       Sorry, there was an error saving your new password. Your link may have expired. Please <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">contact us</a> if this message persists.
     </p>
+
+    <div *ngIf="!tokenValid"  class="error">
+      Sorry, there was an error changing your new password. Your link may have expired. Please <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">contact us</a> if this message persists.
+    </div>
 
 </div>

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -61,7 +61,7 @@
     </p>
 
     <div *ngIf="tokenValid === false"  class="error">
-      Sorry, there was an error changing your new password. Your link may have expired. Please <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">contact us</a> if this message persists.
+      Sorry, your link may have expired. Please <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">contact us</a> if this message persists.
     </div>
 
 </div>

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -8,6 +8,14 @@
       align="left"
       text="Reset your Password"
     ></biggive-heading>
+
+  <mat-spinner
+    *ngIf="tokenValid === undefined"
+    aria-label="Loading"
+    color="primary"
+    diameter="15"
+  ></mat-spinner>
+
     <!-- Note: check explicitly for `undefined` here, not for `!saveSuccessful`, because
     `saveSuccessful` has can be undefined, false, or true, all with a unique meaning. -->
     <div *ngIf="saveSuccessful === undefined && !savingNewPassword && tokenValid">
@@ -52,7 +60,7 @@
       Sorry, there was an error saving your new password. Your link may have expired. Please <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">contact us</a> if this message persists.
     </p>
 
-    <div *ngIf="!tokenValid"  class="error">
+    <div *ngIf="tokenValid === false"  class="error">
       Sorry, there was an error changing your new password. Your link may have expired. Please <a href="https://www.thebiggive.org.uk/s/contact-us" target="_blank">contact us</a> if this message persists.
     </div>
 

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -33,6 +33,7 @@ export class ResetPasswordComponent implements OnInit {
   saveSuccessful: boolean|undefined = undefined;
   errorMessage: string;
   token: string;
+  tokenValid: boolean = true;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -55,6 +56,14 @@ export class ResetPasswordComponent implements OnInit {
     this.route.queryParams
       .subscribe(params => {
         this.token = params.token;
+        this.identityService.checkTokenValid(this.token).subscribe(
+          (response: {valid: boolean}) => {
+            this.tokenValid = response.valid;
+          },
+          () => {
+            this.tokenValid = false;
+          }
+        );
         if (!this.token) {
           this.router.navigate(['']);
         }

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -33,7 +33,7 @@ export class ResetPasswordComponent implements OnInit {
   saveSuccessful: boolean|undefined = undefined;
   errorMessage: string;
   token: string;
-  tokenValid: boolean = true;
+  tokenValid: boolean|undefined = undefined;
 
   constructor(
     private formBuilder: FormBuilder,


### PR DESCRIPTION
This PR relies on https://github.com/thebiggive/identity/pull/44 so that should be merged first.

We show the error below instead of the new password form if someone clicks a password reset link that has expired or doesn't exist.

Ideally like to make it an actual 404 error page, but I'm not sure how to persuade react router to do that, and this way may be fine, especially since we don't seem to serve a 404 page anywhere at the moment.

![Screenshot from 2022-12-08 12-42-28](https://user-images.githubusercontent.com/159481/206449712-433c7658-9b05-4087-a6d0-8bbe37ac3e08.png)
