### PR TITLE
DON-820 – avoid & better report errors paying with donation funds

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -412,14 +412,14 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   })
 
   resumeDonationsIfPossible() {
-    this.donationService.getProbablyResumableDonation(this.campaignId)
+    this.donationService.getProbablyResumableDonation(this.campaignId, this.getPaymentMethodType())
       .subscribe((existingDonation: (Donation|undefined)) => {
         this.previousDonation = existingDonation;
 
         // The local check might not have the latest donation status in edge cases, so we need to check the copy
         // the Donations API returned still has a resumable status and wasn't completed or cancelled since being
         // saved locally.
-        if (!existingDonation || !this.donationService.isResumable(existingDonation)) {
+        if (!existingDonation || !this.donationService.isResumable(existingDonation, this.getPaymentMethodType())) {
           // No resumable donations
           return;
         }
@@ -652,7 +652,6 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       });
     }
   }
-
 
   /**
    * According to stripe docs https://stripe.com/docs/js/element/events/on_change?type=paymentElement the change event has
@@ -1497,7 +1496,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       feeCoverAmount: sanitiseCurrency(this.amountsGroup.value.feeCoverAmount),
       matchedAmount: 0, // Only set >0 after donation completed
       matchReservedAmount: 0, // Only set >0 after initial donation create API response
-      paymentMethodType: (this.creditPenceToUse > 0) ? 'customer_balance' : 'card',
+      paymentMethodType: this.getPaymentMethodType(),
       projectId: this.campaignId,
       psp: this.psp,
       tipAmount: sanitiseCurrency(this.amountsGroup.value.tipAmount?.trim()),
@@ -2183,5 +2182,9 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       this.paymentStepErrors = "";
       this.next()
     }
+  }
+
+  private getPaymentMethodType() {
+    return (this.creditPenceToUse > 0) ? 'customer_balance' : 'card';
   }
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -774,8 +774,8 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     if (hasCredit) {
       // Settlement is via the Customer's cash balance, with no client-side provision of a Payment Method.
-      this.donationService.finaliseCashBalancePurchase(this.donation).subscribe(
-        (donation) => {
+      this.donationService.finaliseCashBalancePurchase(this.donation).subscribe({
+        next: (donation) => {
           this.matomoTracker.trackEvent(
             'donate',
             'stripe_customer_balance_payment_success',
@@ -783,15 +783,18 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
           );
           this.exitPostDonationSuccess(donation, 'donation-funds');
         },
-        (error: HttpErrorResponse) => {
+        error: (response: HttpErrorResponse) => {
+          // I think this is the path to a detailed message in MatchBot `ActionError`s.
+          const errorMsg = response.error?.error?.description;
+
           this.matomoTracker.trackEvent(
             'donate_error',
             'stripe_customer_balance_payment_error',
-            error.message ?? '[No message]',
+            errorMsg ?? '[No message]',
           );
-          this.stripeError = `Cash balance application failed: ${error.message}`;
+          this.stripeError = 'Your donation has not been processed as it seems you have insufficient funds. Please refresh the page to see your remaining balance.';
         },
-      );
+      });
 
       return;
     }

--- a/src/app/donation.service.spec.ts
+++ b/src/app/donation.service.spec.ts
@@ -188,7 +188,7 @@ describe('DonationService', () => {
 
       service.saveDonation(inputDonation, 'fakeheader.fakebody.fakesig');
 
-      service.getProbablyResumableDonation('11I400000009Sds3e3').subscribe(outputDonation => {
+      service.getProbablyResumableDonation('11I400000009Sds3e3', 'card').subscribe(outputDonation => {
         expect(outputDonation).toBe(inputDonation);
       }, () => {
         expect(false).toBe(true); // Always fail on observable error
@@ -210,7 +210,7 @@ describe('DonationService', () => {
   it('should return undefined for resumable donations with unknown project ID', () => {
     const service: DonationService = TestBed.inject(DonationService);
     service.saveDonation(getDummyDonation(), 'fakeheader.fakebody.fakesig');
-    service.getProbablyResumableDonation('notARealProjectId').subscribe(donation => {
+    service.getProbablyResumableDonation('notARealProjectId', 'card').subscribe(donation => {
       expect(donation).toBeUndefined();
     }, () => {
       expect(false).toBe(true); // Always fail on observable error

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -71,11 +71,11 @@ export class DonationService {
     return couplet.donation;
   }
 
-  isResumable(donation: Donation, requiredPaymentMethodType: 'card' | 'customer_balance'): boolean {
+  isResumable(donation: Donation, paymentMethodType: 'card' | 'customer_balance'): boolean {
     return (
       donation.status !== undefined &&
       this.resumableStatuses.includes(donation.status) &&
-      donation.paymentMethodType === requiredPaymentMethodType
+      donation.paymentMethodType === paymentMethodType
     );
   }
 
@@ -87,7 +87,7 @@ export class DonationService {
    */
   getProbablyResumableDonation(
     projectId: string,
-    requiredPaymentMethodType: 'card' | 'customer_balance',
+    paymentMethodType: 'card' | 'customer_balance',
   ): Observable<Donation | undefined> {
     this.removeOldLocalDonations();
 
@@ -95,7 +95,7 @@ export class DonationService {
       return (
         donationItem.donation.projectId === projectId && // Only bring back donations to the same project/CCampaign...
         this.getCreatedTime(donationItem.donation) > (Date.now() - 600000) && // ...from the past 10 minutes...
-        this.isResumable(donationItem.donation, requiredPaymentMethodType) // ...with a reusable last-known status & method.
+        this.isResumable(donationItem.donation, paymentMethodType) // ...with a reusable last-known status & method.
       );
     });
 


### PR DESCRIPTION
* [only offer reuse of donations with the active `paymentMethodType`](https://github.com/thebiggive/donate-frontend/pull/1361/commits/7a902dd55514ea292ac8c397adc12c26f19daa89)
[7a902dd](https://github.com/thebiggive/donate-frontend/pull/1361/commits/7a902dd55514ea292ac8c397adc12c26f19daa89)
    * This should avoid the donate form breaking in edge cases like donors
who started one donation recently, then later topped up with new funds
* [update error copy, reflecting the remaining way we know paying with donor funds can fail](https://github.com/thebiggive/donate-frontend/pull/1361/commits/1008caa2458d688125b634596e708bc08625e8a4)
[1008caa](https://github.com/thebiggive/donate-frontend/pull/1361/commits/1008caa2458d688125b634596e708bc08625e8a4)