### PR TITLE
MAT-339: Display generic error message in case of 500 from matchbot o…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1345,12 +1345,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   }
 
   private handleStripeError(
-    error: StripeError | {message: string, code: string, decline_code?: string},
+    error: StripeError | {message: string, code: string, decline_code?: string} | undefined,
     context: string,
   ) {
     this.submitting = false;
     this.stripeError = this.getStripeFriendlyError(error, context);
-    this.stripeResponseErrorCode = error.code;
+    this.stripeResponseErrorCode = error?.code;
     if (this.isBillingPostcodePossiblyInvalid()) {
       this.paymentGroup.controls.billingPostcode!.setValidators([
         Validators.required,
@@ -1369,9 +1369,14 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
    * @param context 'method_setup', 'card_change' or 'confirm'.
    */
   private getStripeFriendlyError(
-    error: StripeError | {message: string, code: string, decline_code?: string},
+    error: StripeError | {message: string, code: string, decline_code?: string} | undefined,
     context: string,
   ): string {
+    if (! error) {
+      return "Sorry, we encountered an error trying to take your donation. Please try again in a moment or contact " +
+        " us if this message persists.";
+    }
+
     let prefix = '';
     switch (context) {
       case 'method_setup':


### PR DESCRIPTION
…n donation confirm

Currently we show an error message if Stripe throws a CardError, but if it returns some other exception we don't display any error.

I'm not 100% sure if we should encorage the donor to retry at this point, just in case there's some unexpected error that happens after the donation is confirmed and they end up double donating. Stripe won't allow double donating from one payment intent, but potentially the donor could go back and make a new intent.

Need to think about the wording of the message.