### PR TITLE
ID-36: Display error message sent in HTML from server in preference t…

### DIFF
--- a/src/app/donation-complete/donation-complete.component.html
+++ b/src/app/donation-complete/donation-complete.component.html
@@ -57,6 +57,7 @@
       <p *ngIf="registerError" class="error" aria-live="assertive">
         <fa-icon [icon]="faExclamationTriangle"></fa-icon>
         {{ registerErrorDescription }}
+        <span [innerHtml]="registerErrorDescriptionHtml"></span>
       </p>
     </div>
 

--- a/src/app/donation-complete/donation-complete.component.scss
+++ b/src/app/donation-complete/donation-complete.component.scss
@@ -130,8 +130,14 @@ hr {
     max-width: 80%;
     margin: auto;
     fa-icon {
-    color: $colour-highlight;
-  }}
+      color: $colour-highlight;
+    }
+    a {
+      // this color style doesn't seem to have any affect - not sure why not. For now I've set the color
+      // as an inline style in the HTML sent from the Identity server. Not ideal.
+      color: inherit;
+    }
+  }
 }
 
 .thank-you-large-donation-text {


### PR DESCRIPTION
…o plain text on password setting failure

By default the link was going to be an invisible blue, so I had to change it. Coral is too low contrast, and I thought white looked better than green.

![image](https://user-images.githubusercontent.com/159481/222762188-57492139-bad8-4350-9e81-db52ccd7d4e7.png)
