### PR TITLE
Fix DON-972: Detailed cookie choices are hidden behind navigation

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -8,7 +8,7 @@ biggive-main-menu {
   position: fixed;
   bottom: 3em;
   right: 3em;
-  z-index: 10;
+  z-index: 20;
 }
 
 .skip-to-content-link {


### PR DESCRIPTION
Before:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/76159942-729c-47b1-8216-c51a3fba3587)



After

![image](https://github.com/thebiggive/donate-frontend/assets/159481/a1c5a98f-5699-447e-9b24-46d7bd12aa78)
