### PR TITLE
MAT-339: Display error description from server on payment confirm if …

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1456,7 +1456,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     if (! error || (! error.message && ! error.code)) {
       if (error && error.hasOwnProperty('description')) {
-        // @ts-ignore - not sure why TS doesn't recognise that it must have a description because I jsut checked
+        // @ts-ignore - not sure why TS doesn't recognise that it must have a description because I just checked
         // with hasOwnProperty.
         return `${prefix}${error!.description}`;
       }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -733,7 +733,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       );
       return;
     }
-    
+
     if (!this.donation) {
       const errorCodeDetail = '[code A1]'; // Donation property absent.
 
@@ -1436,9 +1436,11 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
    * @param context 'method_setup', 'card_change' or 'confirm'.
    */
   private getStripeFriendlyError(
-    error: StripeError | {message: string, code: string, decline_code?: string} | undefined,
+    error: StripeError | {message: string, code: string, decline_code?: string, description?: string} | undefined,
     context: string,
   ): string {
+
+    console.log({error, context})
 
     let prefix = '';
     switch (context) {
@@ -1452,7 +1454,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
         prefix = 'Payment processing failed: ';
     }
 
-    if (! error) {
+    if (! error || (! error.message && ! error.code)) {
+      if (error && error.hasOwnProperty('description')) {
+        // @ts-ignore - not sure why TS doesn't recognise that it must have a description because I jsut checked
+        // with hasOwnProperty.
+        return `${prefix}${error!.description}`;
+      }
       return `${prefix}Sorry, we encountered an error. Please try again in a moment or contact us if this message persists.`;
     }
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1440,7 +1440,6 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     context: string,
   ): string {
 
-    console.log({error, context})
 
     let prefix = '';
     switch (context) {


### PR DESCRIPTION
…no other details available.

I made Matchbot throw an error artificially to test this.  We'd rather not any error show up like this, but if we do this gives us more to go on to fix it.

Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/3766618b-75b2-4eef-972c-f7e610471f5b)


After

![image](https://github.com/thebiggive/donate-frontend/assets/159481/3fa1566c-d08a-4fda-87c0-18ff89dd2320)
