### PR TITLE
DON-810: Adjust new stepper font sizes: Header and payment card inputs

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
@@ -25,7 +25,7 @@ div.mdc-form-field label {
   // which is different for the selected and non-selected step. Also overriding that by being more specific
   // in the selector above, including 'div', but don't want to rely just on that.
 
-  font-size: 18px !important; ;
+  font-size: 17px !important; ;
   line-height: 20px;
   @media #{$breakpoint-lg} {
     font-size: 20px !important;

--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
@@ -20,8 +20,17 @@ div.mdc-form-field label {
   font-size: inherit;
 }
 
-:host ::ng-deep .mat-step-label, .mat-step-label-selected {
-  @include b-rt-0;
+:host ::ng-deep div.mat-step-label, div.mat-step-label-selected, div.mat-step-label.mat-step-label-selected {
+  // important is a bit of a hack to make sure we override the font size set by material design,
+  // which is different for the selected and non-selected step. Also overriding that by being more specific
+  // in the selector above, including 'div', but don't want to rely just on that.
+
+  font-size: 18px !important; ;
+  line-height: 20px;
+  @media #{$breakpoint-lg} {
+    font-size: 20px !important;
+    line-height: 27px;
+  }
 }
 
 input {

--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.ts
@@ -16,5 +16,7 @@ import {DonationStartFormParentComponent} from "./donation-start-form-parent.com
   ]
 })
 export class DonationStartFormNewComponent extends DonationStartFormParentComponent {
-  // this class intentionally left empty - it only exists as a place to hang a @Component decorator. Everything else is in parent class.
+  // this class intentionally left mostly empty - it only exists as a place to hang a @Component decorator. Everything else is in parent class.
+
+  protected inputFontSize: '14px'|'18px' = '18px';
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.ts
@@ -18,5 +18,5 @@ import {DonationStartFormParentComponent} from "./donation-start-form-parent.com
 export class DonationStartFormNewComponent extends DonationStartFormParentComponent {
   // this class intentionally left mostly empty - it only exists as a place to hang a @Component decorator. Everything else is in parent class.
 
-  protected inputFontSize: '14px'|'18px' = '18px';
+  protected inputFontSize: '14px'|'17px' = '17px';
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
@@ -237,7 +237,7 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
    * just here because it varies between the old and new stepper designs. Once the old stepper is deleted
    * this can be hard coded in stripe service again.
    */
-  protected inputFontSize: '14px'|'18px' = '14px';
+  protected inputFontSize: '14px'|'17px' = '14px';
 
 
   constructor(

--- a/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form-parent.component.ts
@@ -233,6 +233,12 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
     this.showCustomTipInput = false;
   }
 
+  /**
+   * just here because it varies between the old and new stepper designs. Once the old stepper is deleted
+   * this can be hard coded in stripe service again.
+   */
+  protected inputFontSize: '14px'|'18px' = '14px';
+
 
   constructor(
     public cardIconsService: CardIconsService,
@@ -1011,7 +1017,7 @@ export class DonationStartFormParentComponent implements AfterContentChecked, Af
     // Card element is mounted the same way regardless of donation info. See
     // this.createDonationAndMaybePerson().subscribe(...) for Payment Request Button mount, which needs donation info
     // first and so happens in `preparePaymentRequestButton()`.
-    this.card = this.stripeService.getCard();
+    this.card = this.stripeService.getCard(this.inputFontSize);
     if (this.cardInfo && this.card) { // Ensure #cardInfo not hidden by PRB success.
       this.card.mount(this.cardInfo.nativeElement);
       this.card.on('change', this.cardHandler);

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -183,7 +183,7 @@ export class StripeService {
     });
   }
 
-  getCard(fontsize: '14px'|'18px'): StripeCardElement | null {
+  getCard(fontsize: '14px'|'17px'): StripeCardElement | null {
     if (!this.elements) {
       console.log('Stripe Elements not ready');
       return null;

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -183,7 +183,7 @@ export class StripeService {
     });
   }
 
-  getCard(): StripeCardElement | null {
+  getCard(fontsize: '14px'|'18px'): StripeCardElement | null {
     if (!this.elements) {
       console.log('Stripe Elements not ready');
       return null;
@@ -203,8 +203,9 @@ export class StripeService {
       iconStyle: 'solid',
       style: {
         base: {
+          // note the font family does not load correctly in my dev env, but it should be OK on staging / prod.
           fontFamily: 'Euclid Triangle, sans-serif',
-          fontSize: '14px',
+          fontSize: fontsize,
         },
       },
     });


### PR DESCRIPTION
Changes as discussed in last comment on Jira: https://thebiggive.atlassian.net/browse/DON-810?focusedCommentId=31188

Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/ff5fa01d-142a-4f69-9a48-af6a062dec9a)


After:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/cb38600c-b91b-45dc-91de-2356b6a10119)


Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/6412f9d0-7d9f-4f33-b001-31f301df7b33)


After:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/5a3620cf-4aa3-4a40-9f21-32881488356b)

Also note the font family inside the payment card input isn't as it should be above - but that seems to just be an issue with the local dev environment. It should be fine when we deploy this code to staging / prod.

Note the font size of the country drop down "United Kingdom" is still 17px rather than 18 - this will need changing in the component library. Easiest change is to just make it 18px there - that will also affect the filter drop downs in the explore page, which may be OK, or we could make it inherit a font size or allow passing one in. I guess it's not ideal that we're picking sizes looking at one page at a time rather than properly following a system across the whole site.