### PR TITLE
Fix title case in menu

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -87,7 +87,7 @@
     </li>
     <li>
       <a (click)="noNav($event)">
-        About us
+        About Us
         <biggive-misc-icon class="bx bxs-chevron-down sub-menu-arrow arrow" background-colour="white" icon-colour="black" icon="CaretRight"></biggive-misc-icon>
       </a>
       <ul class="sub-menu">


### PR DESCRIPTION
This matches what we have on wordpress site, as well as casing of other menu items