### PR TITLE
Stop loading global styles both globally and on `AppComponent`

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,1 +1,0 @@
-@import '../styles';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,7 +17,6 @@ import { NavigationService } from './navigation.service';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements AfterViewInit, OnInit {
   @ViewChild(BiggiveHeader) header: BiggiveHeader;


### PR DESCRIPTION
Global styles are already loaded in `angular.json` so they seem to have been extraneous here. Removing this decreases the `main` bundle's uncompressed size quite a bit.