### PR TITLE
REG-33: Skip prompts to continue donation if in regression test envir…

### DIFF
--- a/src/app/donation-start/donation-start.component.ts
+++ b/src/app/donation-start/donation-start.component.ts
@@ -1352,16 +1352,25 @@ export class DonationStartComponent implements AfterContentChecked, AfterContent
       }
     }
 
-    // Amount reserved for matching is 'false-y', i.e. 0
-    if (response.donation.donationMatched && !response.donation.matchReservedAmount) {
-      this.promptToContinueWithNoMatchingLeft(response.donation);
-      return;
-    }
+    if (
+      environment.environmentId !== "regression" ||
+      (new URLSearchParams(window.location.search)).has('include-continue-prompt')
+    ) {
+      // Prompting to continue confuses the regression test automation, so we skip the prompt in the regression
+      // test environment at least for the time being. See JIRA REG-33 . When regression tests think they know how to
+      // deal with the prompts they can send the include-continue-prompt query string.
 
-    // Amount reserved for matching is > 0 but less than the full donation
-    if (response.donation.donationMatched && response.donation.matchReservedAmount < response.donation.donationAmount) {
-      this.promptToContinueWithPartialMatching(response.donation);
-      return;
+      // Amount reserved for matching is 'false-y', i.e. 0
+      if (response.donation.donationMatched && !response.donation.matchReservedAmount) {
+        this.promptToContinueWithNoMatchingLeft(response.donation);
+        return;
+      }
+
+      // Amount reserved for matching is > 0 but less than the full donation
+      if (response.donation.donationMatched && response.donation.matchReservedAmount < response.donation.donationAmount) {
+        this.promptToContinueWithPartialMatching(response.donation);
+        return;
+      }
     }
 
     this.scheduleMatchingExpiryWarning(this.donation);


### PR DESCRIPTION
…onment

It's not ideal to make the site behave more differently in regression environment than in prod than it has to, but it's better than leaving tests failing while other dev work continues.

It seems like it may be hard to make the regression test runner cope with this popup properly since it can appear at an unpredictable moment and interrupts other tasks. Removing it in regression environment for now should let us confirm for sure that it is what makes the tests fail, and restore our ability to detect regressions.