### PR TITLE
ID-35: Don't specify login duration on login

### DIFF
--- a/src/app/donation-complete/donation-complete-set-password-dialog.html
+++ b/src/app/donation-complete/donation-complete-set-password-dialog.html
@@ -14,7 +14,7 @@
 
       <p class="b-rt-0 radio-group-label" id="stayLoggedIn-label">If you're on a private computer, you can safely choose to be logged in.</p>
       <mat-radio-group tabindex="0" aria-labelledby="stayLoggedIn-label" formControlName="stayLoggedIn">
-        <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Log me in and stay logged in for a week</mat-radio-button>
+        <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Log me in</mat-radio-button>
         <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">Don't log me in</mat-radio-button>
       </mat-radio-group>
     </form>


### PR DESCRIPTION
I think we probably don't need it, and we don't have a way to make sure this is up to date with any backend changes that set the duration. I noticed this by chance.