### PR TITLE
DON-938 – rationalise various captcha + step management

### DIFF
--- a/src/app/donation-complete/donation-complete.component.ts
+++ b/src/app/donation-complete/donation-complete.component.ts
@@ -36,7 +36,6 @@ export class DonationCompleteComponent implements OnInit {
   loggedIn = false;
   minPasswordLength: number;
   noAccess = false;
-  offerToSetPassword = false;
   encodedPrefilledText: string;
   recaptchaIdSiteKey = environment.recaptchaIdentitySiteKey;
   registerError?: string;
@@ -206,7 +205,6 @@ export class DonationCompleteComponent implements OnInit {
               next: person => {
                 this.patchedCorePersonInfo = true;
                 this.person = person;
-                this.offerToSetPassword = !person.has_password;
               },
               error: (error: HttpErrorResponse) => {
                 // For now we probably don't really need to inform donors if we didn't patch their Person data, and just won't ask them to

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -395,8 +395,11 @@
           <div class="sr-combo-inputs-row">
             <biggive-text-input>
               <span slot="label">Payment Method</span> <!-- no label because we don't have a labelable form element - the card form is supplied by Stripe not us -->
-            <div slot="input" class="sr-input sr-card-element" id="card-info" #cardInfo></div>
+              <div slot="input" class="sr-input sr-card-element" id="card-info" #cardInfo></div>
             </biggive-text-input>
+            <div *ngIf="!captchaIsSolved" class="error" aria-live="polite">
+              <p>Payment fields require the "captcha" puzzle to be solved before we can show them safely.</p>
+            </div>
             <div>
               Your card information will be held for re-use if you set a password on the next page. It is held securely only with Stripe.
             </div>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -403,7 +403,7 @@
               <span slot="label">Payment Method</span> <!-- no label because we don't have a labelable form element - the card form is supplied by Stripe not us -->
               <div slot="input" class="sr-input sr-card-element" id="card-info" #cardInfo></div>
             </biggive-text-input>
-            <div *ngIf="!captchaIsSolved" class="error" aria-live="polite">
+            <div *ngIf="!donor" class="error" aria-live="polite">
               <p>Payment fields require the "captcha" puzzle to be solved before we can show them safely.</p>
             </div>
             <div>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -207,7 +207,7 @@
             class="continue b-w-100 b-rt-0"
             mat-raised-button
             color="primary"
-            (click)="progressFromStepOne()"
+            (click)="progressToNonAmountsStep()"
           >Continue</button>
       </div>
       </mat-step>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -982,7 +982,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     }
 
     this.idCaptchaCode = captchaResponse;
-    if (!this.donation) {
+    if (!this.donation && this.donationAmount > 0) {
       this.createDonationAndMaybePerson();
     }
   }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -709,6 +709,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     // We need to check the current index in the stepper because we've seen this fire as soon
     // as the step *before* 'Payment details' loads and initialises the Stripe Payment element.
     if (!this.donation || !this.stripePaymentMethodReady || !this.stripePaymentElement || !this.stripeElements) {
+      // Gift Aid step is only shown (at step index 1) when campaign is in GBP.
       const paymentStepIndex = this.donation?.currencyCode === 'GBP' ? 2 : 1;
       if (this.stepper.selectedIndex > paymentStepIndex) {
         this.jumpToStep('Payment details');

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1308,16 +1308,20 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   private markYourDonationStepIncomplete() {
     const step = this.stepper.steps.get(0);
-    if (step) {
-      step.completed = false;
+    if (!step) {
+      throw new Error('Step 0 not found');
     }
+
+    step.completed = false;
   }
 
   private markYourDonationStepComplete() {
     const step = this.stepper.steps.get(0);
-    if (step) {
-      step.completed = true;
+    if (!step) {
+      throw new Error('Step 0 not found');
     }
+
+    step.completed = true;
   }
 
   private destroyStripeElements() {

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -508,16 +508,6 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     const stepperHeaders = stepper.getElementsByClassName('mat-step-header');
     for (const stepperHeader of stepperHeaders) {
       stepperHeader.addEventListener('click', (clickEvent: any) => {
-        if (clickEvent.target.index > 0 && !this.donor && !this.idCaptchaCode && !this.donation) {
-          // Disallow any step jumps by header click without a valid captcha, since the donor could have
-          // dismissed the puzzle (including by accident) and they'll face errors later, which are more annoying,
-          // without a working code.
-          clickEvent?.preventDefault();
-          this.promptForCaptcha();
-          this.jumpToStep(this.yourDonationStepLabel);
-          return;
-        }
-
         if (clickEvent.target.index > 0) {
           this.progressFromStepOne(); // Handles amount error if needed, like Continue button does.
           return;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -509,7 +509,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     for (const stepperHeader of stepperHeaders) {
       stepperHeader.addEventListener('click', (clickEvent: any) => {
         if (clickEvent.target.index > 0) {
-          this.progressFromStepOne(); // Handles amount error if needed, like Continue button does.
+          this.progressToNonAmountsStep(); // Handles amount error if needed, like Continue button does.
           return;
         }
 
@@ -1081,7 +1081,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     }
   }
 
-  progressFromStepOne() {
+  /**
+   * Validates the `amounts` group, then calls the general step change fn `next()`. Used by both
+   * the first Continue button and by the step header click handler, which I think helped guard
+   * against a scenario where one might get 'stuck' without seeing the amount error that explains why.
+   */
+  progressToNonAmountsStep() {
     const control = this.donationForm.controls['amounts'];
     if(! control!.valid) {
       this.showErrorToast(this.displayableAmountsStepErrors() || 'Sorry, there was an error with the donation amount or tip amount');

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -580,7 +580,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   async stepChanged(event: StepperSelectionEvent) {
     if (event.selectedIndex > 0 && !this.donor) {
-      if (event.selectedIndex > 1) {
+      if (event.selectedIndex >= this.paymentStepIndex) {
         // Try to help explain why they're blocked in cases of persistent later step heading clicks etc.
         this.showErrorToast("Sorry, you must complete the puzzle to proceed; this is a security measure to protects donors' cards");
         // Immediate step jumps seem to be disallowed
@@ -709,9 +709,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     // We need to check the current index in the stepper because we've seen this fire as soon
     // as the step *before* 'Payment details' loads and initialises the Stripe Payment element.
     if (!this.donation || !this.stripePaymentMethodReady || !this.stripePaymentElement || !this.stripeElements) {
-      // Gift Aid step is only shown (at step index 1) when campaign is in GBP.
-      const paymentStepIndex = this.donation?.currencyCode === 'GBP' ? 2 : 1;
-      if (this.stepper.selectedIndex > paymentStepIndex) {
+      if (this.stepper.selectedIndex > this.paymentStepIndex) {
         this.jumpToStep('Payment details');
       }
 
@@ -933,6 +931,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     return this.donationForm.controls.amounts!.get('tipAmount');
   }
 
+  /**
+   * Gift Aid step is only shown (at step index 1) when campaign is in GBP.
+   */
+  get paymentStepIndex() {
+    return this.donation?.currencyCode === 'GBP' ? 2 : 1;
+  }
 
   /**
    * Quick getter for donation amount, to keep template use concise.

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -268,7 +268,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   ngOnDestroy() {
     if (this.donation) {
-      this.clearDonation(this.donation, false, false);
+      this.clearDonation(this.donation, {clearAllRecord: false, jumpToStart: false});
     }
 
     this.destroyStripeElements();
@@ -434,7 +434,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
             if (this.donation) {
               // We already know the requested amount, so no need to jump back.
-              this.clearDonation(this.donation, true, false);
+              this.clearDonation(this.donation, {clearAllRecord: true, jumpToStart: false});
             }
             this.createDonationAndMaybePerson();
           });
@@ -619,7 +619,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
           if (this.donation) {
             // We know the new amount already, so no need to jump back.
-            this.clearDonation(this.donation, true, false);
+            this.clearDonation(this.donation, {clearAllRecord: true, jumpToStart: false});
           }
           this.createDonationAndMaybePerson();
         });
@@ -1054,7 +1054,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     // when we know we have only just hidden the error in this call.
     if (this.donationCreateError && this.stepper.selected?.label === this.yourDonationStepLabel) {
       if (this.donation) {
-        this.clearDonation(this.donation, true, true);
+        this.clearDonation(this.donation, {clearAllRecord: true, jumpToStart: true});
         this.matomoTracker.trackEvent(
           'donate',
           'create_retry',
@@ -1820,7 +1820,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
    *                        this should be false. In other cases we need to know the new amount so it
    *                        should usually be true, if the page is not being unloaded.
    */
-  private clearDonation(donation: Donation, clearAllRecord: boolean, jumpToStart: boolean) {
+  private clearDonation(donation: Donation, {clearAllRecord, jumpToStart}: {clearAllRecord: boolean; jumpToStart: boolean}) {
     if (clearAllRecord) { // i.e. don't keep donation around for /thanks/... or reuse.
       this.donationService.removeLocalDonation(donation);
     }
@@ -2157,7 +2157,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
             this.matomoTracker.trackEvent('donate', 'cancel', `Donor cancelled donation ${donation.donationId} to campaign ${this.campaignId}`),
 
             // Also resets captcha.
-            this.clearDonation(donation, true, true);
+            this.clearDonation(donation, {clearAllRecord: true, jumpToStart: true});
 
             // Go back to 1st step to encourage donor to try again
             this.stepper.reset();

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1825,7 +1825,8 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
    * and returns to step 1 so required input can be collected again.
    * We DON'T reset `this.donor`, so there should be no need for a new captcha code.
    *
-   * @param jumpToStart If the caller is already setting up a known-value donation alongside the clear,
+   * @param clearAllRecord  Don't keep donation around for /thanks/... or reuse.
+   * @param jumpToStart     If the caller is already setting up a known-value donation alongside the clear,
    *                        this should be false. In other cases we need to know the new amount so it
    *                        should usually be true, if the page is not being unloaded.
    */

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -78,7 +78,6 @@ declare var _paq: {
   ]
 })
 export class DonationStartFormComponent implements AfterContentChecked, AfterContentInit, OnDestroy, OnInit {
-  @ViewChild('captcha') captcha: RecaptchaComponent;
   @ViewChild('idCaptcha') idCaptcha: RecaptchaComponent;
   @ViewChild('cardInfo') cardInfo: ElementRef;
   @ViewChild('stepper') private stepper: MatStepper;
@@ -193,7 +192,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   private idCaptchaCode?: string;
   private stripeResponseErrorCode?: string; // stores error codes returned by Stripe after callout
-  private stepChangedBlockedByCaptcha = false;
+  private stepChangeBlockedByCaptcha = false;
   @Input({ required: true }) donor: Person | undefined;
 
   /**
@@ -508,6 +507,31 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     const stepperHeaders = stepper.getElementsByClassName('mat-step-header');
     for (const stepperHeader of stepperHeaders) {
       stepperHeader.addEventListener('click', (clickEvent: any) => {
+        // Disallow any step jumps by header click without a valid captcha, since the donor could have
+        // dismissed the puzzle (including by accident) and they'll face errors later, which are more annoying,
+        // without a working code. If they click step 1 while on step 1 this might fire the captcha slightly
+        // earlier than normal, but that should be mostly harmless – at worst if they take that unusual
+        // step they might have to solve 2 puzzles.
+
+        // For now, I've gone with only checking this on header click because the other way of changing step
+        // is, as far as we know, working. And we want to minimise the change during CC23. A better solution
+        // later might be to remove all the captcha executes that happen specifically on button clicks (`next()`)
+        // and to execute it in `stepChanged()` – except when just booted back to step 0 – instead.
+        if (!this.idCaptchaCode) {
+          clickEvent.preventDefault();
+
+          try {
+            this.idCaptcha.reset();
+          } catch (e) {
+            this.matomoTracker.trackEvent('identity_error', 'step_change_captcha_reset_failed', e.message);
+            this.reset(); // Includes page refresh atm – annoying but less so than filling out even more broken fields.
+            return;
+          }
+
+          this.idCaptcha.execute();
+          return;
+        }
+
         if (clickEvent.target.innerText.includes('Your details') && this.stepper.selected?.label === 'Gift Aid') {
           this.triedToLeaveGiftAid = true;
         }
@@ -533,8 +557,11 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     this.paymentReadinessTracker = new PaymentReadinessTracker(this.paymentGroup,);
     this.donationForm.reset();
     this.identityService.clearJWT();
-    this.idCaptcha.reset();
     this.destroyStripeElements();
+
+    // We should probably reinstate `this.idCaptcha.reset();` here iff we replace the full
+    // location.reload(). For as long as we are unloading the whole doc, there should be
+    // no need to reset the ViewChild.
 
     location.reload();
   }
@@ -571,6 +598,13 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   }
 
   async stepChanged(event: StepperSelectionEvent) {
+    if (event.selectedStep.label === 'Payment details' && !this.idCaptchaCode) {
+      this.showErrorToast('Sorry, you need to complete the "captcha" puzzle first – this is a fraud control to help protect our donors');
+      this.jumpToStep(event.previouslySelectedStep.label);
+      this.idCaptcha.execute();
+      return;
+    }
+
     // We need to allow enough time for the Stepper's animation to get the window to
     // its final position for this step, before this scroll position update can be reliably
     // helpful.
@@ -941,9 +975,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       this.idCaptchaCode = undefined;
       return;
     }
-    if (this.stepChangedBlockedByCaptcha) {
+
+    if (this.stepChangeBlockedByCaptcha) {
       this.stepper.next();
-      this.stepChangedBlockedByCaptcha = false;
+      this.stepChangeBlockedByCaptcha = false;
     }
 
     this.idCaptchaCode = captchaResponse;
@@ -985,7 +1020,6 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     return this.donationAmount + this.giftAidAmount() + this.expectedMatchAmount();
   }
 
-
   scrollTo(el: Element): void {
     if (el) {
        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -1025,7 +1059,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     const promptingForCaptcha = this.promptForCaptcha();
 
     if (promptingForCaptcha) {
-      this.stepChangedBlockedByCaptcha = true;
+      this.stepChangeBlockedByCaptcha = true;
       return;
     }
 
@@ -1545,7 +1579,18 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       return false;
     }
 
-    this.idCaptcha.reset();
+    try {
+      this.idCaptcha.reset();
+    } catch (e) {
+      // The donor may be having connection problems, and we've seen reCAPTCHA behave weirdly if the
+      // @ViewChild doesn't have a working, mounted element here. To avoid wasting donors' time and
+      // failing later, track so we can measure frequency and attempt a full reset – which currently
+      // includes a page reload.
+      this.matomoTracker.trackEvent('identity_error', 'person_captcha_reset_failed', e.message);
+      this.reset();
+      return true; // Make sure callers treat this as "not ready", while we finish reloading.
+    }
+
     this.idCaptcha.execute(); // Prepare for a Person create which needs an Identity captcha.
 
     return true;
@@ -1730,6 +1775,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     }
   }
 
+  /**
+   * Also resets captcha & relevant donation persistence state mgmt,
+   * and returns to step 1 so required input can be collected again.
+   */
   private clearDonation(donation: Donation, clearAllRecord: boolean) {
     if (clearAllRecord) { // i.e. don't keep donation around for /thanks/... or reuse.
       this.donationService.removeLocalDonation(donation);
@@ -1740,6 +1789,13 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     // Ensure we get a new code on donation setup if person ID somehow gets cleared. Sending a code we
     // already verified again will fail and block creating a new person without a page refresh.
     this.idCaptchaCode = undefined;
+    try {
+      this.idCaptcha.reset();
+    } catch (e) {
+      this.matomoTracker.trackEvent('identity_error', 'person_captcha_reset_failed_during_clear', e.message);
+      this.reset();
+      return;
+    }
 
     this.creatingDonation = false;
     this.donationCreateError = false;
@@ -1754,6 +1810,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     delete this.donation;
     this.donationChangeCallBack(undefined)
+
+    // If we are clearing the donation, then any attempts to submit() if donor is further down the
+    // form are doomed to fail.
+    this.jumpToStep(this.yourDonationStepLabel);
   }
 
   private promptToContinueWithNoMatchingLeft(donation: Donation) {
@@ -1807,7 +1867,6 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       tipAmount: tipOrFeeAmount,
     });
   };
-
 
   private setConditionalValidators(): void {
     // Do not add a validator on `tipPercentage` because as a dropdown it always
@@ -1996,6 +2055,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     return this.paymentReadinessTracker.readyToProgressFromPaymentStep;
   }
 
+  get captchaIsSolved(): boolean {
+    return this.idCaptchaCode !== undefined;
+  }
+
   private promptToContinue(
     title: string,
     status: string,
@@ -2067,11 +2130,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
           () => {
             this.matomoTracker.trackEvent('donate', 'cancel', `Donor cancelled donation ${donation.donationId} to campaign ${this.campaignId}`),
 
+            // Also resets captcha.
             this.clearDonation(donation, true);
 
             // Go back to 1st step to encourage donor to try again
-            this.captcha.reset();
-            this.idCaptcha.reset();
             this.stepper.reset();
             this.amountsGroup.patchValue({ tipPercentage: this.tipPercentage });
             this.tipPercentageChanged = false;

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -30,8 +30,6 @@ export interface Donation {
      */
     charityId: string;
 
-    creationRecaptchaCode?: string;
-
     /**
      * ISO 4217 code for the currency in which all monetary values are denominated.
      */


### PR DESCRIPTION
* fix the condition for showing last-resort 'no captcha' error message in 'Payment details' step – our goal is still to make it impossible to see this through earlier step change checks & restrictions
* fix attempts to create undefined amount donations if amount field's empty
* jump back to 'Your donation' step only when we need to collect a [new] amount
* fix when we show a "toast" when dismissed captchas mean donor has got to a point
that can't work;
and jump back a step then too to avoid showing unusable fields
* invoke the captcha from the same common place in code, with the same associated
state changes, every time
* pick up on stepper header clicks more reliably
* check for `this.donor` when assessing captcha readiness, since if we have a valid
donor already we don't need to issue new captcha puzzles