### PR TITLE
DON-818: Copy popup modal modal from components library into this app…

### DIFF
--- a/src/app/donation-complete/donation-complete-set-password-dialog.component.ts
+++ b/src/app/donation-complete/donation-complete-set-password-dialog.component.ts
@@ -10,6 +10,7 @@ import { minPasswordLength } from 'src/environments/common';
 import { RecaptchaModule } from 'ng-recaptcha';
 import { allChildComponentImports } from '../../allChildComponentImports';
 import { Person } from '../person.model';
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -25,6 +26,7 @@ import { Person } from '../person.model';
     MatRadioModule,
     ReactiveFormsModule,
     RecaptchaModule,
+    PopupStandaloneComponent,
   ]
 })
 export class DonationCompleteSetPasswordDialogComponent implements OnInit {

--- a/src/app/donation-complete/donation-complete-set-password-dialog.html
+++ b/src/app/donation-complete/donation-complete-set-password-dialog.html
@@ -1,4 +1,4 @@
-<biggive-popup-standalone>
+<app-popup-standalone>
   <h2 mat-dialog-title>Set a password</h2>
 
   <mat-dialog-content class="mat-typography">
@@ -23,4 +23,4 @@
     <button mat-raised-button id="createAccountButton" [disabled]="!form.valid" (click)="set()" color="primary">Create Account</button>
     <button mat-raised-button [mat-dialog-close]="false" cdkFocusInitial color="accent">Cancel</button>
   </mat-dialog-actions>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/app/donation-start/donation-start-match-confirm-dialog.component.ts
+++ b/src/app/donation-start/donation-start-match-confirm-dialog.component.ts
@@ -3,6 +3,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { allChildComponentImports } from '../../allChildComponentImports';
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -12,6 +13,7 @@ import { allChildComponentImports } from '../../allChildComponentImports';
     ...allChildComponentImports,
     MatButtonModule,
     MatDialogModule,
+    PopupStandaloneComponent,
   ],
 })
 export class DonationStartMatchConfirmDialogComponent {

--- a/src/app/donation-start/donation-start-match-confirm-dialog.html
+++ b/src/app/donation-start/donation-start-match-confirm-dialog.html
@@ -1,4 +1,4 @@
-<biggive-popup-standalone>
+<app-popup-standalone>
   <h2 mat-dialog-title>{{ data.title }}</h2>
 
   <mat-dialog-content class="mat-typography">
@@ -16,4 +16,4 @@
     <button mat-raised-button [mat-dialog-close]="false" color="primary">{{ data.cancelCopy }}</button>
     <button id="proceed-with-donation" mat-raised-button [mat-dialog-close]="true" cdkFocusInitial color="accent">Continue donation</button>
   </mat-dialog-actions>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/app/donation-start/donation-start-matching-expired-dialog.component.ts
+++ b/src/app/donation-start/donation-start-matching-expired-dialog.component.ts
@@ -3,6 +3,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
 
 import { allChildComponentImports } from '../../allChildComponentImports';
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -12,6 +13,7 @@ import { allChildComponentImports } from '../../allChildComponentImports';
     ...allChildComponentImports,
     MatButtonModule,
     MatDialogModule,
+    PopupStandaloneComponent,
   ],
 })
 export class DonationStartMatchingExpiredDialogComponent {

--- a/src/app/donation-start/donation-start-matching-expired-dialog.html
+++ b/src/app/donation-start/donation-start-matching-expired-dialog.html
@@ -1,4 +1,4 @@
-<biggive-popup-standalone>
+<app-popup-standalone>
   <h2 mat-dialog-title>Match funding has expired</h2>
 
   <mat-dialog-content class="mat-typography">
@@ -15,4 +15,4 @@
     <button [mat-dialog-close]="false" mat-raised-button color="primary">Restart</button>
     <button id="proceed-with-donation" [mat-dialog-close]="true" mat-raised-button color="accent">Continue</button>
   </mat-dialog-actions>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/app/donation-start/donation-start-offer-reuse-dialog.component.ts
+++ b/src/app/donation-start/donation-start-offer-reuse-dialog.component.ts
@@ -5,6 +5,7 @@ import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { allChildComponentImports } from '../../allChildComponentImports';
 import { Donation } from '../donation.model';
 import { ExactCurrencyPipe } from '../exact-currency.pipe';
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -15,6 +16,7 @@ import { ExactCurrencyPipe } from '../exact-currency.pipe';
     ExactCurrencyPipe,
     MatButtonModule,
     MatDialogModule,
+    PopupStandaloneComponent,
   ],
 })
 export class DonationStartOfferReuseDialogComponent {

--- a/src/app/donation-start/donation-start-offer-reuse-dialog.html
+++ b/src/app/donation-start/donation-start-offer-reuse-dialog.html
@@ -1,4 +1,4 @@
-<biggive-popup-standalone>
+<app-popup-standalone>
   <h2 mat-dialog-title>Continue donation?</h2>
 
   <mat-dialog-content class="mat-typography">
@@ -16,4 +16,4 @@
     <button mat-raised-button [mat-dialog-close]="false" color="primary">Cancel</button>
     <button id="proceed-with-donation" mat-raised-button [mat-dialog-close]="true" cdkFocusInitial color="accent">Proceed</button>
   </mat-dialog-actions>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/app/login-modal/login-modal.component.ts
+++ b/src/app/login-modal/login-modal.component.ts
@@ -11,6 +11,7 @@ import { Credentials } from '../credentials.model';
 import { environment } from '../../environments/environment';
 import { IdentityService } from '../identity.service';
 import { EMAIL_REGEXP } from '../validators/patterns';
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -26,6 +27,7 @@ import { EMAIL_REGEXP } from '../validators/patterns';
     MatProgressSpinnerModule,
     ReactiveFormsModule,
     RecaptchaModule,
+    PopupStandaloneComponent,
   ],
 })
 export class LoginModalComponent implements OnInit {

--- a/src/app/login-modal/login-modal.html
+++ b/src/app/login-modal/login-modal.html
@@ -1,4 +1,4 @@
-<biggive-popup-standalone>
+<app-popup-standalone>
   <re-captcha
     #captcha
     size="invisible"
@@ -53,12 +53,12 @@
           <mat-label for="loginEmailAddress">Email address</mat-label>
           <input matInput type="email" id="loginEmailAddress" formControlName="emailAddress">
         </mat-form-field>
-  
+
         <mat-form-field class="b-w-100" color="primary">
           <mat-label for="loginPassword">Password</mat-label>
           <input matInput type="password" id="loginPassword" formControlName="password">
         </mat-form-field>
-  
+
         <p *ngIf="loginError" class="error" aria-live="assertive">
           Login error: {{ loginError }}
         </p>
@@ -79,4 +79,4 @@
       </div>
     </mat-dialog-actions>
   </ng-template>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/app/popup-standalone/popup-standalone.component.html
+++ b/src/app/popup-standalone/popup-standalone.component.html
@@ -1,0 +1,8 @@
+<div class="popup" data-visible="true">
+  <div class="sleeve">
+    <div class="header"></div>
+    <div class="content">
+      <ng-content></ng-content>
+    </div>
+  </div>
+</div>

--- a/src/app/popup-standalone/popup-standalone.component.scss
+++ b/src/app/popup-standalone/popup-standalone.component.scss
@@ -1,0 +1,49 @@
+@import '../../abstract';
+
+:host {
+  display: contents;
+}
+
+.popup {
+    position: fixed;
+    display: none;
+    z-index: 100;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 15px;
+    background-color: rgba(0,0,0,0.75);
+    transition: all 0.5s ease-in-out;
+    .sleeve {
+      position: relative;
+      max-width: 600px;
+      padding: 30px;
+      box-sizing: border-box;
+      margin-left: auto;
+      margin-right: auto;
+      top: 50%;
+      transform: translateY(-50%);
+      background-color: white;
+      text-align: left;
+    }
+    .header {
+      .close {
+        width: 25px;
+        height: 25px;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background-color: $colour-primary;
+        background-image: url(/assets/images/cross.svg?1);
+        background-size: 50% 50%;
+        background-position: center center;
+        background-repeat: no-repeat;
+        border-radius: 50%;
+        cursor: pointer;
+      }
+  }
+  &[data-visible=true] {
+    display: block;
+  }
+}

--- a/src/app/popup-standalone/popup-standalone.component.spec.ts
+++ b/src/app/popup-standalone/popup-standalone.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PopupStandaloneComponent } from './popup-standalone.component';
+
+describe('PopupStandaloneComponent', () => {
+  let component: PopupStandaloneComponent;
+  let fixture: ComponentFixture<PopupStandaloneComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ PopupStandaloneComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PopupStandaloneComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/popup-standalone/popup-standalone.component.ts
+++ b/src/app/popup-standalone/popup-standalone.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-popup-standalone',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './popup-standalone.component.html',
+  styleUrls: ['./popup-standalone.component.scss']
+})
+export class PopupStandaloneComponent {
+}

--- a/src/app/register-modal/register-modal.component.ts
+++ b/src/app/register-modal/register-modal.component.ts
@@ -10,6 +10,7 @@ import {environment} from '../../environments/environment';
 import {IdentityService} from '../identity.service';
 import {EMAIL_REGEXP} from '../validators/patterns';
 import {DomSanitizer, SafeHtml} from "@angular/platform-browser";
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -24,6 +25,7 @@ import {DomSanitizer, SafeHtml} from "@angular/platform-browser";
     MatInputModule,
     ReactiveFormsModule,
     RecaptchaModule,
+    PopupStandaloneComponent,
   ],
 })
 export class RegisterModalComponent implements OnInit {

--- a/src/app/register-modal/register-modal.html
+++ b/src/app/register-modal/register-modal.html
@@ -1,6 +1,6 @@
-<biggive-popup-standalone>
+<app-popup-standalone>
   <h2 mat-dialog-title>Register</h2>
-  
+
   <mat-dialog-content class="mat-typography">
     <form [formGroup]="form">
       <re-captcha
@@ -54,4 +54,4 @@
     >Register</button>
     <button mat-raised-button [mat-dialog-close]="false" cdkFocusInitial color="accent">Cancel</button>
   </mat-dialog-actions>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/app/update-card-modal/update-card-modal.component.ts
+++ b/src/app/update-card-modal/update-card-modal.component.ts
@@ -10,6 +10,7 @@ import {PaymentMethod} from "@stripe/stripe-js";
 import {COUNTRIES} from "../countries";
 import {MatOptionModule} from "@angular/material/core";
 import {MatSelectModule} from "@angular/material/select";
+import {PopupStandaloneComponent} from "../popup-standalone/popup-standalone.component";
 
 @Component({
   standalone: true,
@@ -25,6 +26,7 @@ import {MatSelectModule} from "@angular/material/select";
     MatSelectModule,
     MatProgressSpinnerModule,
     ReactiveFormsModule,
+    PopupStandaloneComponent,
   ],
 })
 export class UpdateCardModalComponent implements OnInit {

--- a/src/app/update-card-modal/update-card-modal.html
+++ b/src/app/update-card-modal/update-card-modal.html
@@ -1,4 +1,4 @@
-<biggive-popup-standalone *ngIf="card">
+<app-popup-standalone *ngIf="card">
 <!--
   *ngIf="card" above shouldn't be needed - we don't load the modal at all without a card, but it makes the `it('should create'`
   test pass. Would be good to remove.
@@ -71,4 +71,4 @@
         Cancel
       </button>
     </mat-dialog-actions>
-</biggive-popup-standalone>
+</app-popup-standalone>

--- a/src/assets/images/cross.svg
+++ b/src/assets/images/cross.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48.8 48.8" style="enable-background:new 0 0 48.8 48.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:2;stroke-linecap:round;}
+</style>
+<path class="st0" d="M24.4,24.4"/>
+<path class="st0" d="M1,1l46.8,46.8"/>
+<path class="st0" d="M47.8,1L1,47.8"/>
+</svg>


### PR DESCRIPTION
…, stop using components version

Component code copied from here
https://github.com/thebiggive/components/tree/818f58fdf1bd3eec7d98f8d7d66a3313e4635fad/src/components/biggive-popup-standalone where it can now be deleted, and just adapted slightly to work as an Angular component

The reason is that there is an issue where text entered into the module on Android phones (and perhaps other devices) appears backwards, because somehow the curser keeps being pulled to the start of the input box as I and others type.

I wasn't able to work out exactly what line of code in this component causes the issue, but in my experiments using my phone yesterday I found that moving the code into the login-modal.html file made the problem go away, so I'm hoping this will also make it go away. Having the code here will also make it much easier to experiemnt with changes in future.

I'm now in the office rather than at home, and with the different network set up I'm not able to test my local envirionment with my phone, so I think we should merge this to develop and test on staging.

Appearance of popup should be entirely unchanged. 
![image](https://github.com/thebiggive/donate-frontend/assets/159481/aee890b7-5b7f-4b2c-8c62-7d10097e5b33)
