### PR TITLE
DON-787: Enable use of new stepper for testing in production

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -1,5 +1,4 @@
 import { Routes } from '@angular/router';
-import { environment } from 'src/environments/environment';
 
 import { CampaignListResolver } from './campaign-list.resolver';
 import { CampaignResolver } from './campaign.resolver';
@@ -43,6 +42,15 @@ const routes: Routes = [
   },
   {
     path: 'donate/:campaignId',
+    pathMatch: 'full',
+    resolve: {
+      campaign: CampaignResolver,
+    },
+    loadChildren: () => import('./donation-start/donation-start-container/donation-start-container.module')
+      .then(c => c.DonationStartContainerModule),
+  },
+  {
+    path: 'donate-new-stepper/:campaignId',
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -117,19 +125,5 @@ const routes: Routes = [
       .then(c => c.MetaCampaignModule),
   },
 ];
-
-if (environment.environmentId !== 'production') {
-   routes.unshift(
-    {
-      path: 'donate-new-stepper/:campaignId',
-      pathMatch: 'full',
-      resolve: {
-        campaign: CampaignResolver,
-      },
-      loadChildren: () => import('./donation-start/donation-start-container/donation-start-container.module')
-        .then(c => c.DonationStartContainerModule),
-    },
-   );
-}
 
 export {routes};


### PR DESCRIPTION
We are not quite ready to direct traffic to the new stepper, but we are ready to start testing it in production ourselves.

When this is deployed URLs such as https://donate.biggive.org/donate-new-stepper/a056900002PoxFoAAJ should work in production to show the new stepper instead of redirecting to the homepage as it does now.

![image](https://github.com/thebiggive/donate-frontend/assets/159481/e0f0eb53-2c79-4e62-839a-bba5c712420d)
