### PR TITLE
DON-889: Fix Skip to content link

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,16 +3,7 @@
           Can't use a simple relative link for the URL because we have base href set of /d/ set in non-dev environments
           which is needed for links to assets but would break this.
     -->
-    <biggive-button
-      space-above="5"
-      colour-scheme="primary"
-      label="Skip to content"
-      full-width="true"
-      size="medium"
-      rounded="false"
-      [url]="currentUrl.toString() + '#content'"
-    ></biggive-button>
-
+    <a [href]="currentUrl.toString() + '#content'">Skip to content</a>
   </div>
 
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-  <div class="skip-to-content-link">
+  <div class="skip-to-content-link" *ngIf="currentUrlWithoutHash$ | async as currentUrl">
     <!--
           Can't use a simple relative link for the URL because we have base href set of /d/ set in non-dev environments
           which is needed for links to assets but would break this.

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -9,9 +9,19 @@
 
 .skip-to-content-link {
   z-index: 10;
+  margin: auto;
+  text-align: center;
+  width: 100%;
   position: absolute;
-  transform: translateY(-100%);
+  font-size: 16px;
+  transform: translateY(-1000%);
   transition: transform 0.3s;
+
+  a {
+    background-color: $colour-background;
+    padding: 5px;
+    border-radius: 3px;
+  }
 }
 
 .skip-to-content-link:focus-within {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import {AfterViewInit, Component, HostListener, Inject, OnInit, PLATFORM_ID, Vie
 import {Event as RouterEvent, NavigationEnd, NavigationStart, Router,} from '@angular/router';
 import {BiggiveMainMenu} from '@biggive/components-angular';
 import {MatomoTracker} from "ngx-matomo";
-import {filter} from 'rxjs/operators';
+import {filter, map} from 'rxjs/operators';
 
 import {DonationService} from './donation.service';
 import {GetSiteControlService} from './getsitecontrol.service';
@@ -18,6 +18,7 @@ import {
   CookiePreferences,
   CookiePreferenceService
 } from "./cookiePreference.service";
+import {Observable} from "rxjs";
 
 @Component({
   selector: 'app-root',
@@ -39,7 +40,7 @@ export class AppComponent implements AfterViewInit, OnInit {
   protected readonly environment = environment;
   protected readonly flags = flags;
   protected readonly userHasExpressedCookiePreference$ = this.cookiePreferenceService.userHasExpressedCookiePreference();
-  public currentUrl: URL;
+  public currentUrlWithoutHash$: Observable<URL>;
 
   constructor(
     private identityService: IdentityService,
@@ -61,7 +62,14 @@ export class AppComponent implements AfterViewInit, OnInit {
       }
     });
 
-    this.currentUrl = new URL(environment.donateGlobalUriPrefix + router.url);
+    this.currentUrlWithoutHash$ = router.events.pipe(
+      filter((event: RouterEvent) => event instanceof NavigationEnd),
+      map((_event) => {
+        const url = new URL(environment.donateGlobalUriPrefix + router.url);
+        url.hash = "";
+        return url;
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
Taking the router.url in the template constructor doesn't work, the router doesn't know what page we're on that early. We need to react to router events instead.

Also I think the push button is not quite as easy to use as a simpe a tag, so as discussed have take away the biggive-button here and put in A tag with some simple custom styling instead:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/fbba2ce5-05aa-4ab2-9217-7e31735afcb0)
