### PR TITLE
DON-871 – don't specify remote Docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,6 @@ jobs:
     steps:
       - aws-ecr/build-and-push-image:
           setup-remote-docker: true
-          remote-docker-version: '24.0.5'
           remote-docker-layer-caching: true
           extra-build-args: '--build-arg BUILD_ENV=<< parameters.env >> --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}'
           repo: '${AWS_ECR_REPO_NAME}'


### PR DESCRIPTION
The point release I tried before is not supported on our current resource class