### PR TITLE
Fix ticker on fund pages

### DIFF
--- a/src/app/meta-campaign/meta-campaign.component.ts
+++ b/src/app/meta-campaign/meta-campaign.component.ts
@@ -149,14 +149,18 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
     if (this.fundSlug) {
       fundKey = makeStateKey<Fund>(`fund-${this.fundSlug}`);
       this.fund = this.state.get<Fund | undefined>(fundKey, undefined);
-      this.setFundSpecificProps();
+      if (this.fund) {
+        this.setFundSpecificProps(this.fund);
+      }
     }
 
     if (!this.fund && this.fundSlug) {
       this.fundService.getOneBySlug(this.fundSlug).subscribe(fund => {
         this.state.set<Fund>(fundKey, fund);
         this.fund = fund;
-        this.setFundSpecificProps();
+        if (this.fund) {
+          this.setFundSpecificProps(this.fund);
+        }
       });
     }
 
@@ -477,12 +481,8 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
     }
   }
 
-  private setFundSpecificProps() {
-    if (this.fund === undefined) {
-      throw new Error('Attempt to set fund specific props with no fund');
-    }
-
-    this.tickerMainMessage = this.currencyPipe.transform(this.fund.amountRaised, this.campaign.currencyCode, 'symbol', currencyPipeDigitsInfo) +
+  private setFundSpecificProps(fund: Fund) {
+    this.tickerMainMessage = this.currencyPipe.transform(fund.amountRaised, this.campaign.currencyCode, 'symbol', currencyPipeDigitsInfo) +
       ' raised' + (this.campaign.currencyCode === 'GBP' ? ' inc. Gift Aid' : '');
 
     const durationInDays = Math.floor((new Date(this.campaign.endDate).getTime() - new Date(this.campaign.startDate).getTime()) / 86400000);
@@ -490,7 +490,7 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
     tickerItems.push({
       label: 'total match funds',
       figure: this.currencyPipe.transform(
-        this.fund.totalForTicker,
+        fund.totalForTicker,
         this.campaign.currencyCode,
         'symbol',
         currencyPipeDigitsInfo
@@ -511,8 +511,8 @@ export class MetaCampaignComponent implements AfterViewChecked, OnDestroy, OnIni
 
     // Show fund name if applicable *and* there's no fund logo. If there's a logo
     // its content + alt text should do the equivalent job.
-    this.title = (!this.fund.logoUri && this.fund.name)
-      ? `${this.campaign.title}: ${this.fund.name}`
+    this.title = (!fund.logoUri && fund.name)
+      ? `${this.campaign.title}: ${fund.name}`
       : this.campaign.title;
 
     this.pageMeta.setCommon(


### PR DESCRIPTION
Throwing an error breaks the page, if there's no fund we don't want to set the specific props yet, but we may need to set them slightly later. Throwing an error broke that.

Changing type of setFundSpecificProps to
`(fund: Fund) => void` so we don't get errors
from calling it without a fund.