### PR TITLE
DON-809: Make next button styling consistent on all steps of new stepper

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
@@ -174,6 +174,7 @@
         <div style="text-align: center">
           <button style="width: 40%;"
             type="button"
+            class="continue b-w-100 b-rt-1"
             mat-raised-button
             color="primary"
             [disabled]="! donationForm.controls['amounts']!.valid"
@@ -267,9 +268,10 @@
           </mat-checkbox>
         </div>
 
-        <div>
+        <div style="text-align: center">
           <button
             type="button"
+            class="continue b-w-100 b-rt-1"
             mat-raised-button
             color="primary"
             (click)="triedToLeaveGiftAid = true; next()"
@@ -391,9 +393,10 @@
           {{ stripeError }}
         </p>
 
-        <div>
+        <div style="text-align: center">
           <button
             type="button"
+            class="continue b-w-100 b-rt-1"
             mat-raised-button
             color="primary"
             [disabled]="!stripePaymentMethodReady"
@@ -479,9 +482,10 @@
           </mat-hint>
         </div>
 
-        <div>
+        <div style="text-align: center">
           <button
             type="button"
+            class="continue b-w-100 b-rt-1"
             mat-raised-button
             color="primary"
             (click)="triedToLeaveMarketing = true; next()"

--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
@@ -264,12 +264,16 @@ a {
   }
 }
 
+button.continue, .c-donate-button {
+  margin-top: 36px !important;
+  margin-bottom: 22px !important;
+  padding: 1.5rem;
+  max-width: 300px;
+}
+
 .c-donate-button {
   @include make-donate-button;
 
-  margin: 1.5rem 0 0.5rem 0;
-  padding: 1.5rem;
-  max-width: 300px;
 }
 
 .c-donate-button-amount {


### PR DESCRIPTION
All the next buttons and the confirm button are styled the same

![image](https://github.com/thebiggive/donate-frontend/assets/159481/fef6329e-c453-4a2c-af67-a4802834f3c2)
