### PR TITLE
DON-788: Allow switching between tip slider and drop-down

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
@@ -65,18 +65,21 @@
           </div>
 
         <div *ngIf="!campaign.feePercentage && creditPenceToUse === 0" style="text-align: center; margin-bottom: 50px;">
-              <!-- We may want to bring something like the below back to test a/b test against the slider, although using our
-                     custom select component instead of mat-select.
-              <mat-form-field appearance="outline">
-              <mat-label for="tipPercentage">Donation to the Big Give Trust</mat-label>
-              <mat-select formControlName="tipPercentage" id="tipPercentage" (selectionChange)="tipPercentageChange()">
-                <mat-option [value]="7.5">7.5%</mat-option>
-                <mat-option [value]="10">10%</mat-option>
-                <mat-option [value]="12.5">12.5%</mat-option>
-                <mat-option [value]="15">15%</mat-option>
-                <mat-option [value]="'Other'">Other</mat-option>
-              </mat-select>
-            </mat-form-field>-->
+
+
+          <!-- Question - what should the prompt text be. There is no equivilent on the slider version. Or should
+    add it somewhere to the slider? -->
+          <div class="donation-input donation-input-main">
+            <biggive-form-field-select *ngIf="tipControlStyle === 'dropdown'"
+                                       [prompt]="'Donation to the Big Give Trust'"
+                                       [options]="suggestedTipPercentages"
+                                       [selectedValue]="this.showCustomTipInput ? 'Other' : tipPercentage"
+                                       [backgroundColour]="'grey'"
+                                       [onSelectionChange]="updateTipAmountFromSelectedPercentage"
+                                       [spaceBelow]="3"
+            >
+            </biggive-form-field-select>
+          </div>
 
             <div [style]="showCustomTipInput ? '' : 'display: none;'" class="donation-input donation-input-main">
 
@@ -104,7 +107,8 @@
             of main donation
             </mat-hint>
           </div>
-          <app-donation-tipping-slider
+
+          <app-donation-tipping-slider *ngIf="tipControlStyle === 'slider'"
               [style]="showCustomTipInput ? 'display: none;' : ''"
               #donationTippingSlider
               [percentageStart]="minimumTipPercentage"
@@ -114,11 +118,15 @@
               [onHandleMoved]="onDonationSliderMove"
             />
 
-            <span class="button" (click)="displayCustomTipInput()" *ngIf="!showCustomTipInput && donationAmount">
+            <span
+              class="button"
+              (click)="displayCustomTipInput()"
+              *ngIf="(!showCustomTipInput && donationAmount) && tipControlStyle === 'slider'"
+            >
               Other amount
             </span>
             <!-- TODO: this check sets an infinite loop, need to check the logic -->
-            <span *ngIf="showCustomTipInput" class="button" (click)="displayPercentageTipInput()" >
+            <span *ngIf="showCustomTipInput && tipControlStyle === 'slider'" class="button" (click)="displayPercentageTipInput()" >
               Back to percentage tip
             </span>
 


### PR DESCRIPTION
To test this add `?tipControl=dropdown` on to the address bar when looking at the new stepper - this will replace the slider control with a drop down control. We still need to work out how to run an a/b test of the two, but probably worth getting the implementation with the dropdown selected this way QA'd first.

The edges of the input are a bit finicitky and can disappear depending on zoom in Firefox - but I think that's a generall issue with all these dropdowns, not specific to tipping.

Screenshots as on Jira:

![Screenshot from 2023-06-27 11-52-37](https://github.com/thebiggive/donate-frontend/assets/159481/fd01a885-fb05-4d33-8e2c-9e6d5e66f6d6)
![Screenshot from 2023-06-27 11-52-56](https://github.com/thebiggive/donate-frontend/assets/159481/82114eae-00f9-4bbc-80da-eb6f09a1b06b)

