### PR TITLE
Remove login after donate

### DIFF
--- a/src/app/donation-complete/donation-complete-set-password-dialog.component.ts
+++ b/src/app/donation-complete/donation-complete-set-password-dialog.component.ts
@@ -51,7 +51,7 @@ export class DonationCompleteSetPasswordDialogComponent implements OnInit {
   set() {
     this.dialogRef.close({
       password: this.form.value.password,
-      stayLoggedIn: this.form.value.stayLoggedIn,
+      stayLoggedIn: [false], // logging in at this point was not working. See PR 972.
     });
   }
 }

--- a/src/app/donation-complete/donation-complete-set-password-dialog.html
+++ b/src/app/donation-complete/donation-complete-set-password-dialog.html
@@ -11,12 +11,6 @@
         <mat-label for="password">Password (at least {{ minPasswordLength }} characters)</mat-label>
         <input matInput type="password" id="password" formControlName="password">
       </mat-form-field>
-
-      <p class="b-rt-0 radio-group-label" id="stayLoggedIn-label">If you're on a private computer, you can safely choose to be logged in.</p>
-      <mat-radio-group tabindex="0" aria-labelledby="stayLoggedIn-label" formControlName="stayLoggedIn">
-        <mat-radio-button class="b-mr-2" labelPosition="after" [value]="true">Log me in</mat-radio-button>
-        <mat-radio-button class="b-mr-2" labelPosition="after" [value]="false">Don't log me in</mat-radio-button>
-      </mat-radio-group>
     </form>
   </mat-dialog-content>
 


### PR DESCRIPTION
It looks like the "Log me in" function within the donation complete page has not been working since January. IMHO whenever something is not working at all we should immediately fix or remove it. I don't have a fix ready to apply so this removes it instead.

Before:

![Screenshot from 2023-03-09 15-05-41](https://user-images.githubusercontent.com/159481/224086201-1e4ac248-eff5-44cc-91ed-6b52d5ee377d.png)

After:

![image](https://user-images.githubusercontent.com/159481/224086325-01156372-3395-4ab1-9e85-a1c0d83fa977.png)
