### PR TITLE
DON-708: Update GMF and C4C highlight cards to show applications open…

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,20 +12,41 @@
 
     <biggive-grid
       column-count="3">
-      <biggive-basic-card
+      <biggive-basic-card *ngIf="greenMatchApplicationsOpen"
         space-below='4'
         icon-colour='brand-3'
         background-image-url='/assets/images/card-background-gmf.jpg'
-        main-title='Save the Date for the Green Match Fund'
+        main-title='Applications for Green Match Fund now open'
+        subtitle='Deadline is 17 January 2023'
+        button-url='https://www.thebiggive.org.uk/charities/s/login/'
+        button-label='Apply Now'
+        button-colour-scheme='clear-primary'
+        class="basic-card-padding">
+      </biggive-basic-card>
+      <biggive-basic-card *ngIf="! greenMatchApplicationsOpen"
+        space-below='4'
+        icon-colour='brand-3'
+        background-image-url='/assets/images/card-background-gmf.jpg'
+        main-title='Save the Date for Green Match Fund'
         subtitle='Applications open 9 Jan 2023'
         button-url='https://blog.thebiggive.org.uk/green-match-fund/'
         button-label='Read more'
         button-colour-scheme='clear-primary'
-        class="basic-card-padding"
-      >
+        class="basic-card-padding">
       </biggive-basic-card>
 
-      <biggive-basic-card
+      <biggive-basic-card *ngIf="championsForChildrenApplicationsOpen"
+        space-below='4'
+        icon-colour='brand-5'
+        background-image-url='/assets/images/colour-orange.png'
+        main-title='Applications for Champions for Children now open!'
+        subtitle='Deadline is 24 February 2023'
+        button-url='https://www.thebiggive.org.uk/charities/s/login/'
+        button-label='Apply Now'
+        button-colour-scheme='clear-primary'
+        class="basic-card-padding">
+      </biggive-basic-card>
+      <biggive-basic-card *ngIf="! championsForChildrenApplicationsOpen"
         space-below='4'
         icon-colour='brand-5'
         background-image-url='/assets/images/colour-orange.png'
@@ -34,10 +55,8 @@
         button-url='https://blog.thebiggive.org.uk/champions-for-children/'
         button-label='Read more'
         button-colour-scheme='clear-primary'
-        class="basic-card-padding"
-      >
+        class="basic-card-padding">
       </biggive-basic-card>
-
       <biggive-basic-card
         space-below='4'
         icon-colour='primary'

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -12,6 +12,9 @@ export class HomeComponent implements OnInit {
   highlightCard1Title = 'Double your donation\nin the Christmas Challenge 2022';
   highlightCard1Subtitle = 'Donate between\n29 Nov – 6 Dec';
 
+  greenMatchApplicationsOpen: boolean;
+  championsForChildrenApplicationsOpen: boolean = true;
+
   public constructor(private pageMeta: PageMetaService) {}
 
   ngOnInit() {
@@ -21,5 +24,10 @@ export class HomeComponent implements OnInit {
       false,
       'https://images-production.thebiggive.org.uk/0011r00002IMRknAAH/CCampaign%20Banner/db3faeb1-d20d-4747-bb80-1ae9286336a3.jpg',
     );
+
+    const openingDate = new Date("2023-01-09T12:00:00.000+00:00");
+    const now = new Date();
+    this.greenMatchApplicationsOpen = now >= openingDate;
+    this.championsForChildrenApplicationsOpen = now >= openingDate;
   }
 }


### PR DESCRIPTION
… from 9 Jan

At the time set the cards should automatically change to appear as in the second screenshot, although probably only after a browser refresh.

![Screenshot from 2023-01-04 11-57-35](https://user-images.githubusercontent.com/159481/210550531-f9deda67-5de7-4a13-96c1-36ae1e6be798.png)

![image](https://user-images.githubusercontent.com/159481/210550674-fb28cc12-cbe7-4132-84e6-93c099e09478.png)

It's relying on the clock in the browsing device to check the time. I'd prefer to rely on the server's clock to be authoritative instead of the browser, but this may be good enough for now, as I'm not sure what the best way would be to use the server's clock.