### PR TITLE
DON-576: Charity carousel amends

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -111,20 +111,18 @@
 
       <swiper-slide><img src="/assets/images/logo-the-brain-tumour-charity.png" alt="The Brain Tumour Charity" width="300"></swiper-slide>
 
-      <div slot="container-end" class="charity-carousel-navigation">
-        <div id="carousel-button-prev" class="button next" title="Previous">
-          <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8.29311 14.5703L1.73926 8.01646L8.29311 1.46261" stroke="#000000" stroke-width="2" />
-          </svg>
-        </div>
-        <div id="carousel-button-next" class="button prev" title="Next">
-          <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M0.739117 1.46094L7.29297 8.01479L0.739118 14.5686" stroke="#000000" stroke-width="2" />
-          </svg>
-        </div>
-      </div>
+
 
     </swiper-container>
+
+    <div class="charity-carousel-navigation">
+      <div id="carousel-button-prev" class="button next" >
+        <img width="25px" src="/assets/images/arrow-prev-with-circle.svg" alt="Previous"/>
+      </div>
+      <div id="carousel-button-next" class="button prev" title="Next">
+        <img width="25px" src="/assets/images/arrow-next-with-circle.svg" title="Next" />
+      </div>
+    </div>
 
     <div class="flex-wrapper">
       <div class="auto-margin">

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -49,43 +49,15 @@ swiper-slide {
   }
 }
 
+.mySwiper {
+  --swiper-pagination-color: #2C089B; // i.e. $colour-primary but for some reason refrencing the variable doesn't seem to work here.
+  --swiper-pagination-bullet-inactive-color: #333333; // i.e. $colour-grey
+}
+
 .charity-carousel-navigation {
   padding: 10px 0;
   text-align: center;
   display: flex;
   justify-content: center;
-  position: relative;
-  top: -30px;
   z-index: 1;
-  .button {
-    margin-left: 15px;
-    display: block;
-    width: 30px;
-    height: 30px;
-    padding: 2.5px 10px;
-    box-sizing: border-box;
-    background-color: #FFFFFF;
-    box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.25);
-    border-radius: 50%;
-    cursor: pointer;
-    text-align: center;
-    svg {
-      width: 15px;
-      height: 15px;
-      position: relative;
-      top: 2.5px;
-    }
-    &.prev {
-      left: 0;
-      svg {
-        left: -3px;
-      }
-    }
-    &.next {
-      right: 0;
-      svg {
-        left: -1px;
-      }
-    }
-  }
 }

--- a/src/assets/images/arrow-next-with-circle.svg
+++ b/src/assets/images/arrow-next-with-circle.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="arrow-next-with-circle.svg"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter50"
+       x="-0.83570522"
+       y="-0.83570522"
+       width="2.6714103"
+       height="2.6714103">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)"
+         id="feFlood49" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="1.800000"
+         id="feGaussianBlur49" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000"
+         id="feOffset49" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite49" />
+      <feComposite
+         result="fbSourceGraphic"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite50" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix50" />
+      <feFlood
+         id="feFlood50"
+         result="flood"
+         in="fbSourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)" />
+      <feGaussianBlur
+         id="feGaussianBlur50"
+         result="blur"
+         in="fbSourceGraphic"
+         stdDeviation="1.800000" />
+      <feOffset
+         id="feOffset50"
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000" />
+      <feComposite
+         id="feComposite51"
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset" />
+      <feComposite
+         id="feComposite52"
+         result="fbSourceGraphic"
+         operator="over"
+         in="fbSourceGraphic"
+         in2="comp1" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix52" />
+      <feFlood
+         id="feFlood52"
+         result="flood"
+         in="fbSourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)" />
+      <feGaussianBlur
+         id="feGaussianBlur52"
+         result="blur"
+         in="fbSourceGraphic"
+         stdDeviation="1.800000" />
+      <feOffset
+         id="feOffset52"
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000" />
+      <feComposite
+         id="feComposite53"
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset" />
+      <feComposite
+         id="feComposite54"
+         result="comp2"
+         operator="over"
+         in="fbSourceGraphic"
+         in2="comp1" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter56"
+       x="-0.27856841"
+       y="-0.27856841"
+       width="1.5571368"
+       height="1.5571368">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)"
+         id="feFlood54" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="1.800000"
+         id="feGaussianBlur54" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000"
+         id="feOffset54" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite55" />
+      <feComposite
+         result="comp2"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite56" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Drop Shadow"
+       id="filter78"
+       x="-0.18571228"
+       y="-0.18571228"
+       width="1.3714246"
+       height="1.3714246">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="0.701961"
+         flood-color="rgb(0,0,0)"
+         id="feFlood77" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="1.200000"
+         id="feGaussianBlur77" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000"
+         id="feOffset77" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite77" />
+      <feComposite
+         result="comp2"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite78" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="25.34375"
+     inkscape:cx="14.027127"
+     inkscape:cy="12.567201"
+     inkscape:window-width="1850"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke-width:1.06497;filter:url(#filter78)"
+     id="path2"
+     cx="9.999999"
+     cy="10"
+     r="7.7539301"
+     transform="matrix(-1,0,0,1,19.999998,0)" />
+  <path
+     d="M 7.9668991,14.3825 12.349406,10.000003 7.9668991,5.6174996"
+     stroke="#000000"
+     stroke-width="1.33738"
+     id="path1" />
+</svg>

--- a/src/assets/images/arrow-prev-with-circle.svg
+++ b/src/assets/images/arrow-prev-with-circle.svg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="arrow-prev-with-circle.svg"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter50"
+       x="-0.83570522"
+       y="-0.83570522"
+       width="2.6714103"
+       height="2.6714103">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)"
+         id="feFlood49" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="1.800000"
+         id="feGaussianBlur49" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000"
+         id="feOffset49" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite49" />
+      <feComposite
+         result="fbSourceGraphic"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite50" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix50" />
+      <feFlood
+         id="feFlood50"
+         result="flood"
+         in="fbSourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)" />
+      <feGaussianBlur
+         id="feGaussianBlur50"
+         result="blur"
+         in="fbSourceGraphic"
+         stdDeviation="1.800000" />
+      <feOffset
+         id="feOffset50"
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000" />
+      <feComposite
+         id="feComposite51"
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset" />
+      <feComposite
+         id="feComposite52"
+         result="fbSourceGraphic"
+         operator="over"
+         in="fbSourceGraphic"
+         in2="comp1" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix52" />
+      <feFlood
+         id="feFlood52"
+         result="flood"
+         in="fbSourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)" />
+      <feGaussianBlur
+         id="feGaussianBlur52"
+         result="blur"
+         in="fbSourceGraphic"
+         stdDeviation="1.800000" />
+      <feOffset
+         id="feOffset52"
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000" />
+      <feComposite
+         id="feComposite53"
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset" />
+      <feComposite
+         id="feComposite54"
+         result="comp2"
+         operator="over"
+         in="fbSourceGraphic"
+         in2="comp1" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter56"
+       x="-0.27856841"
+       y="-0.27856841"
+       width="1.5571368"
+       height="1.5571368">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="1.000000"
+         flood-color="rgb(32,32,32)"
+         id="feFlood54" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="1.800000"
+         id="feGaussianBlur54" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000"
+         id="feOffset54" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite55" />
+      <feComposite
+         result="comp2"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite56" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Drop Shadow"
+       id="filter78"
+       x="-0.18571228"
+       y="-0.18571228"
+       width="1.3714246"
+       height="1.3714246">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="0.701961"
+         flood-color="rgb(0,0,0)"
+         id="feFlood77" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="1.200000"
+         id="feGaussianBlur77" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="0.000000"
+         dy="0.000000"
+         id="feOffset77" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite77" />
+      <feComposite
+         result="comp2"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite78" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="25.34375"
+     inkscape:cx="14.027127"
+     inkscape:cy="12.567201"
+     inkscape:window-width="1850"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke-width:1.06497;filter:url(#filter78)"
+     id="path2"
+     cx="9.999999"
+     cy="10"
+     r="7.7539301" />
+  <path
+     d="M 12.033099,14.3825 7.6505916,10.000003 12.033099,5.6174996"
+     stroke="#000000"
+     stroke-width="1.33738"
+     id="path1" />
+</svg>


### PR DESCRIPTION
Rebuilt carousel button SVGs to include circles with shadows, so we can control the position of the arrow within the circle easily.

![image](https://github.com/thebiggive/donate-frontend/assets/159481/f61d80cf-12bd-46aa-925a-7f7ce2b006c1)
