### PR TITLE
New stepper: Remove £x.xx donation to support Big Give text above slider

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
@@ -64,13 +64,13 @@
             </mat-checkbox>
           </div>
 
-        <div *ngIf="!campaign.feePercentage && creditPenceToUse === 0" style="text-align: center; margin-bottom: 50px;">
+        <div *ngIf="!campaign.feePercentage && creditPenceToUse === 0" style="text-align: center;">
 
 
           <!-- Question - what should the prompt text be. There is no equivilent on the slider version. Or should
     add it somewhere to the slider? -->
-          <div class="donation-input donation-input-main">
-            <biggive-form-field-select *ngIf="tipControlStyle === 'dropdown'"
+          <div class="donation-input donation-input-main" *ngIf="tipControlStyle === 'dropdown'">
+            <biggive-form-field-select
                                        [prompt]="'Donation to the Big Give Trust'"
                                        [options]="suggestedTipPercentages"
                                        [selectedValue]="this.showCustomTipInput ? 'Other' : tipPercentage"
@@ -100,7 +100,8 @@
               {{ currencySymbol }}, optionally with 2 decimals and up to {{ maximumDonationAmount | exactCurrency:campaign.currencyCode }}.
             </div>
 
-          <mat-hint *ngIf="!customTip() && donationAmount && donationAmount > 0">{{ tipValue | exactCurrency:campaign.currencyCode }} donation to support Big Give</mat-hint>
+          <!-- The text below is not shown if we have the slider because it would just repeat content that's already displayed on the slider itself -->
+          <mat-hint *ngIf="!customTip() && donationAmount && donationAmount > 0 && tipControlStyle !== 'slider'">{{ tipValue | exactCurrency:campaign.currencyCode }} donation to support Big Give</mat-hint>
 
           <mat-hint *ngIf="customTip() && donationAmount && donationAmount > 0">
               {{ (tipAmount() > 0 && tipAmount() / donationAmount < 0.001) ? 'Less than 0.1%' : (tipAmount() / donationAmount) | percent:'1.0-1' }}


### PR DESCRIPTION
As discussed this text unecassarily repeats the conent of the slider tooltip. Also removed a 50px margin that we don't need.

Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/5b4086d3-6260-468c-9dcf-38fd1847f3be)


After:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/b9d071de-0247-4e17-b165-e3206eebab24)

Drop down version is largely unchanged:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/11263a1b-54f0-47c9-8847-e5157cbb33ff)

