### PR TITLE
DON-783: Save donations & campaigns in session storage not local storage, save ID & JWT in cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "material-icons-font": "^2.1.0",
         "morgan": "^1.10.0",
         "ng-recaptcha": "^12.0.0",
+        "ngx-cookie-service": "^16.0.0",
         "ngx-infinite-scroll": "^16.0.0",
         "ngx-matomo": "^2.0.0",
         "ngx-webstorage-service": "^5.0.0",
@@ -13651,6 +13652,18 @@
         "tslib": "^2.2.0"
       },
       "peerDependencies": {
+        "@angular/core": "^16.0.0"
+      }
+    },
+    "node_modules/ngx-cookie-service": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-16.0.0.tgz",
+      "integrity": "sha512-bD0F8/I6Y7lfP1THeQDR70hv1SSEfFOjJqF1tnLphNBvR9EwkITO2KSOtfag7VH5CHT16PRIqv8XaGRDbCNAmA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0",
         "@angular/core": "^16.0.0"
       }
     },
@@ -29314,6 +29327,14 @@
       "requires": {
         "@types/grecaptcha": "^3.0.3",
         "tslib": "^2.2.0"
+      }
+    },
+    "ngx-cookie-service": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-16.0.0.tgz",
+      "integrity": "sha512-bD0F8/I6Y7lfP1THeQDR70hv1SSEfFOjJqF1tnLphNBvR9EwkITO2KSOtfag7VH5CHT16PRIqv8XaGRDbCNAmA==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "ngx-infinite-scroll": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "material-icons-font": "^2.1.0",
     "morgan": "^1.10.0",
     "ng-recaptcha": "^12.0.0",
+    "ngx-cookie-service": "^16.0.0",
     "ngx-infinite-scroll": "^16.0.0",
     "ngx-matomo": "^2.0.0",
     "ngx-webstorage-service": "^5.0.0",

--- a/src/app/donation-complete/donation-complete.component.html
+++ b/src/app/donation-complete/donation-complete.component.html
@@ -7,8 +7,7 @@
   <div *ngIf="isDataLoaded">
     <p *ngIf="noAccess" class="error">
       We can only show your receipt in the tab where you donated, in order to keep your information secure. Don't worry
-      though, we'll email you a receipt within a few minutes confirming if your donation was processed. If you donated
-      more than 30 days ago, please check your email for your receipt.
+      though, we'll email you a receipt within a few minutes confirming if your donation was processed.
     </p>
 
     <p *ngIf="timedOut" class="error" aria-live="assertive">

--- a/src/app/donation-complete/donation-complete.component.html
+++ b/src/app/donation-complete/donation-complete.component.html
@@ -6,7 +6,7 @@
 
   <div *ngIf="isDataLoaded">
     <p *ngIf="noAccess" class="error">
-      We can only show your receipt on the device where you donated, in order to keep your information secure. Don't worry
+      We can only show your receipt in the tab where you donated, in order to keep your information secure. Don't worry
       though, we'll email you a receipt within a few minutes confirming if your donation was processed. If you donated
       more than 30 days ago, please check your email for your receipt.
     </p>

--- a/src/app/donation.service.spec.ts
+++ b/src/app/donation.service.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { inject, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatomoModule } from 'ngx-matomo';
-import { InMemoryStorageService } from 'ngx-webstorage-service';
+import {InMemoryStorageService, SESSION_STORAGE} from 'ngx-webstorage-service';
 
 import { Donation } from './donation.model';
 import { DonationCreatedResponse } from './donation-created-response.model';
@@ -56,6 +56,7 @@ describe('DonationService', () => {
     providers: [
       // Inject in-memory storage for tests, in place of local storage.
       { provide: TBG_DONATE_STORAGE, useExisting: InMemoryStorageService },
+      { provide: SESSION_STORAGE, useExisting: InMemoryStorageService },
       DonationService,
       InMemoryStorageService,
     ],

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -237,7 +237,7 @@ export class DonationService {
   }
 
   /**
-   * This funtion can be deleted 1 day after this version is deployed - when we store only in session storage there is no need
+   * @todo This funtion can be deleted 1 day after this version is deployed - when we store only in session storage there is no need
    * to remove anything.
    */
   removeOldLocalDonations() {

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -236,6 +236,10 @@ export class DonationService {
     this.sessionStorage.set(this.storageKey, donationCouplets);
   }
 
+  /**
+   * This funtion can be deleted 1 day after this version is deployed - when we store only in session storage there is no need
+   * to remove anything.
+   */
   removeOldLocalDonations() {
     const donationsOlderThan8Hours: Array<{ donation: Donation, jwt: string }> = this.getDonationCouplets().filter(donationItem => {
       return (!donationItem.donation.createdTime || this.getCreatedTime(donationItem.donation) < (Date.now() - (8 * 60 * 60 * 1_000)));

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -232,14 +232,15 @@ export class DonationService {
       1,
     );
 
+    this.storage.set(this.storageKey, donationCouplets);
     this.sessionStorage.set(this.storageKey, donationCouplets);
   }
 
   removeOldLocalDonations() {
-    const donationsOlderThan30Days: Array<{ donation: Donation, jwt: string }> = this.getDonationCouplets().filter(donationItem => {
-      return (!donationItem.donation.createdTime || this.getCreatedTime(donationItem.donation) < (Date.now() - 2592000000));
+    const donationsOlderThan8Hours: Array<{ donation: Donation, jwt: string }> = this.getDonationCouplets().filter(donationItem => {
+      return (!donationItem.donation.createdTime || this.getCreatedTime(donationItem.donation) < (Date.now() - (8 * 60 * 60 * 1_000)));
     });
-    for (const oldDonationCouplet of donationsOlderThan30Days) {
+    for (const oldDonationCouplet of donationsOlderThan8Hours) {
       this.removeLocalDonation(oldDonationCouplet.donation);
     }
   }

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -236,10 +236,6 @@ export class DonationService {
     this.sessionStorage.set(this.storageKey, donationCouplets);
   }
 
-  /**
-   * @todo This funtion can be deleted 1 day after this version is deployed - when we store only in session storage there is no need
-   * to remove anything.
-   */
   removeOldLocalDonations() {
     const donationsOlderThan8Hours: Array<{ donation: Donation, jwt: string }> = this.getDonationCouplets().filter(donationItem => {
       return (!donationItem.donation.createdTime || this.getCreatedTime(donationItem.donation) < (Date.now() - (8 * 60 * 60 * 1_000)));

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -96,7 +96,7 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
     private route: ActivatedRoute,
     public searchService: SearchService,
     private state: TransferState,
-    @Inject(SESSION_STORAGE) private storage: StorageService,
+    @Inject(SESSION_STORAGE) private sessionStorage: StorageService,
     private scroller: ViewportScroller,
     @Inject(openPipeToken) private timeLeftToOpenPipe: TimeLeftPipe,
     @Inject(endPipeToken) private timeLeftToEndPipe: TimeLeftPipe,
@@ -257,7 +257,7 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
         time: Date.now(), // ms
       };
 
-      this.storage.set(this.recentChildrenKey, recentChildrenData);
+      this.sessionStorage.set(this.recentChildrenKey, recentChildrenData);
     }, () => {
       this.filterError = true; // Error, should only be thrown if the callout SF API returns an error
       this.loading = false;
@@ -273,7 +273,7 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
     this.offset = 0;
     const query = this.campaignService.buildQuery(this.searchService.selected, 0, this.campaignId, this.campaignSlug, this.fundSlug);
 
-    const recentChildrenData = this.storage.get(this.recentChildrenKey);
+    const recentChildrenData = this.sessionStorage.get(this.recentChildrenKey);
     // Only an exact query match should reinstate the same child campaigns on load.
     if (
       recentChildrenData &&

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -13,7 +13,7 @@ import {
   TransferState,
 } from '@angular/core';
 import { ActivatedRoute, Router, NavigationEnd, NavigationStart } from '@angular/router';
-import { StorageService } from 'ngx-webstorage-service';
+import {SESSION_STORAGE, StorageService} from 'ngx-webstorage-service';
 import { Subscription } from 'rxjs';
 
 import { Campaign } from '../campaign.model';
@@ -97,7 +97,7 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
     private route: ActivatedRoute,
     public searchService: SearchService,
     private state: TransferState,
-    @Inject(TBG_DONATE_STORAGE) private storage: StorageService,
+    @Inject(SESSION_STORAGE) private storage: StorageService,
     private scroller: ViewportScroller,
     @Inject(openPipeToken) private timeLeftToOpenPipe: TimeLeftPipe,
     @Inject(endPipeToken) private timeLeftToEndPipe: TimeLeftPipe,

--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -20,7 +20,6 @@ import { Campaign } from '../campaign.model';
 import { CampaignSummary } from '../campaign-summary.model';
 import { CampaignService, SearchQuery } from '../campaign.service';
 import { DatePipe } from '@angular/common'
-import { TBG_DONATE_STORAGE } from '../donation.service';
 import { environment } from '../../environments/environment';
 import { Fund } from '../fund.model';
 import { FundService } from '../fund.service';


### PR DESCRIPTION
This means the thank you page will now only be viewable in the same tab where the donation was made, and not at all after the tab is closed. While it might be nice to have the thank you page available for longer I think this is OK and avoids storing more info in the browser than we need. Donors should be able to see all the details of their old donations in their emails.

Session storage is scoped to the browser tab and automatically expires when the tab is closed, whereas local storage never expires.

Ideally I would like something that persists for the session only (or for a short time like 1 day) but is available across all tabs. That seems more work to set up, would perhaps require using a cookie and relying on the server side db for the content instead.