### PR TITLE
New stepper: fix postcss plugin build warning; ensure consistent layouts

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form-new.component.scss
@@ -91,7 +91,7 @@ div .c-banner {
 
 div.donationInfoWrapper {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   margin-top: 10px;
   margin-bottom: 40px;
   flex-direction: column;


### PR DESCRIPTION
> "Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js) (1550:3) from "autoprefixer" plugin: start value has mixed support, consider using flex-start instead"