### PR TITLE
Make `mdc-form-field`s full width

### DIFF
--- a/src/assets/scss/_overwrite-mat.scss
+++ b/src/assets/scss/_overwrite-mat.scss
@@ -25,6 +25,9 @@ mat-spinner {
 
 .mdc-form-field {
   margin-top: 16px;
+  // Fields can remain inline-flex, but we want e.g. comms options to be full width
+  // and stack vertically, even if they'd fit side by side on desktop.
+  width: 100%;
 }
 
 .mat-mdc-form-field-icon-prefix {


### PR DESCRIPTION
Fix minor Angular Material form field regression