### PR TITLE
DON-576: Show list of zero cards case of error in SF homepage highlig…

### DIFF
--- a/src/app/highlight-cards-resolver.ts
+++ b/src/app/highlight-cards-resolver.ts
@@ -3,12 +3,20 @@ import {ActivatedRouteSnapshot, ResolveFn} from '@angular/router';
 import {environment} from "../environments/environment";
 import {inject} from "@angular/core";
 import {CampaignService} from "./campaign.service";
+import {catchError} from "rxjs/operators";
+import {of} from "rxjs";
 
 export const highlightCardsResolver: ResolveFn<readonly HighlightCard[] | null> = (route: ActivatedRouteSnapshot) => {
   const campaignService = inject(CampaignService);
 
   if (route.queryParams.hasOwnProperty('highlightAPIEnabled') && environment.environmentId !== 'production') {
-    return campaignService.getHomePageHighlightCards();
+    return campaignService.getHomePageHighlightCards().pipe(
+      // If the HighlightCards API has any error we still want to show the rest of the homepage, so we catch the error
+      catchError(error => {
+        console.error("Error fetching hompepage highlight cards", error);
+        return of([]);
+      })
+    );
   }
 
     const Jan8th = new Date('2024-01-08T00:00:00+00:00');


### PR DESCRIPTION
…ht card API

Previously we would have thrown an error from the resolver which would have blocked rendering the rest of the homepage - as we found on Friday when there was a bug on the SF side.