### PR TITLE
DON-938 – UX & further edge case improvements

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -398,7 +398,7 @@
               <div slot="input" class="sr-input sr-card-element" id="card-info" #cardInfo></div>
             </biggive-text-input>
             <div *ngIf="!captchaIsSolved" class="error" aria-live="polite">
-              <p>Payment fields require the "captcha" puzzle solution to load safely.</p>
+              <p>Payment fields require the "captcha" puzzle to be solved before we can show them safely.</p>
             </div>
             <div>
               Your card information will be held for re-use if you set a password on the next page. It is held securely only with Stripe.

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -599,7 +599,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   async stepChanged(event: StepperSelectionEvent) {
     if (event.selectedStep.label === 'Payment details' && !this.idCaptchaCode) {
-      this.showErrorToast('Sorry, you need to complete the "captcha" puzzle first – this is a fraud control to help protect donors');
+      this.showErrorToast('Sorry, you need to complete the "captcha" puzzle first – this is a fraud control to help protect our donors');
       this.jumpToStep(event.previouslySelectedStep.label);
       this.idCaptcha.execute();
       return;


### PR DESCRIPTION
* if donor has managed to get to the Payment details step, try to jump to the previous step
* if that happens, show a toast explaining why
* if they are somehow on Payment Details without a captcha code, also explain why the fields are unavailable next to where they should load on the page

Not tested end to end yet, but screenshots from local dev wip:

<img width="874" alt="Screenshot 2023-11-30 at 11 17 47" src="https://github.com/thebiggive/donate-frontend/assets/3274454/69a938cb-731d-40c2-accc-586e3995b31c">

<img width="607" alt="Screenshot 2023-11-30 at 11 17 39" src="https://github.com/thebiggive/donate-frontend/assets/3274454/b2ecbca4-03e6-44ea-9af6-c52bb05c9de5">