### PR TITLE
Refactor: Required-input all the things

### DIFF
--- a/src/app/campaign-card/campaign-card.component.ts
+++ b/src/app/campaign-card/campaign-card.component.ts
@@ -24,7 +24,7 @@ import { ImageService } from '../image.service';
   ],
 })
 export class CampaignCardComponent implements OnInit {
-  @Input() campaign: CampaignSummary;
+  @Input({ required: true }) campaign: CampaignSummary;
   @Input() inFundContext: boolean;
   bannerUri: string|null = null;
   isFinished: boolean;

--- a/src/app/campaign-info/campaign-info.component.ts
+++ b/src/app/campaign-info/campaign-info.component.ts
@@ -23,7 +23,7 @@ const endPipeToken = 'timeLeftToEndPipe';
 })
 export class CampaignInfoComponent implements OnInit {
   additionalImageUris: Array<string|null> = [];
-  @Input() campaign: Campaign;
+  @Input({ required: true }) campaign: Campaign;
   campaignOpen: boolean;
   campaignFinished: boolean;
   campaignRaised: string; // Formatted

--- a/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
@@ -84,7 +84,7 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
   requestButtonShown = false;
   showChampionOptIn = false;
 
-  @Input() campaign: Campaign;
+  @Input({ required: true }) campaign: Campaign;
   @Input() column: 'primary'|'secondary'
 
   /**
@@ -196,7 +196,7 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
   private idCaptchaCode?: string;
   private stripeResponseErrorCode?: string; // stores error codes returned by Stripe after callout
   private stepChangedBlockedByCaptcha = false;
-  @Input() donor: Person | undefined;
+  @Input({ required: true }) donor: Person | undefined;
 
   /**
    * Keys are ISO2 codes, values are names.
@@ -690,7 +690,7 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
       this.stripeError = `Missing donation information – please refresh and try again, or email hello@biggive.org quoting ${errorCodeDetail} if this problem persists`;
       this.stripeResponseErrorCode = undefined;
       this.matomoTracker.trackEvent(
-        'donate_error', 
+        'donate_error',
         'submit_missing_donation_basics',
         `Donation not set or form invalid ${errorCodeDetail}`,
       );
@@ -1381,7 +1381,7 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
     );
     if (createResponseMissingData) {
       this.matomoTracker.trackEvent(
-        'donate_error', 
+        'donate_error',
         'donation_create_response_incomplete',
         `Missing expected response data creating new donation for campaign ${this.campaignId}`,
       );

--- a/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
@@ -85,7 +85,6 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
   showChampionOptIn = false;
 
   @Input({ required: true }) campaign: Campaign;
-  @Input() column: 'primary'|'secondary'
 
   /**
    * Called when the donation object is set or deleted. **NOT** called when properties of the object are changed.

--- a/src/app/donation-start/donation-start-form/donation-tipping-slider/donation-tipping-slider.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-tipping-slider/donation-tipping-slider.component.ts
@@ -23,12 +23,12 @@ export class DonationTippingSliderComponent implements OnInit, AfterContentInit,
   /**
    * @todo start using this
    */
-  @Input() percentageStart: number;
-  @Input() percentageEnd: number;
-  @Input() donationAmount: number;
+  @Input({ required: true }) percentageStart: number;
+  @Input({ required: true }) percentageEnd: number;
+  @Input({ required: true }) donationAmount: number;
   //ISO-4217 currency code (e.g. GBP, USD)
-  @Input() donationCurrency!: 'GBP' | 'USD';
-  @Input() onHandleMoved: (tipPercentage: number, tipAmount: number) => void;
+  @Input({ required: true }) donationCurrency!: 'GBP' | 'USD';
+  @Input({ required: true }) onHandleMoved: (tipPercentage: number, tipAmount: number) => void;
 
   /**
    * movable part of the slider

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.ts
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.ts
@@ -10,14 +10,14 @@ import { LoginModalComponent } from '../../login-modal/login-modal.component';
   styleUrls: ['./donation-start-login.component.scss']
 })
 export class DonationStartLoginComponent {
-  @Input() loadAuthedPersonInfo: (dataId: string, dataJwt: string) => void;
-  @Input() logout: () => void;
-  @Input() campaign: Campaign;
-  @Input() creditPenceToUse: number;
-  @Input() email?: string;
-  @Input() personId: string | undefined;
-  @Input() personIsLoginReady: boolean;
-  @Input() canLogin: boolean;
+  @Input({ required: true }) loadAuthedPersonInfo: (dataId: string, dataJwt: string) => void;
+  @Input({ required: true }) logout: () => void;
+  @Input({ required: true }) campaign: Campaign;
+  @Input({ required: true }) creditPenceToUse: number;
+  @Input({ required: true }) email?: string;
+  @Input({ required: true }) personId: string | undefined;
+  @Input({ required: true }) personIsLoginReady: boolean;
+  @Input({ required: true }) canLogin: boolean;
 
   constructor(
     public dialog: MatDialog,

--- a/src/app/donation-start/donation-start-secondary/donation-start-secondary.component.ts
+++ b/src/app/donation-start/donation-start-secondary/donation-start-secondary.component.ts
@@ -23,7 +23,7 @@ const endPipeToken = 'timeLeftToEndPipe';
 })
 export class DonationStartSecondaryComponent implements OnInit {
 
-  @Input() campaign: Campaign;
+  @Input({ required: true }) campaign: Campaign;
 
   bannerUri: string | null;
   campaignRaised: string; // Formatted


### PR DESCRIPTION
Taking advantage of the new feature in Angular 16 to express when an input is always set. This gets checked at compile time in all templates that use the component

See https://netbasal.com/from-good-to-great-required-inputs-in-angular-47374c8a43cf

I dif a fairly niave search for all the @Input decotators and added required - then took it away anywhere it triggered a compile error. Seems reasonable to assume that if we currently allways pass an input to a componen then it's probably required.