### PR TITLE
Don't build a `//` URI where the real app doesn't

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -3,7 +3,7 @@ import {CampaignStats} from "../../src/app/campaign-stats.model";
 describe('App boot fundamentals', () => {
   beforeEach(() => {
     cy.intercept(
-      {url: "https://sf-api-staging.thebiggivetest.org.uk//campaigns/services/apexrest/v1.0/campaigns/stats"},
+      {url: "https://sf-api-staging.thebiggivetest.org.uk/campaigns/services/apexrest/v1.0/campaigns/stats"},
       {
         body: {totalRaised: 500_000, totalCampaignCount: 123_456} as CampaignStats
       }


### PR DESCRIPTION
It seems like due to Chrome behaviour(?) Cypress "eats" the extra slash, but it could confuse devs comparing it to how the real app builds this.