### PR TITLE
DON-838: Increase match fund banner z index

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.scss
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.scss
@@ -14,7 +14,7 @@
 }
 
 .c-timer_new_design {
-  z-index: 2;
+  z-index: 10; // must be high enough to occulude eyebrowe prompt texts on inputs in the Payment Details section.
   position: fixed;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Not sure if there's a better way based on putting the banner in a separate stacking context to the eyebrows instead of increasing Z

Before:
![image](https://github.com/thebiggive/donate-frontend/assets/159481/301cce35-ce64-45e8-bd52-29aedd1b7c0b)

After:
![image](https://github.com/thebiggive/donate-frontend/assets/159481/92e72f1a-08a5-4abe-91ef-d7621725d25e)
