### PR TITLE
DON-838: New stepper / Reduce match funding banner to fit on mobile

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.scss
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.scss
@@ -21,22 +21,30 @@
   background: $colour-black;
   color: white;
   text-align: center;
-  font-size: 20px;
+  @media #{$breakpoint-lg} {
+    font-size: 20px;
+  }
+  font-size: 15px;
 
   .centered {
-    display: inline-block;
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: center;
     padding: 0;
     margin: auto;
     line-height: 3em;
+    white-space: nowrap;
   }
 
   span {
-    display: block;
-    float: left;
+    display: inline-block;
   }
 
  span.time-left {
-   font-size: 24px;
+   @media #{$breakpoint-lg} {
+     font-size: 24px;
+   }
+   font-size: 18px;
    margin-left: 1em;
    background-color: $colour-primary;
    color: white;


### PR DESCRIPTION
Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/3e3c5d23-37a7-40aa-aacb-ecc0aafa0760)


After:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/4431b4c9-b43a-4190-81ad-062d3f8c7f16)

I would ideally like to get rid of the tiny bit of black visible on the right edge as well, but that seems fiddly and not sure how much time it's worth right now.
