### PR TITLE
DON-794: Load slider with handle in correct position

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-tipping-slider/donation-tipping-slider.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-tipping-slider/donation-tipping-slider.component.ts
@@ -229,7 +229,7 @@ export class DonationTippingSliderComponent implements OnInit, AfterContentInit,
     }
 
     this.position = this.width * positionAsFractionOfWidth;
-    this.handle.nativeElement.style.marginLeft = this.position + 'px';
+    this.handle.nativeElement.style.marginLeft = Math.round(positionAsFractionOfWidth * 100) + '%';
   }
 
   private detectWidth() {


### PR DESCRIPTION
Writing the margin as a percentage means it doesn't matter if this code runs before we know the width of the container

It now looks like this on page load:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/2e89c987-6b68-4588-b07d-5c2b28038adf)

The appearance after an amount has been input as on staging:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/a1475d66-621c-4e07-8164-7d1c16cfce47)
