### PR TITLE
DON-735: Adjust layout for single highlight cards on home page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -9,8 +9,9 @@
   ></biggive-hero-image>
 
   <div class="b-container">
-    <biggive-grid [columnCount]="highlightCardsToShow.length">
-      <biggive-basic-card *ngFor="let card of highlightCardsToShow"
+    <div class="highlight-card-list">
+      <div class="highlight-card-wrapper" *ngFor="let card of highlightCardsToShow">
+    <biggive-basic-card
                           [spaceBelow]='4'
                           [headingLevel]="2"
                           [buttonColourScheme]="'clear-primary'"
@@ -23,8 +24,8 @@
                           [buttonLabel]="card.button.text"
                           [buttonUrl]="card.button.href.toString()"
       />
-    </biggive-grid>
-
+      </div>
+    </div>
   </div>
 
   <biggive-page-section

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -9,9 +9,8 @@
   ></biggive-hero-image>
 
   <div class="b-container">
-    <div class="highlight-card-list">
-      <div class="highlight-card-wrapper" *ngFor="let card of highlightCardsToShow">
-    <biggive-basic-card
+    <biggive-grid [columnCount]="highlightCardsToShow.length">
+      <biggive-basic-card *ngFor="let card of highlightCardsToShow"
                           [spaceBelow]='4'
                           [headingLevel]="2"
                           [buttonColourScheme]="'clear-primary'"
@@ -24,8 +23,8 @@
                           [buttonLabel]="card.button.text"
                           [buttonUrl]="card.button.href.toString()"
       />
-      </div>
-    </div>
+    </biggive-grid>
+
   </div>
 
   <biggive-page-section

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -9,21 +9,41 @@
   ></biggive-hero-image>
 
   <div class="b-container">
-    <biggive-grid [columnCount]="highlightCardsToShow.length">
-      <biggive-basic-card *ngFor="let card of highlightCardsToShow"
-                          [spaceBelow]='4'
-                          [headingLevel]="2"
-                          [buttonColourScheme]="'clear-primary'"
-                          [class]="'basic-card-padding'"
+    <!-- The grid layout works fine for 2 or three cards but not quite for a single card. Easier to treat single
+         card as a special case rather than changing the grid implemnation or replacing it entirely.
+         -->
+    <div class="single-highlight-card" *ngIf="highlightCardsToShow.length === 1; else highlightCardGrid">
+      <biggive-basic-card
+        [spaceBelow]='4'
+        [headingLevel]="2"
+        [buttonColourScheme]="'clear-primary'"
+        [class]="'basic-card-padding'"
 
-                          [iconColour]="card.iconColor"
-                          [backgroundImageUrl]="card.backgroundImageUrl.toString()"
-                          [mainTitle]="card.headerText"
-                          [subtitle]="card.bodyText"
-                          [buttonLabel]="card.button.text"
-                          [buttonUrl]="card.button.href.toString()"
+        [iconColour]="highlightCardsToShow[0]!.iconColor"
+        [backgroundImageUrl]="highlightCardsToShow[0]!.backgroundImageUrl.toString()"
+        [mainTitle]="highlightCardsToShow[0]!.headerText"
+        [subtitle]="highlightCardsToShow[0]!.bodyText"
+        [buttonLabel]="highlightCardsToShow[0]!.button.text"
+        [buttonUrl]="highlightCardsToShow[0]!.button.href.toString()"
       />
-    </biggive-grid>
+    </div>
+    <ng-template #highlightCardGrid>
+      <biggive-grid [columnCount]="highlightCardsToShow.length">
+        <biggive-basic-card *ngFor="let card of highlightCardsToShow"
+                            [spaceBelow]='4'
+                            [headingLevel]="2"
+                            [buttonColourScheme]="'clear-primary'"
+                            [class]="'basic-card-padding'"
+
+                            [iconColour]="card.iconColor"
+                            [backgroundImageUrl]="card.backgroundImageUrl.toString()"
+                            [mainTitle]="card.headerText"
+                            [subtitle]="card.bodyText"
+                            [buttonLabel]="card.button.text"
+                            [buttonUrl]="card.button.href.toString()"
+        />
+      </biggive-grid>
+    </ng-template>
 
   </div>
 

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,5 +1,3 @@
-@import '../../abstract';
-
 .auto-margin {
   margin: auto; //centres the button
 }
@@ -11,23 +9,4 @@
 .basic-card-padding {
   padding: 0 10px;
   box-sizing: border-box;
-}
-
-.highlight-card-list {
-  display: grid;
-  grid-auto-flow: row;
-  grid-auto-columns: minmax(0, 0.6fr);
-  justify-content: center;
-  align-content: center;
-  gap: 0;
-  margin-bottom: 105px;
-  @media #{$breakpoint-lg} {
-    grid-auto-flow: column;
-  }
-
-  .highlight-card-wrapper {
-    padding: 0 10px;
-    margin-top: 90px;
-    height: 410px;
-  }
 }

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -10,3 +10,7 @@
   padding: 0 10px;
   box-sizing: border-box;
 }
+.single-highlight-card {
+  max-width: 650px;
+  margin: auto;
+}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,3 +1,5 @@
+@import '../../abstract';
+
 .auto-margin {
   margin: auto; //centres the button
 }
@@ -9,4 +11,23 @@
 .basic-card-padding {
   padding: 0 10px;
   box-sizing: border-box;
+}
+
+.highlight-card-list {
+  display: grid;
+  grid-auto-flow: row;
+  grid-auto-columns: minmax(0, 0.6fr);
+  justify-content: center;
+  align-content: center;
+  gap: 0;
+  margin-bottom: 105px;
+  @media #{$breakpoint-lg} {
+    grid-auto-flow: column;
+  }
+
+  .highlight-card-wrapper {
+    padding: 0 10px;
+    margin-top: 90px;
+    height: 410px;
+  }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -106,6 +106,6 @@ export class HomeComponent implements OnInit {
       }
 
       return true;
-    })
+    });
   }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -106,6 +106,6 @@ export class HomeComponent implements OnInit {
       }
 
       return true;
-    });
+    })
   }
 }


### PR DESCRIPTION
We can handle 1,2, or 3 highlight cards on the homepage. 2 or more use the grid component as in the past, a single card is treated as a special case.

1 card:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/952c65b2-7168-42aa-afec-cff12d84be6b)

2 cards:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/fb3004f1-961f-4bf8-a14e-9f8c32052c46)

3 cards:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/e23af040-af6a-4a6f-ae62-fe50878ecbaa)

6 cards is not supported, but in case it happened this is how it would look:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/401369c8-6224-4733-95cd-671c595a3456)


