### PR TITLE
BG2-2526: Improve reset password error display

### DIFF
--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -16,9 +16,29 @@
     diameter="15"
   ></mat-spinner>
 
+
+  <p *ngIf="saveSuccessful">
+    You have reset your password. Please click <a href="/">here</a> for the homepage, or <a href="/transfer-funds">here</a> to transfer donation funds to your account.
+  </p>
+
+  <!-- Note: check explicitly for `saveSuccessful === false` here, not for `!saveSuccessful`,
+  because `saveSuccessful` has can be undefined, false, or true, all with a unique meaning. -->
+  <p *ngIf="saveSuccessful === false && ! errorMessageHtml" class="error">
+    Sorry, there was an error saving your new password. Your link may have expired. Please <a href="https://community.biggive.org/s/contact-us" target="_blank">contact us</a> if this message persists.
+  </p>
+
+  <div *ngIf="saveSuccessful === false && errorMessageHtml">
+    <!-- Setting HTML like this could be dangerous, but we trust the Identity server that supplied this HTML code to have given us a good error message -->
+    <p class="error" [innerHtml]="errorMessageHtml"></p>
+  </div>
+
+  <div *ngIf="tokenValid === false"  class="error">
+    Sorry, your link may have expired. Please <a href="https://community.biggive.org/s/contact-us" target="_blank">contact us</a> if this message persists.
+  </div>
+
   <!-- Note: check explicitly for `undefined` here, not for `!saveSuccessful`, because
   `saveSuccessful` has can be undefined, false, or true, all with a unique meaning. -->
-  <div *ngIf="saveSuccessful === undefined && !savingNewPassword && tokenValid">
+  <div *ngIf="(saveSuccessful === undefined || errorMessageHtml) && !savingNewPassword && tokenValid">
     <form [formGroup]="passwordForm">
       <p class="b-rt-0">Please enter your new password (min {{ minPasswordLength }} characters)</p>
       <mat-form-field color="primary">
@@ -45,23 +65,4 @@
   <div *ngIf="saveSuccessful === undefined && savingNewPassword">
     <mat-spinner [diameter]="40" aria-label="Loading your details"></mat-spinner>
   </div>
-
-  <p *ngIf="saveSuccessful">
-    You have reset your password. Please click <a href="/">here</a> for the homepage, or <a href="/transfer-funds">here</a> to transfer donation funds to your account.
-  </p>
-
-  <!-- Note: check explicitly for `saveSuccessful === false` here, not for `!saveSuccessful`,
-  because `saveSuccessful` has can be undefined, false, or true, all with a unique meaning. -->
-  <p *ngIf="saveSuccessful === false && ! errorMessage" class="error">
-    Sorry, there was an error saving your new password. Your link may have expired. Please <a href="https://community.biggive.org/s/contact-us" target="_blank">contact us</a> if this message persists.
-  </p>
-
-  <p *ngIf="saveSuccessful === false && errorMessage" class="error">
-    {{errorMessage}}
-  </p>
-
-  <div *ngIf="tokenValid === false"  class="error">
-    Sorry, your link may have expired. Please <a href="https://community.biggive.org/s/contact-us" target="_blank">contact us</a> if this message persists.
-  </div>
-
 </main>

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -15,7 +15,7 @@ export class ResetPasswordComponent implements OnInit {
   passwordForm: FormGroup;
   savingNewPassword: boolean = false;
   saveSuccessful: boolean|undefined = undefined;
-  errorMessage: string | undefined;
+  errorMessageHtml: string | undefined;
   token: string;
   tokenValid: boolean|undefined = undefined;
 
@@ -69,12 +69,13 @@ export class ResetPasswordComponent implements OnInit {
     this.identityService.resetPassword(this.passwordForm.controls.password!.value, this.token).subscribe({
       next: (_) => {
         this.savingNewPassword = false;
+        this.errorMessageHtml = undefined;
         this.saveSuccessful = true;
       },
       error: (error) => {
         this.savingNewPassword = false;
         this.saveSuccessful = false;
-        this.errorMessage = error.error?.error?.description;
+        this.errorMessageHtml = error.error?.error?.description;
       },
     });
   };


### PR DESCRIPTION
This will be better with accompanying changes in Identity, but should be fine to deploy independantly first

Changes:

- Treat the error message from the server as HTML, so that it can include a link to our privacy policy
- Don't hide the form when the error message is displayed, so the donor can try again.

With the changes in identity, if I try to set my password to "correct horse battery staple" then I get this:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/97a5068b-d6f8-444a-ba26-ebfb2e831ae8)

When this is deployed without the accompanying changes in identity server, it will initially look like this:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/70cd4f04-d7d8-46ae-abc9-17350aa8fb3a)

