### PR TITLE
DON-706: Store donor dator on transfer funds tip

### DIFF
--- a/src/app/transfer-funds/transfer-funds.component.html
+++ b/src/app/transfer-funds/transfer-funds.component.html
@@ -1,13 +1,13 @@
 <main>
-    <div *ngIf="isLoggedIn" id="loggedInHeader">
-        <p>Logged in as {{ userFullName }}</p>
+    <div *ngIf="donor" id="loggedInHeader">
+        <p>Logged in as {{ donor.first_name }} {{donor.last_name}}</p>
       <button id="my-account-link" mat-raised-button routerLink="/my-account">My Account</button>
       <button mat-raised-button (click)="logout()">Log out</button>
     </div>
     <div class="b-container">
         <h3 class="b-rh-1 b-bold">Transfer Donation Funds</h3>
 
-        <form *ngIf="isLoggedIn && !isLoading && !isPurchaseComplete" [formGroup]="creditForm">
+        <form *ngIf="donor && !isLoading && !isPurchaseComplete" [formGroup]="creditForm">
             <mat-stepper orientation="vertical" [linear]="true" #stepper>
                 <mat-step
                     [completed]="false"
@@ -178,7 +178,7 @@
             <mat-spinner [diameter]="40" aria-label="Loading your details"></mat-spinner>
         </div>
 
-        <div *ngIf="!isLoggedIn && !isLoading">
+        <div *ngIf="!donor && !isLoading">
             <p>You must be logged in to transfer donation funds.</p>
 
             <div class="auth-options">
@@ -196,7 +196,7 @@
             </div>
         </div>
 
-        <div *ngIf="isLoggedIn && isPurchaseComplete">
+        <div *ngIf="donor && isPurchaseComplete">
             <h2>Transfer Instructions</h2>
             <p>Please make a bank transfer of {{ totalToTransfer | exactCurrency: currency }} to your Donation Funds account using the following details</p>
             <p><strong>Recipient</strong> {{ accountHolderName }}</p>

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -406,26 +406,15 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
       donation.pspCustomerId = this.identityService.getPspId();
     }
 
-    this.createDonation(donation);
-  }
-
-  /**
-   * Creates a Donation itself. Both success and error callbacks should unconditionally set `creatingDonation` false.
-   */
-  private createDonation(donation: Donation) {
-    if (this.donor === undefined) {
-      throw new Error("Cannot create donation without logged in donor");
-    }
-
     // No re-tries for create() where donors have only entered amounts. If the
     // server is having problem it's probably more helpful to fail immediately than
     // to wait until they're ~10 seconds into further data entry before jumping
     // back to the start.
     this.donationService.create(donation, this.donor.id, this.identityService.getJWT())
-    .subscribe({
-      next: this.newDonationSuccess.bind(this),
-      error: this.newDonationError.bind(this),
-    });
+      .subscribe({
+        next: this.newDonationSuccess.bind(this),
+        error: this.newDonationError.bind(this),
+      });
   }
 
   private newDonationSuccess(response: DonationCreatedResponse) {

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -32,14 +32,12 @@ import { getCurrencyMaxValidator } from '../validators/currency-max';
 })
 export class TransferFundsComponent implements AfterContentInit, OnInit {
   addressSuggestions: GiftAidAddressSuggestion[] = [];
-  isLoggedIn: boolean = false;
   isLoading: boolean = false;
   isPurchaseComplete = false;
   isOptedIntoGiftAid = false;
   currency = '£';
   campaign: Campaign;
   donation?: Donation;
-  userFullName: string;
   creditForm: FormGroup;
   amountsGroup: FormGroup;
   giftAidGroup: FormGroup;
@@ -48,12 +46,12 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
   maximumCreditAmount = environment.maximumCreditAmount;
   maximumDonationAmount = maximumDonationAmountForFundedDonation;
   showAddressLookup: boolean = true;
-  personId?: string;
   sortCode?: string;
   accountNumber?: string;
   accountHolderName?: string;
   private initialTipSuggestedPercentage = 15;
   private postcodeRegExp = new RegExp('^([A-Z][A-HJ-Y]?\\d[A-Z\\d]? \\d[A-Z]{2}|GIR 0A{2})$');
+  donor: Person | undefined = undefined;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -313,9 +311,8 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
   }
 
   logout() {
-    this.personId = undefined;
+    this.donor = undefined;
     this.isLoading = false;
-    this.isLoggedIn = false;
 
     this.accountHolderName = undefined;
     this.accountNumber = undefined;
@@ -329,11 +326,8 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
   private loadAuthedPersonInfo(id: string, jwt: string) {
     this.isLoading = true;
     this.identityService.get(id, jwt).subscribe((person: Person) => {
-      this.isLoggedIn = true;
       this.isLoading = false;
-      this.userFullName = person.first_name + ' ' + person.last_name;
-
-      this.personId = person.id; // Should mean donations are attached to the Stripe Customer.
+      this.donor = person;
 
       // Pre-fill rarely-changing form values from the Person.
       this.giftAidGroup.patchValue({
@@ -367,7 +361,14 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
       return;
     }
 
+    if (this.donor === undefined) {
+      throw new Error("Cannot create donation without logged in donor");
+    }
+
     const donation: Donation = {
+      emailAddress: this.donor.email_address,
+      firstName: this.donor.first_name,
+      lastName: this.donor.last_name,
       charityId: this.campaign.charity.id,
       charityName: this.campaign.charity.name,
       countryCode: 'GB', // hard coded to GB only for now
@@ -401,7 +402,7 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
       donation.homeBuildingNumber = undefined;
     }
 
-    if (this.personId) {
+    if (this.donor.id) {
       donation.pspCustomerId = this.identityService.getPspId();
     }
 
@@ -412,11 +413,15 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
    * Creates a Donation itself. Both success and error callbacks should unconditionally set `creatingDonation` false.
    */
   private createDonation(donation: Donation) {
+    if (this.donor === undefined) {
+      throw new Error("Cannot create donation without logged in donor");
+    }
+
     // No re-tries for create() where donors have only entered amounts. If the
     // server is having problem it's probably more helpful to fail immediately than
     // to wait until they're ~10 seconds into further data entry before jumping
     // back to the start.
-    this.donationService.create(donation, this.personId, this.identityService.getJWT())
+    this.donationService.create(donation, this.donor.id, this.identityService.getJWT())
     .subscribe({
       next: this.newDonationSuccess.bind(this),
       error: this.newDonationError.bind(this),


### PR DESCRIPTION
This relies on matchbot changes at https://github.com/thebiggive/matchbot/pull/577 to be useful, but the PRs can safely be deployed in either order - matchbot will just ignore the additional fields at the moment.

There are no changes here visible to the donor, but after donating (given the matchbot changes is also present) the entry in the matchbot DB looks like this:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/25bc022d-2262-493c-a589-7c3088822de8)
