### PR TITLE
DON-614: Intercept HTTP call to SF API in cypress tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  blockHosts: [
+    'sf-api-staging.thebiggivetest.org.uk',
+    'api.getAddress.io',
+  ],
   e2e: {
     baseUrl: 'http://localhost:4200',
     includeShadowDom: true,

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,6 +1,20 @@
+import {CampaignStats} from "../../src/app/campaign-stats.model";
+
 describe('App boot fundamentals', () => {
-  it('Shows our headline copy on the Donate home page', () => {
-    cy.visit('/')
-    cy.contains('Matching Donations.')
+  beforeEach(() => {
+    cy.intercept(
+      {url: "https://sf-api-staging.thebiggivetest.org.uk//campaigns/services/apexrest/v1.0/campaigns/stats"},
+      {
+        body: {totalRaised: 500_000, totalCampaignCount: 123_456} as CampaignStats
+      }
+    )
+  })
+
+  it('Shows our copy on the Donate home page', () => {
+    cy.visit('/');
+
+    cy.contains('Matching Donations.');
+    cy.contains('£500,000');
+    cy.contains('raised for over 123,456 charity projects since 2008');
   })
 })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -15,3 +15,7 @@
 
 // When a command from ./commands is ready to use, import with `import './commands'` syntax
 // import './commands';
+
+import {CampaignStats} from "../../src/app/campaign-stats.model";
+
+


### PR DESCRIPTION
Makes the frontend a little more self-contained, although we lose some incidental testing of the SF API