### PR TITLE
Update components to version 1.0.181

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/platform-browser-dynamic": "^14.1.0",
         "@angular/platform-server": "^14.1.0",
         "@angular/router": "^14.1.0",
-        "@biggive/components-angular": "^1.0.175",
+        "@biggive/components-angular": "^1.0.181",
         "@fortawesome/angular-fontawesome": "~0.11.1",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -2482,9 +2482,9 @@
       }
     },
     "node_modules/@biggive/components": {
-      "version": "1.0.180",
-      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.180.tgz",
-      "integrity": "sha512-DgBysypoSW9mVQuYgSJGmkwkgSgPxPLHPLlezptgomlj9Sb8ho1RqqiH/njwQquKW20mAplZLa7B0prXnoiakg==",
+      "version": "1.0.181",
+      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.181.tgz",
+      "integrity": "sha512-Ze/Ryg7f2hLrr+9Eo0hVxPS7jfr4LzZuOKiMbpTiSdLa7rj4Jz1dXi0vWGoHqDTyNnBXP8zT1s8L1GujE3bTPA==",
       "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",
@@ -2497,9 +2497,9 @@
       }
     },
     "node_modules/@biggive/components-angular": {
-      "version": "1.0.180",
-      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.180.tgz",
-      "integrity": "sha512-kM11sK+ufxBa+lNpioOhJ7AP/BaIRDhzS//wpwsDXVckcr9V8n0pPoO9SjFXyZQu8nUcm9KUabpiF8klh/jUUw==",
+      "version": "1.0.181",
+      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.181.tgz",
+      "integrity": "sha512-h1DMc3f9AAxlhQi1q1cNjt9NPjrGqZq18dEK6AGpbvUmjssD7TdlAmG+8vWgBfQki6UgiQVRiV8qE+2kyMuzYA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -19581,9 +19581,9 @@
       }
     },
     "@biggive/components": {
-      "version": "1.0.180",
-      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.180.tgz",
-      "integrity": "sha512-DgBysypoSW9mVQuYgSJGmkwkgSgPxPLHPLlezptgomlj9Sb8ho1RqqiH/njwQquKW20mAplZLa7B0prXnoiakg==",
+      "version": "1.0.181",
+      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.181.tgz",
+      "integrity": "sha512-Ze/Ryg7f2hLrr+9Eo0hVxPS7jfr4LzZuOKiMbpTiSdLa7rj4Jz1dXi0vWGoHqDTyNnBXP8zT1s8L1GujE3bTPA==",
       "peer": true,
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",
@@ -19596,9 +19596,9 @@
       }
     },
     "@biggive/components-angular": {
-      "version": "1.0.180",
-      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.180.tgz",
-      "integrity": "sha512-kM11sK+ufxBa+lNpioOhJ7AP/BaIRDhzS//wpwsDXVckcr9V8n0pPoO9SjFXyZQu8nUcm9KUabpiF8klh/jUUw==",
+      "version": "1.0.181",
+      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.181.tgz",
+      "integrity": "sha512-h1DMc3f9AAxlhQi1q1cNjt9NPjrGqZq18dEK6AGpbvUmjssD7TdlAmG+8vWgBfQki6UgiQVRiV8qE+2kyMuzYA==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2482,9 +2482,9 @@
       }
     },
     "node_modules/@biggive/components": {
-      "version": "1.0.179",
-      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.179.tgz",
-      "integrity": "sha512-l+uWhN7/1qk3Bn+ew6ZWeKYEfYFbgk21coX3VNYRjnwCKlRp6vv03UGiRwclCpzTTqHdh/ONt/TAxfG9gwsWtw==",
+      "version": "1.0.180",
+      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.180.tgz",
+      "integrity": "sha512-DgBysypoSW9mVQuYgSJGmkwkgSgPxPLHPLlezptgomlj9Sb8ho1RqqiH/njwQquKW20mAplZLa7B0prXnoiakg==",
       "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",
@@ -2497,9 +2497,9 @@
       }
     },
     "node_modules/@biggive/components-angular": {
-      "version": "1.0.179",
-      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.179.tgz",
-      "integrity": "sha512-wIDv4ZTBVEgTgn6sGoNQu4lx78IZYF6a3NPAvIJnLCbWx3CgVT18HTkW3UGqz/hv40ir5BBWNsdA9vexjQ6NqQ==",
+      "version": "1.0.180",
+      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.180.tgz",
+      "integrity": "sha512-kM11sK+ufxBa+lNpioOhJ7AP/BaIRDhzS//wpwsDXVckcr9V8n0pPoO9SjFXyZQu8nUcm9KUabpiF8klh/jUUw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4667,9 +4667,9 @@
       "dev": true
     },
     "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.32.tgz",
-      "integrity": "sha512-Sz2g88b3iAu2jpMnhtps2bRX2GAAOvanOxGcVi+o7ybGjLetxK23o2cHskXKypvXxtZTsJegel5pUWSPpYphww==",
+      "version": "3.0.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.33.tgz",
+      "integrity": "sha512-az35wEPH00kW6eZDqHC0BumzAB4XD+YJb1b5tHEfsy73viCN7uGy8kvutwig5bgVwt1Hx7GuU09G50Sc5osBlA==",
       "dev": true,
       "dependencies": {
         "js-yaml": "^3.10.0",
@@ -5757,9 +5757,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001436",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
-      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "dev": true,
       "funding": [
         {
@@ -8007,9 +8007,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -19581,9 +19581,9 @@
       }
     },
     "@biggive/components": {
-      "version": "1.0.179",
-      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.179.tgz",
-      "integrity": "sha512-l+uWhN7/1qk3Bn+ew6ZWeKYEfYFbgk21coX3VNYRjnwCKlRp6vv03UGiRwclCpzTTqHdh/ONt/TAxfG9gwsWtw==",
+      "version": "1.0.180",
+      "resolved": "https://registry.npmjs.org/@biggive/components/-/components-1.0.180.tgz",
+      "integrity": "sha512-DgBysypoSW9mVQuYgSJGmkwkgSgPxPLHPLlezptgomlj9Sb8ho1RqqiH/njwQquKW20mAplZLa7B0prXnoiakg==",
       "peer": true,
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",
@@ -19596,9 +19596,9 @@
       }
     },
     "@biggive/components-angular": {
-      "version": "1.0.179",
-      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.179.tgz",
-      "integrity": "sha512-wIDv4ZTBVEgTgn6sGoNQu4lx78IZYF6a3NPAvIJnLCbWx3CgVT18HTkW3UGqz/hv40ir5BBWNsdA9vexjQ6NqQ==",
+      "version": "1.0.180",
+      "resolved": "https://registry.npmjs.org/@biggive/components-angular/-/components-angular-1.0.180.tgz",
+      "integrity": "sha512-kM11sK+ufxBa+lNpioOhJ7AP/BaIRDhzS//wpwsDXVckcr9V8n0pPoO9SjFXyZQu8nUcm9KUabpiF8klh/jUUw==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -19825,9 +19825,9 @@
           }
         },
         "globals": {
-          "version": "13.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+          "version": "13.19.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+          "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -21187,9 +21187,9 @@
       "dev": true
     },
     "@yarnpkg/parsers": {
-      "version": "3.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.32.tgz",
-      "integrity": "sha512-Sz2g88b3iAu2jpMnhtps2bRX2GAAOvanOxGcVi+o7ybGjLetxK23o2cHskXKypvXxtZTsJegel5pUWSPpYphww==",
+      "version": "3.0.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.33.tgz",
+      "integrity": "sha512-az35wEPH00kW6eZDqHC0BumzAB4XD+YJb1b5tHEfsy73viCN7uGy8kvutwig5bgVwt1Hx7GuU09G50Sc5osBlA==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.10.0",
@@ -22021,9 +22021,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001436",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
-      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "dev": true
     },
     "caseless": {
@@ -23563,9 +23563,9 @@
           }
         },
         "globals": {
-          "version": "13.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+          "version": "13.19.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+          "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/platform-browser-dynamic": "^14.1.0",
     "@angular/platform-server": "^14.1.0",
     "@angular/router": "^14.1.0",
-    "@biggive/components-angular": "^1.0.175",
+    "@biggive/components-angular": "^1.0.181",
     "@fortawesome/angular-fontawesome": "~0.11.1",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.0",


### PR DESCRIPTION
I ran `FONTAWESOME_NPM_AUTH_TOKEN=***** npm update` to make this change.

This brings in recent menu changes from [COM](https://github.com/thebiggive/components/)

![Screenshot from 2022-12-12 10-29-05](https://user-images.githubusercontent.com/159481/207023040-f8640a29-b9c8-4124-844e-713099702fa8.png)
![image](https://user-images.githubusercontent.com/159481/207023071-28bebc5e-cba3-4d6b-ba50-bbf31371e3f0.png)

![image](https://user-images.githubusercontent.com/159481/207092469-56f64cd6-3816-4e46-baac-7c3bfc62d64d.png)

