### PR TITLE
DON-810: Inherit site font into input fields in new stepper

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
@@ -168,6 +168,10 @@ input:disabled {
   }
 }
 
+input {
+  font-family: inherit;
+}
+
 .c-your-donation {
   p {
     margin: 0;


### PR DESCRIPTION
See e.g. https://stackoverflow.com/a/2875030

I'm also wondering if there's a better place to put this code to mkae it not specific to the donation page.

And on the other hand whether there's a good enough reason for browsers to bring their own default styling to input fields that means we should leave it alone. But I know using css-reset files is a widespread practice. I couldn't really find any description of exactly why input elements have font family set by browsers.