### PR TITLE
Fix BG2-2285: Donor password reset link not working

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -66,7 +66,7 @@ export class AppComponent implements AfterViewInit, OnInit {
       // donations are currently not working on the new domain. No-one should be visiting that domain yet, but
       // in case they do we redirect them to the old domain for now:
 
-      window.location.href = "https://donate.thebiggive.org.uk/" + window.location.pathname;
+      window.location.host = "donate.thebiggive.org.uk";
     }
   }
 


### PR DESCRIPTION
The redirect from new domain back to old domain was losing the secret token as that was in a query parameter and not part of the pathname

I've tested out assigning window.location.host in the browser console instead and that works.