### PR TITLE
ID-36: Make registration error warning triangle more prominent

### DIFF
--- a/src/app/donation-complete/donation-complete.component.scss
+++ b/src/app/donation-complete/donation-complete.component.scss
@@ -124,6 +124,10 @@ hr {
       }
     }
   }
+
+  p.error fa-icon {
+    color: $colour-highlight;
+  }
 }
 
 .thank-you-large-donation-text {


### PR DESCRIPTION
Updated screenshot (as will be shown when this PR and https://github.com/thebiggive/identity/pull/70 are merged): 
![image](https://user-images.githubusercontent.com/159481/222477183-45885c49-2910-47cf-aad6-72c7044ff312.png)
