### PR TITLE
DON-948: Don't display logged in status on donate page if donor has n…

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -91,7 +91,9 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
     this.identityService.get(id, jwt).subscribe({
       next: (person: Person) => {
         this.donor = person; // Should mean donations are attached to the Stripe Customer.
-        this.loggedInEmailAddress = person.email_address;
+        if (this.identityService.probablyHaveLoggedInPerson()) {
+          this.loggedInEmailAddress = person.email_address;
+        }
         this.donationStartForm.loadPerson(person, id, jwt);
         this.donationStartForm.resumeDonationsIfPossible();
 


### PR DESCRIPTION
…ot set a password

This is needed for consistency with the rest of the site, which doesn't treat you as really "logged in" unless you have set a password for your account.

Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/5c478578-15da-4511-9eb4-a159ab068e24)


After:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/7fa0fd72-d227-486d-a9f3-76592dc25439)
