### PR TITLE
Stop passing `donateLinkId` around

### DIFF
--- a/src/app/campaign-details/campaign-details.component.spec.ts
+++ b/src/app/campaign-details/campaign-details.component.spec.ts
@@ -57,7 +57,6 @@ describe('CampaignDetailsComponent', () => {
       {
         id: 'testCharityId',
         name: 'Test Charity',
-        donateLinkId: 'SFIdOrLegacyId',
         optInStatement: 'Opt in statement.',
         website: 'https://www.testcharity.co.uk',
         regulatorNumber: '123456',

--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -12,7 +12,6 @@ export class Campaign {
     public charity: {
       id: string,
       name: string,
-      donateLinkId: string,
       optInStatement: string,
       facebook?: string,
       instagram?: string,

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -39,12 +39,12 @@ export class CampaignResolver  {
 
     if (campaignSlug && fundSlug && campaignSlug !== "campaign") {
       const query = this.campaignService.buildQuery(this.searchService.selected, 0, campaignId ?? undefined, campaignSlug, fundSlug);
-      this.campaignService.search(query as SearchQuery).subscribe(
-        () => {},
-        () => {
+      this.campaignService.search(query as SearchQuery).subscribe({
+        next: () => {},
+        error: () => {
           this.router.navigateByUrl(`/${campaignSlug}`);
-        }
-      )
+        },
+      });
     }
 
     return this.loadWithStateCache(

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -30,7 +30,6 @@ describe('CampaignService', () => {
       {
         id: '0011r00002HHAprAAH',
         name: 'Awesome Charity',
-        donateLinkId: 'SFIdOrLegacyId',
         optInStatement: 'Opt in statement.',
         website: 'https://www.awesomecharity.co.uk',
         regulatorNumber: '123456',

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
@@ -79,7 +79,6 @@ describe('DonationStartLoginComponent', () => {
       {
         id: '0011r00002HHAprAAH',
         name: 'Awesome Charity',
-        donateLinkId: 'SFIdOrLegacyId',
         optInStatement: 'Opt in statement.',
         regulatorNumber: '123456',
         regulatorRegion: 'Scotland',

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -52,13 +52,11 @@ function makeDonationStartFormComponent(donationService: DonationService,) {
     undefined as unknown as PageMetaService,
     undefined as unknown as PostcodeService,
     {},
-    {snapshot: {}} as unknown as ActivatedRoute,
     {
       navigate: () => {
       }
     } as unknown as Router,
     undefined as unknown as StripeService,
-    undefined as unknown as CurrencyPipe,
     undefined as unknown as DatePipe,
     undefined as unknown as TimeLeftPipe
   );
@@ -140,7 +138,6 @@ describe('DonationStartNewPrimaryComponent', () => {
         {
           id: '0011r00002HHAprAAH',
           name: 'Awesome Charity',
-          donateLinkId: 'SFIdOrLegacyId',
           optInStatement: 'Opt in statement.',
           regulatorNumber: '123456',
           regulatorRegion: 'Scotland',

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -52,6 +52,7 @@ function makeDonationStartFormComponent(donationService: DonationService,) {
     undefined as unknown as PageMetaService,
     undefined as unknown as PostcodeService,
     {},
+    {snapshot: {}} as unknown as ActivatedRoute,
     {
       navigate: () => {
       }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -1,4 +1,4 @@
-import {CurrencyPipe, DatePipe} from "@angular/common";
+import {DatePipe} from '@angular/common';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {FormBuilder, FormGroup, ReactiveFormsModule} from '@angular/forms';

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -253,13 +253,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     private pageMeta: PageMetaService,
     private postcodeService: PostcodeService,
     @Inject(PLATFORM_ID) private platformId: Object,
-    private route: ActivatedRoute,
     private router: Router,
     private stripeService: StripeService,
-    private currencyPipe: CurrencyPipe,
     public datePipe: DatePipe,
     public timeLeftPipe: TimeLeftPipe,
-
   ) {
     this.defaultCountryCode = this.donationService.getDefaultCounty();
     this.countryOptionsObject = Object.assign(

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -19,7 +19,7 @@ import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
 import {MatCheckboxChange} from '@angular/material/checkbox';
 import {MatDialog} from '@angular/material/dialog';
 import {MatStepper} from '@angular/material/stepper';
-import {Router} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {RecaptchaComponent} from 'ng-recaptcha';
 import {debounceTime, distinctUntilChanged, retryWhen, startWith, switchMap, tap} from 'rxjs/operators';
 import {
@@ -252,6 +252,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     private pageMeta: PageMetaService,
     private postcodeService: PostcodeService,
     @Inject(PLATFORM_ID) private platformId: Object,
+    private route: ActivatedRoute,
     private router: Router,
     private stripeService: StripeService,
     public datePipe: DatePipe,

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1,5 +1,5 @@
 import {StepperSelectionEvent} from '@angular/cdk/stepper';
-import {CurrencyPipe, DatePipe, getCurrencySymbol, isPlatformBrowser} from '@angular/common';
+import {DatePipe, getCurrencySymbol, isPlatformBrowser} from '@angular/common';
 import {HttpErrorResponse} from '@angular/common/http';
 import {
   AfterContentChecked,
@@ -19,7 +19,7 @@ import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
 import {MatCheckboxChange} from '@angular/material/checkbox';
 import {MatDialog} from '@angular/material/dialog';
 import {MatStepper} from '@angular/material/stepper';
-import {ActivatedRoute, Router} from '@angular/router';
+import {Router} from '@angular/router';
 import {RecaptchaComponent} from 'ng-recaptcha';
 import {debounceTime, distinctUntilChanged, retryWhen, startWith, switchMap, tap} from 'rxjs/operators';
 import {
@@ -69,7 +69,6 @@ import {MatomoTracker} from 'ngx-matomo';
   templateUrl: './donation-start-form.component.html',
   styleUrls: ['./donation-start-form.component.scss'],
   providers: [
-    CurrencyPipe,
     TimeLeftPipe,
   ]
 })

--- a/src/app/meta-campaign/meta-campaign.component.spec.ts
+++ b/src/app/meta-campaign/meta-campaign.component.spec.ts
@@ -45,7 +45,6 @@ describe('MetaCampaignComponent', () => {
     {
       id: 'tbgId',
       name: 'Big Give',
-      donateLinkId: 'SFIdOrLegacyId',
       optInStatement: 'Opt in statement.',
       website: 'https://www.thebiggive.org.uk',
       regulatorNumber: '123456',


### PR DESCRIPTION
Groundwork for dropping this deprecated, redundant property from all apps.

And other minor refactoring.