### PR TITLE
BG2-2521: Only send slack alarms on real failures + fix still missing…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,9 +230,8 @@ workflows:
             - deploy-regression-static
           post-steps:
             - slack/notify:
-                # Temporarily sending alarms to test alarm sending setup.
-                channel: deployments, staging-alarms, production-alarms, regression-alarms
-#                event: fail
+                channel: deployments, regression-alarms
+                event: fail
                 template: basic_fail_1
                 mentions: <@here>
       - aws-ecs/deploy-service-update:
@@ -270,13 +269,14 @@ workflows:
           context:
             - docker-hub-creds
             - ecs-deploys
+            - slack
           requires:
             - deploy-staging-static
           post-steps:
             - slack/notify:
                 # Temporarily sending alarms to test alarm sending setup.
-                channel: deployments, staging-alarms, production-alarms, regression-alarms
-#                event: fail
+                channel: deployments, staging-alarms
+                event: fail
                 template: basic_fail_1
                 mentions: <@here>
       - aws-ecs/deploy-service-update:
@@ -312,8 +312,7 @@ workflows:
                     ]
                   }
             - slack/notify:
-                # Temporarily sending alarms to test alarm sending setup.
-                channel: deployments, staging-alarms, production-alarms, regression-alarms
+                channel: deployments, staging-alarms,
                 event: fail
                 template: basic_fail_1
                 mentions: <@here>
@@ -339,8 +338,7 @@ workflows:
             - deploy-production-static
           post-steps:
             - slack/notify:
-                # Temporarily sending alarms to test alarm sending setup.
-                channel: deployments, staging-alarms, production-alarms, regression-alarms
+                channel: deployments, production-alarms
                 event: fail
                 template: basic_fail_1
                 mentions: <@here>


### PR DESCRIPTION
… slack contexts