### PR TITLE
DON-713: Default to including only matched campaigns on explore page

### DIFF
--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -156,7 +156,7 @@ export class CampaignService {
       params = params.append('fundSlug', searchQuery.fundSlug);
     }
 
-    if (searchQuery.onlyMatching) {
+    if (searchQuery.onlyMatching !== false) {
       params = params.append('onlyMatching', 'true');
     }
 

--- a/src/app/search.service.ts
+++ b/src/app/search.service.ts
@@ -41,7 +41,7 @@ export class SearchService {
       beneficiary: '',
       category: '',
       country: '',
-      onlyMatching: false,
+      onlyMatching: true,
       sortField: defaultSort,
       term: '',
     };
@@ -152,7 +152,7 @@ export class SearchService {
       for (const key of Object.keys(queryParams)) {
         if (key === 'onlyMatching') {
           // convert URL query param string to boolean
-          this.selected[key] = (queryParams[key] === 'true');
+          this.selected[key] = (queryParams[key] !== 'false');
         } else {
           this.selected[key] = queryParams[key];
         }


### PR DESCRIPTION
If readers want to see unmatched campaigns they will need to click to dismiss the "Match Funded" pillbox. That change will be persisted in the address bar with a change from /explore to /explore?onlyMatching=false