### PR TITLE
Fix DON-946: Stop stripe blocking retrying donation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ orbs:
 
 jobs:
   test:
+    resource_class: large
     docker:
       - image: cimg/node:16.18-browsers
         auth:
@@ -49,7 +50,6 @@ jobs:
 
       - store_artifacts:
           path: cypress/screenshots
-
   deploy-staging-static:
     docker:
       # This image's base Node version must match that used in `Dockerfile`, which is the basis for ECS app

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -422,7 +422,9 @@
 
         </div>
 
-        <p *ngIf="stripeError" class="error" aria-live="polite">
+        <p *ngIf="stripeError" class="stripeError" aria-live="assertive">
+          <!-- We do not use the "error" css class because we don't want to scroll to this error automatically, since
+          it likely can't be fixed here and the donor will have to try making their payment again to make it go away. -->
           {{ stripeError }}
         </p>
 
@@ -576,7 +578,9 @@
             Sorry, we are really busy and cannot take your donation right now. Please refresh the page in a few minutes to try again.
           </p>
 
-          <p *ngIf="stripeError" class="error" aria-live="assertive">
+          <p *ngIf="stripeError" class="stripeError" aria-live="assertive">
+            <!-- We do not use the "error" css class because we don't want to scroll to this error automatically, since
+            it likely can't be fixed here and the donor will have to try making their payment again to make it go away. -->
             {{ stripeError }}
           </p>
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -356,7 +356,7 @@ button.continue, .c-donate-button {
   text-align: center;
 }
 
-.error {
+.error, .stripeError {
   color: mat.get-color-from-palette($donate-warn);
   margin: 1rem 0;
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -64,7 +64,9 @@ function makeDonationStartFormComponent(donationService: DonationService,) {
     undefined as unknown as StripeService,
     undefined as unknown as DatePipe,
     undefined as unknown as TimeLeftPipe,
-    undefined as unknown as MatSnackBar,
+    {
+      open: () => {}
+    } as unknown as MatSnackBar,
   );
 
   const stubGroup = {

--- a/src/app/validators/validate-billing-post-code.ts
+++ b/src/app/validators/validate-billing-post-code.ts
@@ -1,7 +1,0 @@
-import { AbstractControl } from '@angular/forms';
-
-export function ValidateBillingPostCode(_: AbstractControl) {
-    return {
-        invalidBillingPostCode: true
-    };
-};


### PR DESCRIPTION
For most errors we ask people to fix them in place before they progress to the next step, but that doesn't work for stripe errors - in that case they need to continue through the form and press the confirm button again.

This reverses some of the work done in DON-493, which I think no longer makes sense now we are confirming payments on the server side only.

Now if you use get a card decline the error looks like this, but it doesn't block you progress through the form and pressing confirm again. You can keep trying as many times as you like until the donation works, which it may do if you add funds to your bank account at the same time:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/9d083302-7a61-4bc9-9c5e-2277f1ea1b7d)
