### PR TITLE
Don-883: Reset donation form if donor goes back to first step

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -9,7 +9,7 @@
       <mat-step
         formGroupName="amounts"
         [stepControl]="amountsGroup"
-        label="Your donation"
+        [label]="yourDonationStepLabel"
         class="c-your-donation"
       >
         <p *ngIf="campaign.matchFundsRemaining > 0" class="c-your-donation__highlight">

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -215,6 +215,8 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   // will be undefined if the drop-down is in use instead of the slider.
   @ViewChild('donationTippingSlider') tippingSlider: DonationTippingSliderComponent | undefined;
 
+  yourDonationStepLabel = 'Your donation' as const;
+
   displayCustomTipInput = () => {
     this.amountsGroup.get('tipAmount')?.setValue('');
 
@@ -602,11 +604,11 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     // Create a donation if coming from first step and not offering to resume
     // an existing donation and not just patching tip amount on `donation`
     // having already gone forward then back in the form.
-    if (event.previouslySelectedStep.label === 'Your donation') {
+    if (event.previouslySelectedStep.label === this.yourDonationStepLabel) {
       if (
         !this.donation && // No change or only tip amount changed, if we got here.
         (this.previousDonation === undefined || this.previousDonation.status === 'Cancelled') &&
-        event.selectedStep.label !== 'Your donation' // Resets fire a 0 -> 0 index event.
+        event.selectedStep.label !== this.yourDonationStepLabel // Resets fire a 0 -> 0 index event.
       ) {
         this.createDonationAndMaybePerson();
       }
@@ -929,7 +931,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     // click, probably because that method needs a refreshed DOM to detect if custom
     // error elements are still present. So the safest fix for now is to skip it
     // when we know we have only just hidden the error in this call.
-    if (this.donationCreateError && this.stepper.selected?.label === 'Your donation') {
+    if (this.donationCreateError && this.stepper.selected?.label === this.yourDonationStepLabel) {
       if (this.donation) {
         this.clearDonation(this.donation, true);
         this.matomoTracker.trackEvent(
@@ -1876,7 +1878,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
           tipPercentage,
         });
 
-        if (this.stepper.selected?.label === 'Your donation') {
+        if (this.stepper.selected?.label === this.yourDonationStepLabel) {
           this.jumpToStep(donation.currencyCode === 'GBP' ? 'Gift Aid' : 'Payment details');
         }
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -547,7 +547,14 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   }
 
   async stepChanged(event: StepperSelectionEvent) {
-    // We need to allow enough time for the Stepper's animation to get the window to
+    if (event.selectedStep.label === this.yourDonationStepLabel) {
+      // workaround bug issue DON-883 - without resestting the page the stripe element is not usable for the new donation that will be created in this step.
+      // Not ideal as this loses content the donor may have typed already, but better to reset the page than let them enter donation details and then fail to
+      // take the payment.
+      this.reset();
+    }
+
+      // We need to allow enough time for the Stepper's animation to get the window to
     // its final position for this step, before this scroll position update can be reliably
     // helpful.
     setTimeout(() => {


### PR DESCRIPTION
Going back to the first step indicates that they may be about to change the donation amount, and we have a bug that means changing the amount makes the confirm payment step at the end fail. This avoids that, at the (high but worth paying) cost of erasing what they've typed into the form. 

It's not a good solution by any means, but I've now spent a full day trying to find a better solution, and not found one. This is a lot better than nothing, and doesn't stop us looking for a better solution.

The one fix I managed to find for the original bug has the side effect of requiring the donor to type in their payment details a 3rd time (after the expected 2nd time that happens because they changed the amount). That's confusing and I think worse than the change here.

The only other option I can think of if we don't find a better fix is to revert to the old stripe card element instead of the payment element.