### PR TITLE
DON-783: Only render cookie consent banner on browser

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,6 +15,13 @@
   [experienceUrlPrefix]="experienceUriPrefix"
 ></biggive-footer>
 
-<div id="cookie-banner" *ngIf="(userHasExpressedCookiePreference$ | async) === false && flags.cookieBannerEnabled">
+  <!-- We only render the following div if isPlatformBrowser, because if rendered on the server side it would flash up on page reload
+       for a few hundred ms for people who have already made cookie preference selection who don't need to see it again. I found
+       that was an issue on mobile, I couldn't see the issue on desktop browsers.
+   -->
+<div
+  id="cookie-banner"
+  *ngIf="isPlatformBrowser && (userHasExpressedCookiePreference$ | async) === false && flags.cookieBannerEnabled"
+>
     <biggive-cookie-banner [blogUriPrefix]="environment.blogUriPrefix" />
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -76,9 +76,10 @@ export class AppComponent implements AfterViewInit, OnInit {
     } // Else fall back to normal link behaviour
   }
 
-  ngOnInit() {
-    if (isPlatformBrowser(this.platformId)) {
+  public isPlatformBrowser = isPlatformBrowser(this.platformId);
 
+  ngOnInit() {
+    if (this.isPlatformBrowser) {
       if (flags.cookieBannerEnabled) {
         this.cookiePreferenceService.userOptInToSomeCookies().subscribe((preferences: CookiePreferences) => {
           if (agreesToThirdParty(preferences)) {


### PR DESCRIPTION
If it renders on the server then the browser just has to un-render it for people who don't need it, which leads to an ugly flash of content thats pasturize before you can read it.