### PR TITLE
DON-889: Add Skip to Content link

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,17 @@
+  <div class="skip-to-content-link">
+    <biggive-button
+      space-above="5"
+      colour-scheme="primary"
+      label="Skip to content"
+      full-width="true"
+      size="medium"
+      rounded="false"
+      url="#content"
+    ></biggive-button>
+
+  </div>
+
+
   <biggive-main-menu *ngIf="isDataLoaded"
     [usePresetMenuContent]="true"
     [donateUrlPrefix]="donateUriPrefix"
@@ -6,6 +20,9 @@
     [isLoggedIn]="isLoggedIn"
     ></biggive-main-menu>
 
+  <a id="content">
+    <!-- target for "skip to content" link -->
+  </a>
   <router-outlet></router-outlet>
 
   <biggive-footer

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,19 @@
+@import '../abstract';
+
 #cookie-banner {
   position: fixed;
   bottom: 3em;
   right: 3em;
   z-index: 10;
+}
+
+.skip-to-content-link {
+  z-index: 10;
+  position: absolute;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+.skip-to-content-link:focus-within {
+  transform: translateY(0%);
 }


### PR DESCRIPTION
This button is visible only when it is focused - at other times it hidden off the edge of the screen.

I used the #focus-within CSS selector, which should work with all browsers except IE and Opera Mini.

![image](https://github.com/thebiggive/donate-frontend/assets/159481/90fefd96-c058-4f89-9318-0c0a2819d436)
