### PR TITLE
Use `autocapitalize` where appropriate

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.html
@@ -140,7 +140,7 @@
                                (closed)="panelOpenState = false">
             <mat-expansion-panel-header>
               <h3 class="b-rt-0 b-m-0 b-bold"><span class="span-hr"></span>How does Big Give use tips?</h3>
-              
+
             </mat-expansion-panel-header>
             <p>
               Big Give is a registered charity (1136547). We don’t charge charities for using our platform; we rely on the generosity of people who donate to leave a Voluntary Tip, which helps us run our match funding campaigns.
@@ -266,6 +266,7 @@
             <input
               formControlName="homePostcode"
               id="homePostcode"
+              autocapitalize="characters"
               matInput
               slot="input"
             />
@@ -317,8 +318,8 @@
           </div>
 
           <div>
-            <biggive-text-input  prompt="Email Address *">
-              <input slot="input" formControlName="emailAddress" id="emailAddress" type="email" matInput>
+            <biggive-text-input prompt="Email Address *">
+              <input slot="input" formControlName="emailAddress" id="emailAddress" type="email" autocapitalize="off" matInput>
             </biggive-text-input>
             <mat-hint>We'll send you a donation receipt and use this to
               confirm it's you in case you have any queries.</mat-hint>
@@ -393,7 +394,7 @@
           </div>
 
           <biggive-text-input prompt="Billing postcode">
-            <input slot="input" formControlName="billingPostcode" id="billingPostcode" matInput (change)="onBillingPostCodeChanged($event)">
+            <input slot="input" formControlName="billingPostcode" id="billingPostcode" matInput (change)="onBillingPostCodeChanged($event)" autocapitalize="characters">
           </biggive-text-input>
 
         </div>

--- a/src/app/login-modal/login-modal.html
+++ b/src/app/login-modal/login-modal.html
@@ -17,7 +17,7 @@
         <form [formGroup]="resetPasswordForm">
           <mat-form-field class="b-w-100" color="primary">
             <mat-label for="loginEmailAddress">Email address</mat-label>
-            <input matInput type="email" id="loginEmailAddress" formControlName="emailAddress">
+            <input matInput type="email" id="loginEmailAddress" formControlName="emailAddress" autocapitalize="off">
           </mat-form-field>
           <p class="b-rt-0">Please enter your email address.</p>
         </form>
@@ -51,7 +51,7 @@
       <form [formGroup]="loginForm">
         <mat-form-field class="b-w-100" color="primary">
           <mat-label for="loginEmailAddress">Email address</mat-label>
-          <input matInput type="email" id="loginEmailAddress" formControlName="emailAddress">
+          <input matInput type="email" id="loginEmailAddress" formControlName="emailAddress" autocapitalize="off">
         </mat-form-field>
 
         <mat-form-field class="b-w-100" color="primary">

--- a/src/app/register-modal/register-modal.html
+++ b/src/app/register-modal/register-modal.html
@@ -24,7 +24,7 @@
 
       <mat-form-field class="b-w-100" color="primary">
         <mat-label for="registerEmailAddress">Email address</mat-label>
-        <input matInput type="email" id="registerEmailAddress" formControlName="emailAddress">
+        <input matInput type="email" id="registerEmailAddress" formControlName="emailAddress" autocapitalize="off">
       </mat-form-field>
 
       <mat-form-field class="b-w-100" color="primary">


### PR DESCRIPTION
Save mobile donors a little effort on typing by hinting where simplified keyboards can be used.

(& improve the chance of us saving better quality postcodes prior to formatting)

Just focusing on the new donation form as we expect it to be live soon.

Identity email is compared as `_ci` so case variation shouldn't block existing donors from logging in.