### PR TITLE
DON-727: Improve payment method layout

### DIFF
--- a/src/app/my-account/my-account.component.html
+++ b/src/app/my-account/my-account.component.html
@@ -20,7 +20,8 @@
         </div>
       </biggive-page-section>
       <biggive-page-section>
-        <table *ngIf="person" class="personal-details">
+        <h2>Your Details</h2>
+        <table *ngIf="person" id="personal-details">
           <!--
           Not sure why Typescript doesn't allow me to concatenate like this.
           <h2>{{person.first_name + person.last_name}}</h2>
@@ -45,19 +46,21 @@
       </biggive-page-section>
 
       <biggive-page-section>
-        <h2>Saved Payment Methods</h2>
+        <h2>Your Payment Methods</h2>
 
         <div *ngIf="paymentMethods === undefined">
           <mat-spinner [diameter]="40" aria-label="Loading payment methods"></mat-spinner>
         </div>
 
-        <div *ngIf="paymentMethods !== undefined && paymentMethods.length > 0">
-          <div *ngFor="let method of paymentMethods">
-            <div *ngIf="method.card !== undefined">
-              {{displayPaymentCard(method.card)}}
-            </div>
-          </div>
-        </div>
+        <table id="paymentMethods" *ngIf="paymentMethods !== undefined && paymentMethods.length > 0">
+          <tr *ngFor="let method of paymentMethods">
+            <td>{{(method.card?.brand || method.type).toUpperCase()}}</td>
+            <td *ngIf="method.card !== undefined">
+              Card Ending: {{method.card.last4}} <br />
+              Expiry Date: {{method.card.exp_month.toString().padStart(2, "0")}}/{{method.card.exp_year}}
+            </td>
+          </tr>
+        </table>
 
         <div *ngIf="paymentMethods !== undefined && paymentMethods.length === 0">
           No saved payment methods

--- a/src/app/my-account/my-account.component.scss
+++ b/src/app/my-account/my-account.component.scss
@@ -10,10 +10,11 @@
   padding: 0.25rem 1rem 1rem 1rem;
 }
 
-table.personal-details {
+table#personal-details, table#paymentMethods {
   td {
     padding-bottom: 15px;
-    padding-right: 20px;
+    padding-right: 60px;
+    min-width: 100px;
   }
 }
 

--- a/src/app/my-account/my-account.component.spec.ts
+++ b/src/app/my-account/my-account.component.spec.ts
@@ -94,6 +94,6 @@ describe('MyAccountComponent', () => {
   });
 
   it('should show payment card number and brand', () => {
-    expect(element.textContent).toContain("AcmeCard **** **** **** 1234")
+    expect(element.textContent).toContain("ACMECARD Card Ending: 1234  Expiry Date: 05/2030")
   });
 });

--- a/src/app/my-account/my-account.component.ts
+++ b/src/app/my-account/my-account.component.ts
@@ -59,13 +59,6 @@ export class MyAccountComponent implements OnInit {
       );
   }
 
-  displayPaymentCard(card: PaymentMethod.Card): string
-  {
-    // we guess that the Primary account number might have ahd 16 digits. This isn't guarnateed to be correct
-    // but maybe good enough to make clear that we're displaying the last 4.
-    return card.brand + " **** **** **** " + card.last4
-  }
-
   logout() {
     this.identityService.clearJWT();
     this.router.navigate(['']);


### PR DESCRIPTION
I think this might be all we need for display of payment methods. There is more information that we have, and that the API is sending to the browser so people can see if they no how, but I think things like the billing address attached to each payment method and what country it's in would just clutter the page if we showed them here.

This is how the page looks if you have several cards saved:

![image](https://user-images.githubusercontent.com/159481/219661270-052851ae-d941-416c-9722-856051098ef5.png)

I'm pretty sure we don't allow any payment methods other than cards, but if someone does have a different method stored (e.g. [Cleaplay](https://www.clearpay.co.uk/en-GB) then it would be displayed like this:

![image](https://user-images.githubusercontent.com/159481/219662938-e6880f94-9200-4e23-b86e-62a359a4e7a3.png)

If people agree that this is enough for the display I'll move on to implementing deletion.