### PR TITLE
Make resume calls on `DonationStartFormComponent` safe

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
@@ -1,5 +1,5 @@
-import {DatePipe} from "@angular/common";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {Component} from "@angular/core";
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import {ActivatedRoute} from "@angular/router";
@@ -12,20 +12,18 @@ import {DonationStartFormComponent} from "../donation-start-form/donation-start-
 import {TBG_DONATE_ID_STORAGE} from "../../identity.service";
 import {TBG_DONATE_STORAGE} from "../../donation.service";
 import {Campaign} from "../../campaign.model";
-import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
-// @Component({
-//   selector: 'app-donation-start-form',
-//   template: '',
-//   providers: [
-//     DatePipe,
-//     { provide: DonationStartFormComponent, useClass: StubDonationStartFormComponent },
-//   ],
-// })
-// class StubDonationStartFormComponent {
-//   // campaign = getDummyCampaign('testCampaignIdForStripe'); // todo rm?
-//   resumeDonationsIfPossible() {}
-// }
+// See https://medium.com/angular-in-depth/angular-unit-testing-viewchild-4525e0c7b756
+@Component({
+  selector: 'app-donation-start-form',
+  template: '',
+  providers: [
+    { provide: DonationStartFormComponent, useClass: DonationStartFormStubComponent },
+  ],
+})
+class DonationStartFormStubComponent {
+  resumeDonationsIfPossible() {}
+}
 
 describe('DonationStartContainer', () => {
   let component: DonationStartContainerComponent;
@@ -35,7 +33,7 @@ describe('DonationStartContainer', () => {
     await TestBed.configureTestingModule({
       declarations: [
         DonationStartContainerComponent,
-        DonationStartFormComponent,
+        DonationStartFormStubComponent,
       ],
       imports: [
         HttpClientTestingModule,
@@ -47,7 +45,6 @@ describe('DonationStartContainer', () => {
             enable: true,
           }
         }),
-        NoopAnimationsModule,
       ],
       providers: [
         {
@@ -59,8 +56,6 @@ describe('DonationStartContainer', () => {
             },
           },
         },
-        DatePipe,
-        // { provide: [{DonationStartFormComponent, useClass: StubDonationStartFormComponent}] },
         InMemoryStorageService,
         { provide: TBG_DONATE_ID_STORAGE, useExisting: InMemoryStorageService },
         { provide: TBG_DONATE_STORAGE, useExisting: InMemoryStorageService },
@@ -70,7 +65,6 @@ describe('DonationStartContainer', () => {
 
     fixture = TestBed.createComponent(DonationStartContainerComponent);
     component = fixture.componentInstance;
-    // component.donationStartForm = TestBed.inject(StubDonationStartFormComponent);
     fixture.detectChanges();
   });
 

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
@@ -1,3 +1,4 @@
+import {DatePipe} from "@angular/common";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -7,17 +8,35 @@ import {InMemoryStorageService} from "ngx-webstorage-service";
 import {of} from "rxjs";
 
 import {DonationStartContainerComponent} from "./donation-start-container.component";
+import {DonationStartFormComponent} from "../donation-start-form/donation-start-form.component";
 import {TBG_DONATE_ID_STORAGE} from "../../identity.service";
 import {TBG_DONATE_STORAGE} from "../../donation.service";
 import {Campaign} from "../../campaign.model";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
-describe('DonationStartLoginComponent', () => {
+// @Component({
+//   selector: 'app-donation-start-form',
+//   template: '',
+//   providers: [
+//     DatePipe,
+//     { provide: DonationStartFormComponent, useClass: StubDonationStartFormComponent },
+//   ],
+// })
+// class StubDonationStartFormComponent {
+//   // campaign = getDummyCampaign('testCampaignIdForStripe'); // todo rm?
+//   resumeDonationsIfPossible() {}
+// }
+
+describe('DonationStartContainer', () => {
   let component: DonationStartContainerComponent;
   let fixture: ComponentFixture<DonationStartContainerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DonationStartContainerComponent ],
+      declarations: [
+        DonationStartContainerComponent,
+        DonationStartFormComponent,
+      ],
       imports: [
         HttpClientTestingModule,
         MatDialogModule,
@@ -28,6 +47,7 @@ describe('DonationStartLoginComponent', () => {
             enable: true,
           }
         }),
+        NoopAnimationsModule,
       ],
       providers: [
         {
@@ -39,6 +59,8 @@ describe('DonationStartLoginComponent', () => {
             },
           },
         },
+        DatePipe,
+        // { provide: [{DonationStartFormComponent, useClass: StubDonationStartFormComponent}] },
         InMemoryStorageService,
         { provide: TBG_DONATE_ID_STORAGE, useExisting: InMemoryStorageService },
         { provide: TBG_DONATE_STORAGE, useExisting: InMemoryStorageService },
@@ -48,11 +70,15 @@ describe('DonationStartLoginComponent', () => {
 
     fixture = TestBed.createComponent(DonationStartContainerComponent);
     component = fixture.componentInstance;
+    // component.donationStartForm = TestBed.inject(StubDonationStartFormComponent);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it(`should create and call form's donation resume helper`, () => {
+    spyOn(component.donationStartForm, 'resumeDonationsIfPossible');
+    component.ngAfterViewInit();
     expect(component).toBeTruthy();
+    expect(component.donationStartForm.resumeDonationsIfPossible).toHaveBeenCalled();
   });
 
   const getDummyCampaign = (campaignId: string) => {

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
 import {Campaign} from "../../campaign.model";
 import {ActivatedRoute} from "@angular/router";
 import { Donation } from 'src/app/donation.model';
@@ -11,7 +11,7 @@ import {ImageService} from "../../image.service";
   templateUrl: './donation-start-container.component.html',
   styleUrls: ['./donation-start-container.component.scss']
 })
-export class DonationStartContainerComponent implements OnInit{
+export class DonationStartContainerComponent implements AfterViewInit, OnInit{
   campaign: Campaign;
   campaignOpenOnLoad: boolean;
   donation: Donation | undefined = undefined;
@@ -31,23 +31,22 @@ export class DonationStartContainerComponent implements OnInit{
   ) {
   }
 
-   ngOnInit() {
+  ngOnInit() {
     this.campaign = this.route.snapshot.data.campaign;
-     this.campaignOpenOnLoad = this.campaignIsOpen();
-     this.imageService.getImageUri(this.campaign.bannerUri, 830).subscribe(uri => this.bannerUri = uri);
+    this.campaignOpenOnLoad = this.campaignIsOpen();
+    this.imageService.getImageUri(this.campaign.bannerUri, 830).subscribe(uri => this.bannerUri = uri);
+  }
 
-     const idAndJWT = this.identityService.getIdAndJWT();
-     if (idAndJWT) {
-       this.loadAuthedPersonInfo(idAndJWT.id, idAndJWT.jwt);
-     } else {
-       if (!this.donationStartForm) {
-         console.error("Donation start form not loaded");
-       }
-       // this.donationStartForm is undefined when we're running donation-start-login.component.spec.ts . I'm not sure
-       // tbh why this class is even called from that test. Null safe call to let it pass.
-       this.donationStartForm?.resumeDonationsIfPossible();
-     }
-   }
+  ngAfterViewInit() {
+    const idAndJWT = this.identityService.getIdAndJWT();
+    if (idAndJWT) {
+      // Callback will `resumeDonationsIfPossible()` after loading the person.
+      this.loadAuthedPersonInfo(idAndJWT.id, idAndJWT.jwt);
+      return;
+    }
+
+    this.donationStartForm.resumeDonationsIfPossible();
+  }
 
   /**
    * Unlike the CampaignService method which is more forgiving if the status gets stuck Active (we don't trust

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -110,8 +110,6 @@ describe('DonationStartNewPrimaryComponent', () => {
       .compileComponents();
   }));
 
-  (window as any).gtag = (...args: any[]) => args;
-
   let component: DonationStartFormComponent;
   let fixture: ComponentFixture<DonationStartFormComponent>;
 


### PR DESCRIPTION
Use a lifecycle hook that can safely assume `@ViewChild`ren are instantiated.