### PR TITLE
Remove hold step in production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,19 +263,12 @@ workflows:
           repo: '${AWS_ECR_REPO_NAME}'
           region: '${AWS_REGION}'
           tag: 'production,production-${CIRCLE_SHA1}'
-      - hold:
-          name: hold # please check chunk filenames match between previous production-static and push-iamge jobs
-          type: approval
-          requires:
-            - deploy-production-static
-            - aws-ecr/build-and-push-image
       - aws-ecs/deploy-service-update:
           context:
             - ecs-deploys
             - jira
             - slack
           requires:
-            - hold # please check chunk filenames match between previous production-static and push-iamge jobs
             - aws-ecr/build-and-push-image
           aws-region: AWS_REGION
           family: 'tbg-production-${AWS_REGION}-${AWS_ECS_SERVICE_SUFFIX}'


### PR DESCRIPTION
Hold step was only introduced because I was nervous about issue DON-741, I don't think its needed now.