### PR TITLE
DON-919: Update homepage cards - 2024 application season

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -10,7 +10,7 @@ import {environment} from "../../environments/environment";
 
 const CCCloseDate = new Date('2023-12-05T12:00:00+00:00');
 const Jan8th = new Date('2024-01-08T12:00:00+00:00');
-const Feb9th = new Date('2024-02-09T12:00:00+00:00');
+const Feb9th = new Date('2024-02-09T23:59:59+00:00');
 const ArtsForImpactApplicationCloseDate = new Date('2023-12-16T00:00:00+00:00');
 const GMFApplicationCloseDate = new Date('2024-01-17T00:00:00+00:00');
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -8,8 +8,9 @@ import {PageMetaService} from '../page-meta.service';
 import {HighlightCard} from "./HighlightCard";
 import {environment} from "../../environments/environment";
 
-const CCOpenDate = new Date('2023-11-28T12:00:00+00:00');
-const CCCloseDate = new Date('2023-12-05T12:00:00+00:00')
+const CCCloseDate = new Date('2023-12-05T12:00:00+00:00');
+const Jan8th = new Date('2024-01-08T12:00:00+00:00');
+const Feb9th = new Date('2024-02-09T12:00:00+00:00');
 const ArtsForImpactApplicationCloseDate = new Date('2023-12-16T00:00:00+00:00');
 const GMFApplicationCloseDate = new Date('2024-01-17T00:00:00+00:00');
 
@@ -35,32 +36,32 @@ export class HomeComponent implements OnInit {
 
   private highlightCards: readonly HighlightCard[] = [
     {
+      appearAt: Jan8th,
+      disappearAt: Feb9th,
+      headerText: 'Applications for Kind²Mind are now open!',
+      bodyText: 'Apply by February 9th 2024',
+      iconColor: "brand-mhf-turquoise",
+      backgroundImageUrl: new URL('/assets/images/turquoise-texture.jpg', environment.donateGlobalUriPrefix),
+      button: {
+        text: 'Apply now',
+        href: new URL('/kind2mind/', environment.blogUriPrefix)
+      }
+    },
+    {
+      appearAt: Jan8th,
+      disappearAt: Feb9th,
+      headerText: 'Applications for Champions for Children by The Childhood Trust are now open!',
+      bodyText: 'Apply by February 9th 2024',
+      iconColor: "brand-c4c-orange",
+      backgroundImageUrl: new URL('/assets/images/colour-orange.png', environment.donateGlobalUriPrefix),
+      button: {
+        text: 'Apply now',
+        href: new URL('/champions-for-children/', environment.blogUriPrefix)
+      }
+    },
+    {
       appearAt: 'asap',
-      disappearAt: CCOpenDate,
-      headerText: 'Christmas Challenge 2023 is starting soon!',
-      bodyText: 'Save the date 28th November - 5th December 2023',
-      iconColor: "brand-cc-red",
-      backgroundImageUrl: new URL('/assets/images/card-background-cc-lights.jpg', environment.donateGlobalUriPrefix),
-      button: {
-        text: 'Find out more',
-        href: new URL('/christmas-challenge-2023', environment.donateGlobalUriPrefix)
-      }
-    },
-    {
-      appearAt: CCOpenDate,
-      disappearAt: CCCloseDate,
-      headerText: 'Double the difference - Christmas Challenge',
-      bodyText: '28th November - 5th December 2023',
-      iconColor: "brand-cc-red",
-      backgroundImageUrl: new URL('/assets/images/card-background-cc-lights.jpg', environment.donateGlobalUriPrefix),
-      button: {
-        text: 'Donate now',
-        href: new URL('/christmas-challenge-2023', environment.donateGlobalUriPrefix)
-      }
-    },
-    {
-      appearAt: CCCloseDate,
-      disappearAt: 'never',
+      disappearAt: Jan8th,
       headerText: 'Christmas Challenge 2023',
       bodyText: '28th November - 5th December 2023',
       iconColor: "brand-cc-red",
@@ -95,8 +96,20 @@ export class HomeComponent implements OnInit {
       }
     },
     {
-      appearAt: ArtsForImpactApplicationCloseDate,
-      disappearAt: "never",
+      appearAt: 'asap',
+      disappearAt: Jan8th,
+      headerText: "One donation. Twice the impact.",
+      bodyText: 'You donate.\nWe double it.',
+      backgroundImageUrl: new URL('/assets/images/blue-texture.jpg', environment.donateGlobalUriPrefix),
+      iconColor: 'primary',
+      button: {
+        text: "Explore now",
+        href: new URL('/explore/', environment.donateGlobalUriPrefix)
+      }
+    },
+    {
+      appearAt: GMFApplicationCloseDate,
+      disappearAt: 'never',
       headerText: "One donation. Twice the impact.",
       bodyText: 'You donate.\nWe double it.',
       backgroundImageUrl: new URL('/assets/images/blue-texture.jpg', environment.donateGlobalUriPrefix),


### PR DESCRIPTION
Screenshot as it looks now (same as in prod already):

![image](https://github.com/thebiggive/donate-frontend/assets/159481/cb0dff70-c7f5-4cb8-9b29-98839f6b16b6)

Screenshot with simulated future date of Jan 10th:

http://localhost:4200/?simulatedDate=2024-01-10

![image](https://github.com/thebiggive/donate-frontend/assets/159481/648add54-0aaa-4407-b317-775e7af468ad)

And then on Feb 1st it will show

![image](https://github.com/thebiggive/donate-frontend/assets/159481/35d01b66-5380-4d61-9047-1fa50be68c25)

And with a simulated date after Feb 9th it looks a bit empty but probably we'll have put something else in before that happens:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/91e58816-beff-4c78-8688-fd8ee3c96c24)

