### PR TITLE
DON-752: Refactor: try to privatise IdentityService.saveJWT

### DIFF
--- a/src/app/donation-complete/donation-complete.component.ts
+++ b/src/app/donation-complete/donation-complete.component.ts
@@ -66,7 +66,7 @@ export class DonationCompleteComponent implements OnInit {
 
   ngOnInit() {
     this.checkDonation();
-    
+
     this.minPasswordLength = minPasswordLength;
 
     this.identityService.getLoggedInPerson().subscribe((person: Person|null) => {
@@ -126,7 +126,7 @@ export class DonationCompleteComponent implements OnInit {
     };
 
     this.identityService.login(credentials).subscribe({
-      next: response => {
+      next: _response => {
         // It's still the same person, just an upgraded / "complete" token. So for now just recycle the ID. We'll probably improve
         // `/auth` to return the ID separately soon, so we can do a normal login form that's able to call this without
         // having to decode the JWT (though maybe that's a good thing for the frontend to be able to do anyway?).
@@ -134,8 +134,6 @@ export class DonationCompleteComponent implements OnInit {
         // gives no visual indication that a longer-term token's been
         // set up yet.
         console.log('Upgraded local token to a long-lived one with more permissions');
-        this.identityService.saveJWT(this.person?.id as string, response.jwt);
-        this.identityService.loginStatusChanged.emit(true);
       },
       error: (error: HttpErrorResponse) => {
         this.matomoTracker.trackEvent('identity_error', 'login_failed', `${error.status}: ${error.message}`);

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1612,6 +1612,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       person.captcha_code = this.idCaptchaCode;
       this.identityService.create(person).subscribe(
         (person: Person) => {
+          // would like to move the line below inside `identityService.create` but that caused test errors when I tried
           this.identityService.saveJWT(person.id as string, person.completion_jwt as string);
           this.donor = person;
           donation.pspCustomerId = person.stripe_customer_id;

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -5,7 +5,7 @@ import {CookieService} from 'ngx-cookie-service';
 import {MatomoTracker} from 'ngx-matomo';
 import {StorageService} from 'ngx-webstorage-service';
 import {Observable, of} from 'rxjs';
-import {delay, retry} from 'rxjs/operators';
+import {delay, retry, tap} from 'rxjs/operators';
 
 import {Credentials} from './credentials.model';
 import {environment} from '../environments/environment';
@@ -41,11 +41,16 @@ export class IdentityService {
     private cookieService: CookieService,
   ) {}
 
-  login(credentials: Credentials): Observable<{ jwt: string}> {
-    return this.http.post<{ jwt: string}>(
+  login(credentials: Credentials): Observable<{ id: string, jwt: string}> {
+    return this.http.post<{ id: string, jwt: string }>(
       `${environment.identityApiPrefix}${this.loginPath}`,
       credentials,
-    );
+    ).pipe(tap({
+      next: (response)  => {
+        this.saveJWT(response.id, response.jwt);
+        this.loginStatusChanged.emit(true);
+      }
+    }));
   }
 
   getResetPasswordToken(email: string, captchaCode: string): Observable<[]> {
@@ -79,7 +84,15 @@ export class IdentityService {
   create(person: Person): Observable<Person> {
     return this.http.post<Person>(
       `${environment.identityApiPrefix}${this.peoplePath}`,
-      person);
+      person).pipe(
+        tap((_person) => {
+          // I would like to run:
+          //      this.saveJWT(person.id as string, person.completion_jwt as string);
+          // here and then make saveJWT private - and it seems to work with manual tests
+          // but it's generating errors "InvalidTokenError: Invalid token specified" in unit tests. Not sure why.
+          this.loginStatusChanged.emit(true);
+        })
+    )
   }
 
   get(id: string, jwt: string, {withTipBalances = false}: {withTipBalances?: boolean} = {}): Observable<Person> {

--- a/src/app/login-modal/login-modal.component.ts
+++ b/src/app/login-modal/login-modal.component.ts
@@ -88,7 +88,6 @@ export class LoginModalComponent implements OnInit {
       };
 
       this.identityService.login(credentials).subscribe((response: { id: string, jwt: string }) => {
-        this.identityService.saveJWT(response.id, response.jwt);
         this.dialogRef.close(response);
         this.loggingIn = false;
       }, (error) => {

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -159,9 +159,7 @@ export class LoginComponent implements OnInit, OnDestroy{
       };
 
       this.identityService.login(credentials).subscribe({
-        next: (response: { id: string, jwt: string }) => {
-          // todo - see if we can make login do `saveJWT` internally and delete it here?
-          this.identityService.saveJWT(response.id, response.jwt);
+        next: (_response: { id: string, jwt: string }) => {
           // assign window.location rather than the more angular-proper way of
           // this.router.navigateByUrl('/') because we need to force the main menu to be updated
           // to show that we're now logged in.

--- a/src/app/register-modal/register-modal.component.ts
+++ b/src/app/register-modal/register-modal.component.ts
@@ -80,7 +80,6 @@ export class RegisterModalComponent implements OnInit {
         email_address: this.form.value.emailAddress,
         raw_password: this.form.value.password,
       }).subscribe((response: { id: string, jwt: string }) => {
-        this.identityService.saveJWT(response.id, response.jwt);
         this.dialogRef.close(response);
         this.registering = false;
       }, (error) => {
@@ -108,6 +107,7 @@ export class RegisterModalComponent implements OnInit {
       first_name: this.form.value.firstName,
       last_name: this.form.value.lastName,
     }).subscribe(initialPerson => {
+      // would like to move the line below inside `identityService.create` but that caused test errors when I tried
       this.identityService.saveJWT(initialPerson.id as string, initialPerson.completion_jwt as string);
 
       initialPerson.raw_password = this.form.value.password;


### PR DESCRIPTION
I tried to make saveJWT a private function but that led to test errors - not sure exactly what was going wrong in that commit. See https://app.circleci.com/pipelines/github/thebiggive/donate-frontend/4857/workflows/cd11916a-8540-4abd-bf3f-d47932774f73/jobs/13879

But this goes part of the way, adding the call to saveJWT inside IdentityService.login so that callers to that don't need to also call saveJWT.