### PR TITLE
Don't show donation header with new design

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.html
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.html
@@ -7,7 +7,7 @@
   </div>
   <div class="c-form-container">
     <div class="b-primary-column">
-      <div class="c-header">
+      <div class="c-header" *ngIf="! useNewDesign">
         <h2 class="c-header__to b-grey b-light">Donation to</h2>
         <h3 class="b-rh-2 b-bold">{{ campaign.charity.name }}</h3>
         <h2 class="c-header__to b-grey b-light">For</h2>


### PR DESCRIPTION
This duplicates information that we show within the new donation stepper
Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/605799d8-416f-4c45-8140-c79f96098450)


After:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/68dd172e-e991-4032-be94-07a497d81a4a)
