### PR TITLE
DON-927 – fix various ID issues

### DIFF
--- a/src/app/donation-complete/donation-complete.component.spec.ts
+++ b/src/app/donation-complete/donation-complete.component.spec.ts
@@ -73,7 +73,7 @@ describe('DonationCompleteComponent', () => {
       feeCoverAmount: 0,
       matchReservedAmount: 0,
       matchedAmount: 0,
-      paymentMethodType: 'card',
+      pspMethodType: 'card',
       projectId: "",
       psp: "stripe",
       tipAmount: 0,

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.html
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.html
@@ -16,7 +16,6 @@
       <app-donation-start-login
         [personId]="this.donor?.id"
         [email]="this.loggedInEmailAddress"
-        [personIsLoginReady]="personIsLoginReady"
         [loadAuthedPersonInfo]="loadAuthedPersonInfo"
         [creditPenceToUse]="this.donationStartForm && this.donationStartForm.creditPenceToUse || 0"
         [campaign]="campaign"

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -19,7 +19,6 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
   campaignOpenOnLoad: boolean;
   donation: Donation | undefined = undefined;
   personId?: string;
-  personIsLoginReady = false;
   loggedInEmailAddress?: string;
 
   @ViewChild('donation_start_form') donationStartForm: DonationStartFormComponent
@@ -55,10 +54,6 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
       this.loadAuthedPersonInfo(idAndJWT.id, idAndJWT.jwt);
       return;
     }
-
-    if (this.donationStartForm) {
-      this.donationStartForm.resumeDonationsIfPossible();
-    }
   }
 
   /**
@@ -93,21 +88,17 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
       return;
     }
 
-    this.identityService.get(id, jwt).subscribe(
-      (person: Person) => {
-      this.donor = person; // Should mean donations are attached to the Stripe Customer.
-      this.personIsLoginReady = true;
-      this.loggedInEmailAddress = person.email_address;
-      this.donationStartForm.loadPerson(person, id, jwt);
-      this.donationStartForm.resumeDonationsIfPossible();
-      },
-      () => {
+    this.identityService.get(id, jwt).subscribe({
+      next: (person: Person) => {
+        this.donor = person; // Should mean donations are attached to the Stripe Customer.
+        this.loggedInEmailAddress = person.email_address;
+        this.donationStartForm.loadPerson(person, id, jwt);
         this.donationStartForm.resumeDonationsIfPossible();
       },
-      () => {
-        this.donationStartForm.resumeDonationsIfPossible();
-      }
-    );
+      error: (err) => {
+        console.log('Could not load Person info: ', err)
+      },
+    });
   };
 
   get canLogin() {

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1492,7 +1492,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       feeCoverAmount: sanitiseCurrency(this.amountsGroup.value.feeCoverAmount),
       matchedAmount: 0, // Only set >0 after donation completed
       matchReservedAmount: 0, // Only set >0 after initial donation create API response
-      paymentMethodType: this.getPaymentMethodType(),
+      pspMethodType: this.getPaymentMethodType(),
       projectId: this.campaignId,
       psp: this.psp,
       tipAmount: sanitiseCurrency(this.amountsGroup.value.tipAmount?.trim()),
@@ -2155,9 +2155,14 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   public loadPerson(person: Person, id: string, jwt: string) {
     this.donor = person; // Should mean donations are attached to the Stripe Customer.
-    this.prepareDonationCredits(person);
-    this.prefillRarelyChangingFormValuesFromPerson(person);
-    this.loadFirstSavedStripeCardIfAny(id, jwt);
+
+    // Only tokens for Identity users with a password have enough access to load payment methods, use credit
+    // balances and access personal data beyond the anonymous new Customer basics.
+    if (this.identityService.isTokenForFinalisedUser(jwt)) {
+      this.prepareDonationCredits(person);
+      this.prefillRarelyChangingFormValuesFromPerson(person);
+      this.loadFirstSavedStripeCardIfAny(id, jwt);
+    }
   }
 
   onDonationSliderMove = (tipPercentage: number, tipAmount: number) => {

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.html
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.html
@@ -4,7 +4,7 @@
       <p><button mat-raised-button (click)="login()">Log in</button></p>
     </div>
 
-    <div *ngIf="personId && personIsLoginReady && email" class="id-info">
+    <div *ngIf="personId && email" class="id-info">
       <p>Logged in as <strong>{{ email}}</strong></p>
       <p>We'll pre-fill some fields with your saved details, but you can change them if you need to.</p>
       <p *ngIf="creditPenceToUse > 0">Your credit balance will be used and the donation value capped at {{ creditPenceToUse / 100 | exactCurrency:campaign.currencyCode }}</p>

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.ts
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.ts
@@ -15,7 +15,6 @@ export class DonationStartLoginComponent {
   @Input({ required: true }) creditPenceToUse: number;
   @Input({ required: true }) email?: string;
   @Input({ required: true }) personId: string | undefined;
-  @Input({ required: true }) personIsLoginReady: boolean;
   @Input({ required: true }) canLogin: boolean;
 
   constructor(

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -63,7 +63,7 @@ export interface Donation {
 
     optInChampionEmail?: boolean;
 
-    paymentMethodType: 'card' | 'customer_balance';
+    pspMethodType: 'card' | 'customer_balance';
 
     /**
      * Unique ID for a CCampaign / project assigned by Big Give, in Salesforce

--- a/src/app/donation.service.spec.ts
+++ b/src/app/donation.service.spec.ts
@@ -31,7 +31,7 @@ describe('DonationService', () => {
       matchReservedAmount: 500.01,
       optInCharityEmail: true,
       optInTbgEmail: false,
-      paymentMethodType: 'card',
+      pspMethodType: 'card',
       projectId: '11I400000009Sds3e3',
       psp: 'stripe',
       status,

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -75,7 +75,7 @@ export class DonationService {
     return (
       donation.status !== undefined &&
       this.resumableStatuses.includes(donation.status) &&
-      donation.paymentMethodType === paymentMethodType
+      donation.pspMethodType === paymentMethodType
     );
   }
 
@@ -94,7 +94,7 @@ export class DonationService {
     const existingDonations = this.getDonationCouplets().filter(donationItem => {
       return (
         donationItem.donation.projectId === projectId && // Only bring back donations to the same project/CCampaign...
-        this.getCreatedTime(donationItem.donation) > (Date.now() - 600000) && // ...from the past 10 minutes...
+        this.getCreatedTime(donationItem.donation) > (Date.now() - 1_500_000) && // ...from the past 25 minutes...
         this.isResumable(donationItem.donation, paymentMethodType) // ...with a reusable last-known status & method.
       );
     });
@@ -164,7 +164,11 @@ export class DonationService {
     );
   }
 
-  getPaymentMethods(personId?: string, jwt?: string, {cacheBust}: { cacheBust?: boolean} = {cacheBust: false}): Observable<{ data: PaymentMethod[] }> {
+  getPaymentMethods(
+    personId?: string,
+    jwt?: string,
+    {cacheBust}: { cacheBust?: boolean} = {cacheBust: false}
+  ): Observable<{ data: PaymentMethod[] }> {
     const cacheBuster = cacheBust ? ("?t=" + new Date().getTime()) : '';
 
     return this.http.get<{ data: PaymentMethod[] }>(
@@ -311,6 +315,7 @@ export class DonationService {
       this.getPersonAuthHttpOptions(jwt),
     );
   }
+
   updatePaymentMethod(
     person: Person,
     jwt: string,

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -431,7 +431,7 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
       matchReservedAmount: 0, // Tips are always unmatched
       optInCharityEmail: false,
       optInTbgEmail: this.marketingGroup.value.optInTbgEmail,
-      paymentMethodType: 'customer_balance',
+      pspMethodType: 'customer_balance',
       projectId: this.campaign.id,
       psp: 'stripe',
       tipAmount: 0,


### PR DESCRIPTION
* Fix `pspMethodType` typo & resulting donation reuse bug
* Offer donation reuse up to 25 mins after creation, not 10
* Stop trying to load various full account data for Identity users who don't have a password
* Drop bogus prop `personIsLoginReady`, which was being set true for everyone and not used meaningfully