### PR TITLE
DON-816 – fix odd layout on new inputs

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
@@ -278,11 +278,11 @@ input {
 }
 
 input {
-  float: right;
   outline: none;
   border: none;
   background-color: $colour-background;
   width: 100%;
+  padding: 0; // We rely on containing element margin, and don't want vendor-dependent extra padding.
 };
 
 #giftAidAddressContainer {


### PR DESCRIPTION
Remove `float: right` which makes right padding
significant, and variable across browsers. And reset `padding` to 0 to further improve consistency
across browsers.