### PR TITLE
DON-871 – remove remote Docker cache config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,21 +178,13 @@ jobs:
             --cache-control "max-age=86400"
 
   build-ecr:
+    machine:
+      enabled: true
     parameters:
       env:
         type: string
-    docker:
-      # As above, match the app's Dockerfile base version. Here we also want to make sure
-      # we're using CircleCI's convenience image so that e.g. `docker` is available.
-      - image: cimg/node:16.18
-        auth:
-          username: $DOCKER_HUB_USERNAME
-          password: $DOCKER_HUB_ACCESS_TOKEN
-
     steps:
       - aws-ecr/build-and-push-image:
-          setup-remote-docker: true
-          remote-docker-layer-caching: true
           # cache-from format is e.g. 123.dkr.ecr.eu-west-1.amazonaws.com/thebiggive-donate:staging
           extra-build-args: '--build-arg BUILD_ENV=<< parameters.env >> --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN} --cache-from "${AWS_ECR_ACCOUNT_URL}/${AWS_ECR_REPO_NAME}:<< parameters.env >>"'
           repo: '${AWS_ECR_REPO_NAME}'


### PR DESCRIPTION
Try to use the ECR orb's default machine-based approach, but with ECR as the explicit layer cache source