### PR TITLE
DON-981: Force recreating donation when logging in to account with funds

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1366,8 +1366,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
       this.paymentReadinessTracker.donationFundsPrepared(this.creditPenceToUse);
       this.setConditionalValidators();
 
-      if (this.donation) {
-        this.donation.pspMethodType = this.getPaymentMethodType();
+      if (this.donation && this.donation.pspMethodType !== "customer_balance") {
+        // We can't convert card donation to a customer balance donation, and the donor should choose the amount
+        // bearing in mind what they have in the balance, so:
+        this.donationService.cancel(this.donation);
+        delete this.donation;
+        this.stepper.reset();
       }
     }
   }

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -28,17 +28,17 @@ export interface Donation {
      * Unique ID for a charity Account assigned by Big Give, in Salesforce
      * case-insensitive format. 18 character string.
      */
-    charityId: string;
+    readonly charityId: string;
 
     /**
      * ISO 4217 code for the currency in which all monetary values are denominated.
      */
-    currencyCode: string;
+    readonly currencyCode: string;
 
     /**
      * Counted in major units of the relevant currency. Should be whole number.
      */
-    donationAmount: number;
+    readonly donationAmount: number;
 
     /**
      * Indicates whether donation was expected to be eligible for either full or partial matching
@@ -61,7 +61,7 @@ export interface Donation {
 
     optInChampionEmail?: boolean;
 
-    pspMethodType: 'card' | 'customer_balance';
+    readonly pspMethodType: 'card' | 'customer_balance';
 
     /**
      * Unique ID for a CCampaign / project assigned by Big Give, in Salesforce

--- a/src/app/search.service.ts
+++ b/src/app/search.service.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, Injectable } from '@angular/core';
+import {Params} from "@angular/router";
 
 export type SelectedType = {
   beneficiary?: string,
@@ -133,7 +134,7 @@ export class SearchService {
         queryParams[key] = String(this.selected[key]);
       }
     }
-    
+
     if (this.selected.sortField === 'relevance' && this.selected.term?.length === 0) {
       delete queryParams.sortField;
     }
@@ -143,10 +144,8 @@ export class SearchService {
 
   /**
    * Apply search state from a route.
-   *
-   * @param routeParams object
    */
-  loadQueryParams(queryParams: any, defaultSort: string) {
+  loadQueryParams(queryParams: Params, defaultSort: string) {
     this.reset(defaultSort, true);
 
     if (Object.keys(queryParams).length > 0) {


### PR DESCRIPTION
At the moment we have a bug where finalising the donation can be blocked when starting a pending donation and then logging in to an account that has donation funds, because we don't allow converting from a card donation to a funds donation.