### PR TITLE
DON-819: Show errors blocking progress from payment step

### DIFF
--- a/src/app/donation-start/donation-start-form/PaymentReadinessTracker.spec.ts
+++ b/src/app/donation-start/donation-start-form/PaymentReadinessTracker.spec.ts
@@ -6,11 +6,38 @@ describe('PaymentReadinessTracker', () => {
     paymentGroup = {valid: true, controls: {}};
   })
 
-
   it('Initially says we are not ready to progress from payment step', () => {
     const sut = new PaymentReadinessTracker(paymentGroup);
 
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
+  })
+
+  it('Lists errors according to payment group controls.', () => {
+    const sut = new PaymentReadinessTracker(paymentGroup);
+    paymentGroup.controls = {
+      firstName: {errors: {required: true}},
+      lastName: {errors: {required: true}},
+      emailAddress: {errors: {required: true}},
+      billingPostcode: {errors: {required: true}},
+    }
+
+    expect(sut.getErrorsBlockingProgress()).toEqual([
+      'Please enter your first name.',
+      'Please enter your last name.',
+      'Please enter your email address.',
+      'Please enter your billing postcode.',
+      'Please complete your payment method.',
+    ]);
+  })
+
+  it('Prompts to select saved card if deselected.', () => {
+    const sut = new PaymentReadinessTracker(paymentGroup);
+    sut.selectedSavedPaymentMethod();
+    sut.clearSavedPaymentMethod();
+
+    expect(sut.getErrorsBlockingProgress()).toEqual([
+      'Please complete your new payment method, or select a saved payment method.',
+    ]);
   })
 
   it("Allows proceeding from payment step when a saved card is selected", () => {

--- a/src/app/donation-start/donation-start-form/PaymentReadinessTracker.spec.ts
+++ b/src/app/donation-start/donation-start-form/PaymentReadinessTracker.spec.ts
@@ -1,42 +1,43 @@
 import {PaymentReadinessTracker} from "./PaymentReadinessTracker";
 
 describe('PaymentReadinessTracker', () => {
+  const paymentGroup1 = {valid: true, controls: {}};
+
   it('Initially says we are not ready to progress from payment step', () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
   })
 
   it("Allows proceeding from payment step when a saved card is selected", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.selectedSavedPaymentMethod();
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   });
 
   it("Blocks proceeding from payment step when a saved card is selected but payments group is invalid", () => {
-    const paymentGroup = {valid: true};
-    const sut = new PaymentReadinessTracker(paymentGroup);
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.selectedSavedPaymentMethod();
-    paymentGroup.valid = false;
+    paymentGroup1.valid = false;
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
   });
 
   it("Allows proceeding from payment step when donor has credit", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
     sut.donorHasFunds();
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   });
 
   it("Allows proceeding from payment step when donation credits are prepared", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
     sut.donationFundsPrepared(1);
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   });
 
   it("Allows proceeding from payment step when a saved card is selected ", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.selectedSavedPaymentMethod();
     sut.onUseSavedCardChange(true);
@@ -44,7 +45,7 @@ describe('PaymentReadinessTracker', () => {
   });
 
   it("Blocks proceeding from payment step when a saved card is selected but not to be used", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.selectedSavedPaymentMethod();
     sut.onUseSavedCardChange(false);
@@ -52,21 +53,21 @@ describe('PaymentReadinessTracker', () => {
   });
 
   it("Allows proceeding from payment step when a complete payment card is given", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.onStripeCardChange({complete: true});
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   })
 
     it("Blocks proceeding fromm payment step when an incomplete payment card is given", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.onStripeCardChange({complete: false});
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
   })
 
   it("Blocks proceeding from payment step when a payment method is selected then cleared", () => {
-    const sut = new PaymentReadinessTracker({valid: true});
+    const sut = new PaymentReadinessTracker(paymentGroup1);
 
     sut.selectedSavedPaymentMethod();
     sut.clearSavedPaymentMethod();

--- a/src/app/donation-start/donation-start-form/PaymentReadinessTracker.spec.ts
+++ b/src/app/donation-start/donation-start-form/PaymentReadinessTracker.spec.ts
@@ -1,43 +1,47 @@
 import {PaymentReadinessTracker} from "./PaymentReadinessTracker";
 
 describe('PaymentReadinessTracker', () => {
-  const paymentGroup1 = {valid: true, controls: {}};
+  let paymentGroup: {valid: boolean, controls: {}}
+  beforeEach(() => {
+    paymentGroup = {valid: true, controls: {}};
+  })
+
 
   it('Initially says we are not ready to progress from payment step', () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
   })
 
   it("Allows proceeding from payment step when a saved card is selected", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.selectedSavedPaymentMethod();
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   });
 
   it("Blocks proceeding from payment step when a saved card is selected but payments group is invalid", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.selectedSavedPaymentMethod();
-    paymentGroup1.valid = false;
+    paymentGroup.valid = false;
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
   });
 
   it("Allows proceeding from payment step when donor has credit", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
     sut.donorHasFunds();
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   });
 
   it("Allows proceeding from payment step when donation credits are prepared", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
     sut.donationFundsPrepared(1);
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   });
 
   it("Allows proceeding from payment step when a saved card is selected ", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.selectedSavedPaymentMethod();
     sut.onUseSavedCardChange(true);
@@ -45,7 +49,7 @@ describe('PaymentReadinessTracker', () => {
   });
 
   it("Blocks proceeding from payment step when a saved card is selected but not to be used", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.selectedSavedPaymentMethod();
     sut.onUseSavedCardChange(false);
@@ -53,21 +57,21 @@ describe('PaymentReadinessTracker', () => {
   });
 
   it("Allows proceeding from payment step when a complete payment card is given", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.onStripeCardChange({complete: true});
     expect(sut.readyToProgressFromPaymentStep).toBeTrue();
   })
 
     it("Blocks proceeding fromm payment step when an incomplete payment card is given", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.onStripeCardChange({complete: false});
     expect(sut.readyToProgressFromPaymentStep).toBeFalse();
   })
 
   it("Blocks proceeding from payment step when a payment method is selected then cleared", () => {
-    const sut = new PaymentReadinessTracker(paymentGroup1);
+    const sut = new PaymentReadinessTracker(paymentGroup);
 
     sut.selectedSavedPaymentMethod();
     sut.clearSavedPaymentMethod();

--- a/src/app/donation-start/donation-start-form/PaymentReadinessTracker.ts
+++ b/src/app/donation-start/donation-start-form/PaymentReadinessTracker.ts
@@ -72,9 +72,6 @@ export class PaymentReadinessTracker {
     return [...this.humanReadableFormValidationErrors(), ...paymentErrors];
   }
 
-  /**
-   * todo - translate keys to human readable names, deal with errors other than 'reqauired'
-   */
   private humanReadableFormValidationErrors() {
     const fieldNames = {
       firstName: 'first name',

--- a/src/app/donation-start/donation-start-form/PaymentReadinessTracker.ts
+++ b/src/app/donation-start/donation-start-form/PaymentReadinessTracker.ts
@@ -89,7 +89,7 @@ export class PaymentReadinessTracker {
         case 'required':
           return `Please enter your ${fieldName}.`;
         case 'pattern':
-          return `Sorry, your ${fieldName} is not recognised - Please enter a valid ${fieldName}.`;
+          return `Sorry, your ${fieldName} is not recognised - please enter a valid ${fieldName}.`;
         default:
           console.error(error);
           return `Sorry, there is an error with the ${key} field.`;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -444,8 +444,8 @@
             class="continue b-w-100 b-rt-0"
             mat-raised-button
             color="primary"
-            [disabled]="! readyToProgressFromPaymentStep"
-            (click)="next()"
+            [disabled]="! readyToProgressFromPaymentStep && ! don819FlagEnabled"
+            (click)="continueFromPaymentStep()"
           >Continue</button>
         </div>
       </mat-step>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -434,8 +434,15 @@
 
         </div>
 
-        <p *ngIf="stripeError" class="error" aria-live="assertive">
+        <p *ngIf="stripeError" class="error" aria-live="polite">
           {{ stripeError }}
+        </p>
+
+        <p class="error" *ngIf="paymentStepErrors && don819FlagEnabled">
+          <!-- No need for aria-live on this because the errors will have already been in an aria-live toast pop.
+               They are here in addition to all the donor to review them in detail.
+          -->
+          {{paymentStepErrors}}
         </p>
 
         <div style="text-align: center">

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -240,6 +240,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   private stripeElements: StripeElements | undefined;
   private selectedPaymentMethodType: string | undefined;
   private paymentReadinessTracker: PaymentReadinessTracker;
+  public paymentStepErrors: string = "";
 
   constructor(
     public cardIconsService: CardIconsService,
@@ -2168,10 +2169,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   continueFromPaymentStep() {
     if (! this.readyToProgressFromPaymentStep) {
-      this.showErrorToast(this.paymentReadinessTracker.getErrorsBlockingProgress().join(" "));
+      this.paymentStepErrors = this.paymentReadinessTracker.getErrorsBlockingProgress().join(" ");
+      this.showErrorToast(this.paymentStepErrors);
       return;
+    } else {
+      this.paymentStepErrors = "";
+      this.next()
     }
-
-    this.next()
   }
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -2166,4 +2166,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     this.tipAmountField?.setValue(this.tipValue);
   }
 
+  continueFromPaymentStep() {
+    if (! this.readyToProgressFromPaymentStep) {
+      this.showErrorToast(this.paymentReadinessTracker.getErrorsBlockingProgress().join(" "));
+      return;
+    }
+
+    this.next()
+  }
 }

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -3,7 +3,7 @@ import {EnvironmentID} from "../environments/environment.interface";
 
 export const flagsForEnvironment = (environmentId: EnvironmentID) => {
   return {
-    don819FlagEnabled: (environmentId === 'development'),
+    don819FlagEnabled: (environmentId === 'development' || environmentId == 'staging'),
   };
 }
 


### PR DESCRIPTION
Instead of a greyed out continue button at the payment step, we now have an active button that triggers display of all errors in the section the donor isn't ready to continue:

The errors are shown both in a toast message to get immediate attention, and above the button to allow the donor to review them as they edit the form:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/9be9d385-bd08-4875-84c1-eb128b65ac5a)
