### PR TITLE
DON-783: Only track users with Matomo if they consent to marketing co…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,7 @@ import {environment} from "../environments/environment";
 import {flags} from "./featureFlags";
 import {CookiePreferenceService} from "./cookiePreference.service";
 import {Subscription} from "rxjs";
+import {MatomoTracker} from "ngx-matomo";
 
 @Component({
   selector: 'app-root',
@@ -44,6 +45,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     private navigationService: NavigationService,
     private cookiePreferenceService: CookiePreferenceService,
     @Inject(PLATFORM_ID) private platformId: Object,
+    private matomoTracker: MatomoTracker,
     private router: Router,
   ) {
     // https://www.amadousall.com/angular-routing-how-to-display-a-loading-indicator-when-navigating-between-routes/
@@ -78,9 +80,12 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
         this.marketingCookieOptInSubscription = this.cookiePreferenceService.userOptInToMarketingCookies().subscribe(() => {
           this.getSiteControlService.init();
           this.marketingCookieOptInSubscription?.unsubscribe();
+          this.matomoTracker.setCookieConsentGiven();
         });
       } else {
         this.getSiteControlService.init();
+        // no-need to simulate user consent for matomo here, if the banner isn't enabled we don't have
+        //  `requireConsent: true` in the matomo config.
       }
 
       // Temporarily client-side redirect the previous non-global domain to the new one.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -85,7 +85,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
       } else {
         this.getSiteControlService.init();
         // no-need to simulate user consent for matomo here, if the banner isn't enabled we don't have
-        //  `requireConsent: true` in the matomo config.
+        //  `requireCookieConsent: true` in the matomo config.
       }
 
       // Temporarily client-side redirect the previous non-global domain to the new one.

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { CharityCampaignsResolver } from './charity-campaigns.resolver';
 import { TBG_DONATE_STORAGE } from './donation.service';
 import { environment } from '../environments/environment';
 import { TBG_DONATE_ID_STORAGE } from './identity.service';
+import {flags} from "./featureFlags";
 
 const matomoBaseUri = 'https://biggive.matomo.cloud';
 const matomoTrackers = environment.matomoSiteId ? [
@@ -46,7 +47,8 @@ const matomoTrackers = environment.matomoSiteId ? [
       trackers: matomoTrackers,
       routeTracking: {
         enable: true,
-      }
+      },
+        requireConsent: flags.cookieBannerEnabled,
     }),
     RouterModule.forRoot(routes, {
       bindToComponentInputs: true,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,7 +48,7 @@ const matomoTrackers = environment.matomoSiteId ? [
       routeTracking: {
         enable: true,
       },
-        requireConsent: flags.cookieBannerEnabled,
+        requireCookieConsent: flags.cookieBannerEnabled,
     }),
     RouterModule.forRoot(routes, {
       bindToComponentInputs: true,


### PR DESCRIPTION
…okies.

We could tell Matomo to remember the consent, using the `rememberConsentGiven` but since we're remembering it already with our own `cookie-preferences` I think it's simpler to rely on that, and just re-send the consent to Matomo every time the app loads.