### PR TITLE
Update slack notification orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.0
   docker: circleci/docker@2.1.2
   jira: circleci/jira@1.3.1
-  slack: circleci/slack@4.9.3
+  slack: circleci/slack@4.12.1
 
 jobs:
   build:


### PR DESCRIPTION
We're getting an error code 60 (CURLE_PEER_FAILED_VERIFICATION). Don't know why, but updating the orb seems like a good start to fixing it.