### PR TITLE
DON-882: Cancel donation before reloading stepper at first step

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -548,7 +548,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       // workaround bug issue DON-883 - without resestting the page the stripe element is not usable for the new donation that will be created in this step.
       // Not ideal as this loses content the donor may have typed already, but better to reset the page than let them enter donation details and then fail to
       // take the payment.
-      this.reset();
+
+      if (this.donation) {
+        this.donationService.cancel(this.donation).subscribe(() => this.reset());
+      }
     }
 
       // We need to allow enough time for the Stepper's animation to get the window to


### PR DESCRIPTION
This should avoid the problem we're seeing in regression tests of being prompted to continue the existing donation, which would be a bit confusing and also makes the tests fail