### PR TITLE
DON-981: Reload page after login on donation page

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -90,6 +90,13 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
 
     this.identityService.get(id, jwt).subscribe({
       next: (person: Person) => {
+        if (this.donor && this.donor !== person) {
+          // Implies we are changing authentication state, as we already had a person and now its a different one.
+          // Page state can be wrong at this point, so for simplicity we reload - otherwise errors relating to the
+          // previous (probably anon) logged in user could affect the donation journey of this user.
+          location.reload();
+        }
+
         this.donor = person; // Should mean donations are attached to the Stripe Customer.
         this.loggedInEmailAddress = person.email_address;
         this.donationStartForm.loadPerson(person, id, jwt);

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -2274,6 +2274,7 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
   public loadPerson(person: Person, id: string, jwt: string) {
     this.donor = person; // Should mean donations are attached to the Stripe Customer.
+    this.paymentStepErrors = "";
 
     // Only tokens for Identity users with a password have enough access to load payment methods, use credit
     // balances and access personal data beyond the anonymous new Customer basics.


### PR DESCRIPTION
I didn't fully get to the bottom of how the bug was happening, but I did manage to reproduce it reliably.

It seemed like the error message that's displayed "Please enter your billing postcode" may be unrelated to the actual block to progress.

I found that we were calling the stepper.next method at https://github.com/thebiggive/donate-frontend/blob/fc4a02a8469edf57c927d56c8a778dce002e22bf/src/app/donation-start/donation-start-form/donation-start-form.component.ts#L1084 but for some reason the stepper didn't visible advance. I don't know what's going inside the stepper or angular that means that doesn't happen, but refreshing the page fixes it. I tried wrapping the function in ngZone.run in case somehow we were outside a context where Angular could detect changes, but that didn't fix anything.

So solution I've chosen here is to just reload the page as soon as the user logs in. That fixes it, and I think still provides a good user experience. Logging in is always slightly slow, since it requires the user finding or remembering their password, and the backend server to verify it. I think users recognise that authentication is a cross-cutting concern (if not in those words) and so are used to the entire app potentially changing and reloading when they log in or log out. They already waited for the auth server to return so waiting very slightly longer for the page to reload hopefully won't feel annoying.