### PR TITLE
DON-880: Don't display terms for apple pay or google pay, adjust matomo event for wallet payments

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1847,7 +1847,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     const stripeMethod = stripe_donation_method || 'undefined';
 
-    // if not card then we assume it must be prb i.e. Google Pay or Apple Pay.
+    // if not card then we assume it must be a Payment Request Button i.e. Google Pay or Apple Pay.
     const action = stripe_donation_method === 'card' ?
         'stripe_card_payment_success' : 'stripe_prb_payment_success';
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1847,9 +1847,13 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     const stripeMethod = stripe_donation_method || 'undefined';
 
+    // if not card then we assume it must be prb i.e. Google Pay or Apple Pay.
+    const action = stripe_donation_method === 'card' ?
+        'stripe_card_payment_success' : 'stripe_prb_payment_success';
+
     this.matomoTracker.trackEvent(
       'donate',
-      'stripe_card_payment_success',
+      action,
       `Stripe Intent processing or done for donation ${donation.donationId} to campaign ${donation.projectId}, stripe method ${stripeMethod}`,
     );
     this.conversionTrackingService.convert(donation, this.campaign);

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1007,7 +1007,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
             googlePay: 'auto'
           },
           terms: {
-            card: "never" // we have our own terms copy for the future payment in donation-start-form.component.html
+            // We have our own terms copy for the future payment in donation-start-form.component.html
+            card: "never",
+            applePay: "never",
+            googlePay: "never",
           },
           fields: {
             billingDetails: {


### PR DESCRIPTION
We display our own terms, so these should not be necassary