### PR TITLE
Fix "finish password reset" page being sort-of-standalone

### DIFF
--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -19,30 +19,26 @@
   <!-- Note: check explicitly for `undefined` here, not for `!saveSuccessful`, because
   `saveSuccessful` has can be undefined, false, or true, all with a unique meaning. -->
   <div *ngIf="saveSuccessful === undefined && !savingNewPassword && tokenValid">
-    <mat-dialog-content class="mat-typography">
-      <form [formGroup]="passwordForm">
-        <p class="b-rt-0">Please enter your new password (min {{ minPasswordLength }} characters)</p>
-        <mat-form-field color="primary">
-            <mat-label>Password</mat-label>
-            <input matInput type="password" formControlName="password">
-        </mat-form-field>
-        <mat-form-field color="primary">
-            <mat-label>Re-enter your password</mat-label>
-            <input matInput type="password" formControlName="confirmPassword" (focus)="onPasswordConfirmationFocus()">
-        </mat-form-field>
-        <div *ngIf="confirmPasswordField?.errors?.notSame" class="error">Passwords must be the same!</div>
-      </form>
-    </mat-dialog-content>
+    <form [formGroup]="passwordForm">
+      <p class="b-rt-0">Please enter your new password (min {{ minPasswordLength }} characters)</p>
+      <mat-form-field color="primary">
+          <mat-label>Password</mat-label>
+          <input matInput type="password" formControlName="password">
+      </mat-form-field>
+      <mat-form-field color="primary">
+          <mat-label>Re-enter your password</mat-label>
+          <input matInput type="password" formControlName="confirmPassword" (focus)="onPasswordConfirmationFocus()">
+      </mat-form-field>
+      <div *ngIf="confirmPasswordField?.errors?.notSame" class="error">Passwords must be the same!</div>
+    </form>
 
-    <mat-dialog-actions>
-        <button
-          id="reset-modal-submit"
-          mat-raised-button
-          [disabled]="!passwordForm.valid || savingNewPassword"
-          (click)="saveNewPassword()"
-          color="primary"
-        >Save new password</button>
-    </mat-dialog-actions>
+    <button
+      id="reset-modal-submit"
+      mat-raised-button
+      [disabled]="!passwordForm.valid || savingNewPassword"
+      (click)="saveNewPassword()"
+      color="primary"
+    >Save new password</button>
   </div>
 
   <!-- If processing, show spinner -->

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -1,29 +1,14 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { getPasswordValidator } from '../validators/validate-passwords-same';
-import { allChildComponentImports } from '../../allChildComponentImports';
 import { ActivatedRoute, Router } from '@angular/router';
 import { IdentityService } from '../identity.service';
 import { minPasswordLength } from 'src/environments/common';
 
 @Component({
-  standalone: true,
   selector: 'app-reset-password',
   templateUrl: './reset-password.component.html',
   styleUrls: ['./reset-password.component.scss'],
-  imports: [
-    ...allChildComponentImports,
-    FormsModule,
-    MatButtonModule,
-    MatDialogModule,
-    MatInputModule,
-    MatProgressSpinnerModule,
-    ReactiveFormsModule,
-  ],
 })
 export class ResetPasswordComponent implements OnInit {
   minPasswordLength: number;

--- a/src/app/reset-password/reset-password.module.ts
+++ b/src/app/reset-password/reset-password.module.ts
@@ -1,14 +1,22 @@
 import { NgModule } from '@angular/core';
-import { allChildComponentImports } from '../../allChildComponentImports';
-import { ResetPasswordRoutingModule } from './reset-password-routing.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { allChildComponentImports } from '../../allChildComponentImports';
+import { ResetPasswordComponent } from './reset-password.component';
+import { ResetPasswordRoutingModule } from './reset-password-routing.module';
 
 @NgModule({
   imports: [
     ...allChildComponentImports,
+    MatButtonModule,
+    MatInputModule,
     MatProgressSpinnerModule,
+    ReactiveFormsModule,
     ResetPasswordRoutingModule,
   ],
-  declarations: [],
+  declarations: [ResetPasswordComponent],
 })
 export class ResetPasswordModule {}


### PR DESCRIPTION
* Define modules consistently in one place
* Do routing the same as other pages
* Remove redundant `MatDialog` container stuff