### PR TITLE
DON-906 – fix some Campaign Info progressbars

### DIFF
--- a/src/app/campaign-info/campaign-info.component.ts
+++ b/src/app/campaign-info/campaign-info.component.ts
@@ -72,7 +72,7 @@ export class CampaignInfoComponent implements OnInit {
   }
 
   getPercentageRaised(campaign: Campaign): number | undefined {
-    return CampaignService.percentRaised(campaign);
+    return CampaignService.percentRaised(campaign, true);
   }
 
   getBeneficiaryIcon(beneficiary: string) {

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -150,4 +150,24 @@ describe('CampaignService', () => {
 
     expect(CampaignService.isOpenForDonations(campaign)).toBe(false);
   });
+
+  it ('should return the % raised for itself when its parent does not use shared funds', () => {
+    const campaign = getDummyCampaign();
+    campaign.parentUsesSharedFunds = false;
+    campaign.amountRaised = 98;
+    campaign.target = 200;
+
+    expect(CampaignService.percentRaised(campaign, true)).toBe(49);
+  });
+
+  it ('should return the % raised for the parent campaign when its parent does use shared funds', () => {
+    const campaign = getDummyCampaign();
+    campaign.parentUsesSharedFunds = true;
+    campaign.amountRaised = 98;
+    campaign.target = 200;
+    campaign.parentAmountRaised = 1000;
+    campaign.parentTarget = 2000;
+
+    expect(CampaignService.percentRaised(campaign, true)).toBe(50);
+  });
 });

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -67,7 +67,22 @@ export class CampaignService {
     return dateToUse;
   }
 
-  static percentRaised(campaign: (Campaign | CampaignSummary)): number | undefined {
+  /**
+   * @param useParentIfApplicable Whether to get a percentage for the parent/meta-campaign if possible. This
+   *                              is possible when `campaign` is a detailed Campaign, e.g. on /campaign/..., and
+   *                              it takes effect when the `parentUsesSharedFunds`.
+   */
+  static percentRaised(
+    campaign: (Campaign | CampaignSummary),
+    useParentIfApplicable = false,
+  ): number | undefined {
+    if (useParentIfApplicable) {
+      campaign = campaign as Campaign;
+      if (campaign.parentUsesSharedFunds && campaign.parentTarget && campaign.parentAmountRaised) {
+        return Math.round((campaign.parentAmountRaised / campaign.parentTarget) * 100);
+      }
+    }
+
     if (!campaign.target) {
       return undefined;
     }


### PR DESCRIPTION
For shared fund child campaigns, make the progress % reflect the parent, like the related numbers next to the bar, where applicable.