### PR TITLE
DON-948: Treat user as not logged in on donate page if they do not ha…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -40,7 +40,7 @@ export class AppComponent implements AfterViewInit, OnDestroy, OnInit {
   protected readonly flags = flags;
   protected readonly userHasExpressedCookiePreference$ = this.cookiePreferenceService.userHasExpressedCookiePreference();
   public currentUrlWithoutHash$: Observable<URL>;
-  
+
   private getPersonSubscription: Subscription;
   private loginStatusChangeSubscription: Subscription;
 

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.html
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.html
@@ -19,7 +19,7 @@
         [loadAuthedPersonInfo]="loadAuthedPersonInfo"
         [creditPenceToUse]="this.donationStartForm && this.donationStartForm.creditPenceToUse || 0"
         [campaign]="campaign"
-        [canLogin]="this.canLogin"
+        [loggedInWithPassword]="this.loggedInWithPassword"
         [loginChangeEmitter]="identityService.loginStatusChanged"
       ></app-donation-start-login>
 

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -105,8 +105,8 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
     });
   };
 
-  get canLogin() {
-    return !this.donor?.id;
+  get loggedInWithPassword() {
+    return !!this.donor?.has_password;
   }
 
   setDonation = (donation: Donation) => {

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.html
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.html
@@ -1,10 +1,5 @@
 <main>
-    <div *ngIf="canLogin" class="id-info">
-      <p><strong>You can donate faster if you've already made an account with us.</strong></p>
-      <p><button mat-raised-button (click)="login()">Log in</button></p>
-    </div>
-
-    <div *ngIf="personId && email" class="id-info">
+    <div *ngIf="loggedInWithPassword else logIn" class="id-info">
       <p>Logged in as <strong>{{ email}}</strong></p>
       <p>We'll pre-fill some fields with your saved details, but you can change them if you need to.</p>
       <p *ngIf="creditPenceToUse > 0">Your credit balance will be used and the donation value capped at {{ creditPenceToUse / 100 | exactCurrency:campaign.currencyCode }}</p>
@@ -12,4 +7,10 @@
         <button id="my-account-link" mat-raised-button routerLink="/my-account">My Account</button>
       </p>
     </div>
+  <ng-template #logIn>
+  <div class="id-info">
+      <p><strong>You can donate faster if you've already made an account with us.</strong></p>
+      <p><button mat-raised-button (click)="login()">Log in</button></p>
+    </div>
+  </ng-template>
 </main>

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.ts
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.ts
@@ -15,7 +15,7 @@ export class DonationStartLoginComponent {
   @Input({ required: true }) creditPenceToUse: number;
   @Input({ required: true }) email?: string;
   @Input({ required: true }) personId: string | undefined;
-  @Input({ required: true }) canLogin: boolean;
+  @Input({ required: false }) loggedInWithPassword: boolean;
 
   @Input({ required: true }) private loginChangeEmitter: EventEmitter<boolean>;
 


### PR DESCRIPTION
…ve a password

Passwordless donor accounts are necassary for viewing thanks pages, but sort of confusing. They go away after the session anyway, so we don't want to let them block donors logging in to a full passworded account.

The donate page will now always show either the login button or the "you are logged in" message, and it only shows the latter in the case that the donor has set a password (either in the current session or previously)

No other changes.

![image](https://github.com/thebiggive/donate-frontend/assets/159481/057da283-3b6b-400b-a1c9-ab6be84b12e8)