### PR TITLE
DON-950: Fix broken Matomo config

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,7 +36,7 @@ const matomoBaseUri = 'https://biggive.matomo.cloud';
     HttpClientModule,
     NgxMatomoModule.forRoot({
       siteId: environment.matomoSiteId,
-      trackerUrl: `${matomoBaseUri}/matomo.js`,
+      trackerUrl: matomoBaseUri,
       mode: MatomoInitializationMode.AUTO,
       requireConsent: MatomoConsentMode.COOKIE,
     }),


### PR DESCRIPTION
Previously it was sending a request to
https://biggive.matomo.cloud/matomo.js/matomo.js which returns a 500. With this change it requests https://biggive.matomo.cloud/matomo.js which works.