### PR TITLE
DON-876: Donation start page a18y improvements

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -152,10 +152,6 @@
               Back to percentage tip
             </span>
 
-          <mat-expansion-panel hideToggle>
-            <mat-expansion-panel-header>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
           <mat-expansion-panel
             (opened)="panelOpenState = true"
             (closed)="panelOpenState = false"

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -556,7 +556,6 @@
         label="Confirm"
         class="c-make-your-donation"
       >
-<!--        here -->
         <p class="b-rt-0 b-m-0 b-mt-40">By clicking on the <span class="b-bold">Donate now</span> button, you agree to
           Big Give's Terms and Conditions and Privacy Policy. <br/>
           <a [href]="termsUrl" target="_blank">

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -556,16 +556,16 @@
         label="Confirm"
         class="c-make-your-donation"
       >
+<!--        here -->
         <p class="b-rt-0 b-m-0 b-mt-40">By clicking on the <span class="b-bold">Donate now</span> button, you agree to
-          Big Give's
+          Big Give's Terms and Conditions and Privacy Policy. <br/>
           <a [href]="termsUrl" target="_blank">
             <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-              Terms and Conditions
-          </a>
-            and
+              Read our Terms and Conditions
+          </a>,
           <a [href]="privacyUrl" target="_blank">
             <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-            Privacy Policy</a>.
+            read our Privacy Policy</a>.
         </p>
 
         <div class="c-donation-summary">


### PR DESCRIPTION
Removing the empty panel doesn't change the appearance of the page.

Not sure why this panel was there, but it's empty and has no code comment to explain its purpose and is confusing when using keyboard navigation and screen reader, so removing

Adjusted confirmation text at the end of the page looks like this:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/bea75b9b-be2c-490e-8c74-108ae21ce96e)
