### PR TITLE
DON-741: Update Circle config to work with aws-ecr-orb 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ workflows:
             - deploy-regression-static
           extra-build-args: '--build-arg BUILD_ENV=regression --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'
-          region: AWS_REGION
+          region: '${AWS_REGION}'
           tag: 'regression,regression-${CIRCLE_SHA1}'
       - aws-ecs/deploy-service-update:
           context:
@@ -208,7 +208,7 @@ workflows:
             - deploy-staging-static
           extra-build-args: '--build-arg BUILD_ENV=staging --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'
-          region: AWS_REGION
+          region: '${AWS_REGION}'
           tag: 'staging,staging-${CIRCLE_SHA1}'
       - hold:
           name: hold # please check chunk filenames match between previous production-static and push-iamge jobs
@@ -268,7 +268,7 @@ workflows:
             - deploy-production-static
           extra-build-args: '--build-arg BUILD_ENV=production --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'
-          region: AWS_REGION
+          region: '${AWS_REGION}'
           tag: 'production,production-${CIRCLE_SHA1}'
       - hold:
           name: hold # please check chunk filenames match between previous production-static and push-iamge jobs


### PR DESCRIPTION
See https://github.com/CircleCI-Public/aws-ecr-orb/releases/tag/v8.0.0

Build failed at https://app.circleci.com/pipelines/github/thebiggive/donate-frontend/3207/workflows/5e1edb79-9b2a-44a8-99c4-0e8f2e266e8e because the orb now wants the regions as a string, not an env variable.