### PR TITLE
DON-870: Stop displaying seconds in reciept on thank you page

### DIFF
--- a/src/app/donation-complete/donation-complete.component.html
+++ b/src/app/donation-complete/donation-complete.component.html
@@ -107,7 +107,8 @@
         <div class="large-donation-spacer" *ngIf="donationIsLarge"></div>
         <div class="receipt">
           <p><strong>Your Receipt</strong></p>
-          <p>{{donation.createdTime | date: 'medium'}}</p>
+          <!-- Date time appears as e.g. "Sep 5, 2023, 2:54 PM" -->
+          <p>{{donation.createdTime | date: 'mediumDate'}}, {{donation.createdTime | date: 'shortTime'}}</p>
           <br>
 
           <table>


### PR DESCRIPTION
No-one's likely to care what second they made their donation, and it's one less thing to listen to for screen reader users