### PR TITLE
Remove empty style file, unused imports

### DIFF
--- a/src/app/update-card-modal/update-card-modal.component.scss
+++ b/src/app/update-card-modal/update-card-modal.component.scss
@@ -1,1 +1,0 @@
-// placeholder SCSS file

--- a/src/app/update-card-modal/update-card-modal.component.ts
+++ b/src/app/update-card-modal/update-card-modal.component.ts
@@ -1,4 +1,4 @@
-import {Component, HostListener, OnInit, ViewChild} from '@angular/core';
+import {Component, HostListener, OnInit} from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
@@ -6,17 +6,15 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { allChildComponentImports } from '../../allChildComponentImports';
-import {Card, PaymentMethod} from "@stripe/stripe-js";
+import {PaymentMethod} from "@stripe/stripe-js";
 import {COUNTRIES} from "../countries";
-import {MatOption, MatOptionModule} from "@angular/material/core";
+import {MatOptionModule} from "@angular/material/core";
 import {MatSelectModule} from "@angular/material/select";
-
 
 @Component({
   standalone: true,
   selector: 'app-update-card-modal',
   templateUrl: 'update-card-modal.html',
-  styleUrls: ['./update-card-modal.component.scss'],
   imports: [
     ...allChildComponentImports,
     FormsModule,


### PR DESCRIPTION
Given we have intermittent CI build issues for the “real” app currently, and the other highly rated answer on https://stackoverflow.com/questions/65537399/angular-11-stuck-on-generating-browser-application-bundles-phase-building/68163709#68163709 mentions empty CSS files, it seems worth a go to also retire the 1 we added recently.

c.f. https://github.com/thebiggive/donate-frontend/pull/1066