### PR TITLE
Don 713 highlight cards on explore page

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -157,6 +157,7 @@ const routes: Routes = [
     pathMatch: 'full',
     resolve: {
       campaigns: CampaignListResolver,
+      highlights: highlightCardsResolver
     },
     loadChildren: () => import('./explore/explore.module')
       .then(c => c.ExploreModule),

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -7,7 +7,7 @@ import { CampaignStats } from './campaign-stats.model';
 import { CampaignSummary } from './campaign-summary.model';
 import { environment } from '../environments/environment';
 import { SelectedType } from './search.service';
-import {HighlightCard, SfApiHighlightCard, SFAPIHighlightCardToHighlightCard} from "./home/HighlightCard";
+import {HighlightCard, SfApiHighlightCard, SFAPIHighlightCardToHighlightCard} from "./highlight-cards/HighlightCard";
 import {map} from "rxjs/operators";
 @Injectable({
   providedIn: 'root',

--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -70,5 +70,14 @@
         </p>
       </div>
     }
+
+    @if (campaigns.length <=6 && ! searchService.selected.term && !loading && highlightCards.length > 0) {
+      <p>Can't find any campaigns to support? Find out what's next at Big Give</p>
+        <app-highlight-cards
+          [highlightCards]="highlightCards">
+        </app-highlight-cards>
+    }
+
   </biggive-page-section>
+
 </main>

--- a/src/app/explore/explore.component.spec.ts
+++ b/src/app/explore/explore.component.spec.ts
@@ -43,6 +43,9 @@ describe('ExploreComponent', () => {
       ],
       providers: [
         { provide: ActivatedRoute, useValue: {
+          snapshot: {
+            data: {}
+          },
           queryParams: of({}), // Let `loadQueryParamsAndRun()` subscribe without crashing.
         } },
       ],

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -9,6 +9,7 @@ import {CampaignGroupsService} from '../campaign-groups.service';
 import {CampaignSummary} from '../campaign-summary.model';
 import {PageMetaService} from '../page-meta.service';
 import {SearchService} from '../search.service';
+import {HighlightCard} from "../highlight-cards/HighlightCard";
 
 /** @todo Reduce overlap duplication w/ MetaCampaignComponent - see https://www.typescriptlang.org/docs/handbook/mixins.html */
 @Component({
@@ -31,6 +32,7 @@ export class ExploreComponent implements OnDestroy, OnInit {
   beneficiaryOptions: string[] = [];
   categoryOptions: string[] = [];
   locationOptions: string[] = [];
+  protected highlightCards: HighlightCard[];
 
   private queryParamsSubscription: Subscription;
 
@@ -69,6 +71,7 @@ export class ExploreComponent implements OnDestroy, OnInit {
     this.locationOptions = CampaignGroupsService.getCountries();
 
     this.queryParamsSubscription = this.scrollToSearchWhenParamsChange();
+    this.highlightCards = this.route.snapshot.data.highlights;
   }
 
   private scrollToSearchWhenParamsChange() {

--- a/src/app/explore/explore.module.ts
+++ b/src/app/explore/explore.module.ts
@@ -7,6 +7,7 @@ import { allChildComponentImports } from '../../allChildComponentImports';
 import { ExploreComponent } from './explore.component';
 import {ExploreRoutingModule} from './explore-routing.module';
 import {OptimisedImagePipe} from '../optimised-image.pipe';
+import {HighlightCardsComponent} from "../highlight-cards/highlight-cards.component";
 
 @NgModule({
   imports: [
@@ -16,6 +17,7 @@ import {OptimisedImagePipe} from '../optimised-image.pipe';
     InfiniteScrollModule,
     MatProgressSpinnerModule,
     OptimisedImagePipe,
+    HighlightCardsComponent,
   ],
   declarations: [
     ExploreComponent,

--- a/src/app/highlight-cards-resolver.ts
+++ b/src/app/highlight-cards-resolver.ts
@@ -1,4 +1,4 @@
-import {HighlightCard} from "./home/HighlightCard";
+import {HighlightCard} from "./highlight-cards/HighlightCard";
 import {ResolveFn} from '@angular/router';
 import {inject} from "@angular/core";
 import {CampaignService} from "./campaign.service";

--- a/src/app/highlight-cards/HighlightCard.spec.ts
+++ b/src/app/highlight-cards/HighlightCard.spec.ts
@@ -5,8 +5,6 @@ describe('highlightCard', () => {
   it('should convert a highlight card from the SF API to one we can display', () => {
     const cardFromApi: SfApiHighlightCard = {
       campaignFamily: 'womenGirls',
-      appearAt: 'asap',
-      disappearAt: 'never',
       headerText: "some header text",
       bodyText: "some body text",
       button: {text: "button text", href:'https://biggive.org/some-path'}
@@ -28,8 +26,6 @@ describe('highlightCard', () => {
   it('should use appropriate colour for emergency campaign', () => {
     const cardFromApi: SfApiHighlightCard = {
       campaignFamily: 'emergencyMatch',
-      appearAt: 'asap',
-      disappearAt: 'never',
       headerText: "some header text",
       bodyText: "some body text",
       button: {text: "button text", href: 'https://biggive.org/some-path'}
@@ -52,8 +48,6 @@ describe('highlightCard', () => {
   it('should use blue primary colour by default', () => {
     const cardFromApi: SfApiHighlightCard = {
       campaignFamily: 'some-unknown-campaign-family' as campaignFamilyName,
-      appearAt: 'asap',
-      disappearAt: 'never',
       headerText: "some header text",
       bodyText: "some body text",
       button: {text: "button text", href: 'https://biggive.org/some-path'}
@@ -79,8 +73,6 @@ describe('highlightCard', () => {
         text: "irrelevant"
       },
       campaignFamily: 'christmasChallenge', // irrelevant
-      appearAt: 'asap', // irrelevant
-      disappearAt: 'never', // irrelevant
       headerText: "irrelevant",
       bodyText: "irrelevant",
     } as const;

--- a/src/app/highlight-cards/HighlightCard.ts
+++ b/src/app/highlight-cards/HighlightCard.ts
@@ -1,17 +1,6 @@
 import { brandColour } from "@biggive/components/dist/types/globals/brand-colour"
 
 export type HighlightCard = {
-  /**
-   * If not 'asap', the card should not be displayed until the date given.
-   * Remember to set the timezone appropriately when creating these date objects.
-   */
-  appearAt: Date | 'asap',
-
-  /**
-   * If not 'never', the card should disappear at this date.
-   */
-  disappearAt: Date | 'never',
-
   backgroundImageUrl: URL,
   // There is ambiguity in the components library about whether brand-6 is grey or turquoise. Best to avoid using brand-6 and
   // use brand-mhf-turquoise instead.
@@ -77,8 +66,6 @@ export const SFAPIHighlightCardToHighlightCard = (experienceUriPrefix: string, b
   };
 
   return {
-    appearAt: sfApiHighlightCard.appearAt,
-    disappearAt: sfApiHighlightCard.disappearAt,
     headerText: sfApiHighlightCard.headerText,
     bodyText: sfApiHighlightCard.bodyText,
     iconColor: campaignFamilyColours[sfApiHighlightCard.campaignFamily] || "primary",

--- a/src/app/highlight-cards/highlight-cards.component.cy.ts
+++ b/src/app/highlight-cards/highlight-cards.component.cy.ts
@@ -1,0 +1,7 @@
+import { HighlightCardsComponent } from './highlight-cards.component'
+
+describe('HighlightCardsComponent', () => {
+  it('should mount', () => {
+    cy.mount(HighlightCardsComponent)
+  })
+})

--- a/src/app/highlight-cards/highlight-cards.component.html
+++ b/src/app/highlight-cards/highlight-cards.component.html
@@ -1,3 +1,6 @@
+<!-- The grid layout works fine for 2 or three cards but not quite for a single card. Easier to treat single
+card as a special case rather than changing the grid implemnation or replacing it entirely.
+-->
 @if (highlightCards.length === 1) {
   <div class="single-highlight-card">
     <biggive-basic-card

--- a/src/app/highlight-cards/highlight-cards.component.html
+++ b/src/app/highlight-cards/highlight-cards.component.html
@@ -1,0 +1,35 @@
+@if (highlightCards.length === 1) {
+  <div class="single-highlight-card">
+    <biggive-basic-card
+      [spaceBelow]='4'
+      [headingLevel]="2"
+      [buttonColourScheme]="'clear-primary'"
+      [class]="'basic-card-padding'"
+      [iconColour]="highlightCards[0]!.iconColor"
+      [backgroundColour]="highlightCards[0]!.iconColor"
+      [backgroundImageUrl]="highlightCards[0]!.backgroundImageUrl.toString()"
+      [mainTitle]="highlightCards[0]!.headerText"
+      [subtitle]="highlightCards[0]!.bodyText"
+      [buttonLabel]="highlightCards[0]!.button.text"
+      [buttonUrl]="highlightCards[0]!.button.href.toString()"
+    />
+  </div>
+} @else {
+  <biggive-grid [columnCount]="highlightCards.length" column-gap="3">
+    @for (card of highlightCards; track $index) {
+      <biggive-basic-card
+        [spaceBelow]='4'
+        [headingLevel]="2"
+        [buttonColourScheme]="'clear-primary'"
+        [class]="'basic-card-padding'"
+        [iconColour]="card.iconColor"
+        [backgroundColour]="card.iconColor"
+        [backgroundImageUrl]="card.backgroundImageUrl.toString()"
+        [mainTitle]="card.headerText"
+        [subtitle]="card.bodyText"
+        [buttonLabel]="card.button.text"
+        [buttonUrl]="card.button.href.toString()"
+      />
+    }
+  </biggive-grid>
+}

--- a/src/app/highlight-cards/highlight-cards.component.ts
+++ b/src/app/highlight-cards/highlight-cards.component.ts
@@ -1,0 +1,16 @@
+import {Component, Input} from '@angular/core';
+import {HighlightCard} from "../highlight-cards/HighlightCard";
+import {ComponentsModule} from "@biggive/components-angular";
+
+@Component({
+  selector: 'app-highlight-cards',
+  standalone: true,
+  imports: [
+    ComponentsModule
+  ],
+  templateUrl: './highlight-cards.component.html',
+  styleUrl: './highlight-cards.component.css'
+})
+export class HighlightCardsComponent {
+  @Input({ required: true }) protected highlightCards: HighlightCard[];
+}

--- a/src/app/highlight-cards/highlight-cards.component.ts
+++ b/src/app/highlight-cards/highlight-cards.component.ts
@@ -9,7 +9,6 @@ import {ComponentsModule} from "@biggive/components-angular";
     ComponentsModule
   ],
   templateUrl: './highlight-cards.component.html',
-  styleUrl: './highlight-cards.component.css'
 })
 export class HighlightCardsComponent {
   @Input({ required: true }) protected highlightCards: HighlightCard[];

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,41 +12,9 @@
       <!-- The grid layout works fine for 2 or three cards but not quite for a single card. Easier to treat single
       card as a special case rather than changing the grid implemnation or replacing it entirely.
       -->
-      @if (highlightCardsToShow.length === 1) {
-        <div class="single-highlight-card">
-          <biggive-basic-card
-            [spaceBelow]='4'
-            [headingLevel]="2"
-            [buttonColourScheme]="'clear-primary'"
-            [class]="'basic-card-padding'"
-            [iconColour]="highlightCardsToShow[0]!.iconColor"
-            [backgroundColour]="highlightCardsToShow[0]!.iconColor"
-            [backgroundImageUrl]="highlightCardsToShow[0]!.backgroundImageUrl.toString()"
-            [mainTitle]="highlightCardsToShow[0]!.headerText"
-            [subtitle]="highlightCardsToShow[0]!.bodyText"
-            [buttonLabel]="highlightCardsToShow[0]!.button.text"
-            [buttonUrl]="highlightCardsToShow[0]!.button.href.toString()"
-            />
-        </div>
-      } @else {
-        <biggive-grid [columnCount]="highlightCardsToShow.length" column-gap="3">
-          @for (card of highlightCardsToShow; track $index) {
-            <biggive-basic-card
-              [spaceBelow]='4'
-              [headingLevel]="2"
-              [buttonColourScheme]="'clear-primary'"
-              [class]="'basic-card-padding'"
-              [iconColour]="card.iconColor"
-              [backgroundColour]="card.iconColor"
-              [backgroundImageUrl]="card.backgroundImageUrl.toString()"
-              [mainTitle]="card.headerText"
-              [subtitle]="card.bodyText"
-              [buttonLabel]="card.button.text"
-              [buttonUrl]="card.button.href.toString()"
-              />
-          }
-        </biggive-grid>
-      }
+      <app-highlight-cards
+        [highlightCards]="highlightCards">
+      </app-highlight-cards>
     </div>
     <biggive-page-section
       colour-scheme="primary"

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -9,9 +9,6 @@
       main-image-align-vertical="center"
     ></biggive-hero-image>
     <div class="b-container">
-      <!-- The grid layout works fine for 2 or three cards but not quite for a single card. Easier to treat single
-      card as a special case rather than changing the grid implemnation or replacing it entirely.
-      -->
       <app-highlight-cards
         [highlightCards]="highlightCards">
       </app-highlight-cards>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -5,7 +5,7 @@ import {RESPONSE} from '../../express.tokens';
 import { Response } from "express";
 
 import {PageMetaService} from '../page-meta.service';
-import {HighlightCard} from "./HighlightCard";
+import {HighlightCard} from "../highlight-cards/HighlightCard";
 import {environment} from "../../environments/environment";
 
 const CCCloseDate = new Date('2023-12-05T12:00:00+00:00');
@@ -29,7 +29,7 @@ export class HomeComponent implements OnInit {
    */
   protected mayBeAboutToRedirect: boolean = true;
 
-  private highlightCards: HighlightCard[];
+  protected highlightCards: HighlightCard[];
 
   public constructor(
     private pageMeta: PageMetaService,
@@ -85,26 +85,5 @@ export class HomeComponent implements OnInit {
     } else {
       this.mayBeAboutToRedirect = false;
     }
-  }
-
-  get highlightCardsToShow(): readonly HighlightCard[] {
-    return this.highlightCards.filter((card: HighlightCard) => {
-      const hasAppearDate = card.appearAt !== 'asap';
-      const hasDisappearDate = card.disappearAt !== 'never';
-
-      if (hasAppearDate && hasDisappearDate && card.appearAt >= card.disappearAt) {
-        throw new Error("disappear date must be after appear date: " + card);
-      }
-
-      if (hasAppearDate && card.appearAt > this.currentTime) {
-        return false;
-      }
-
-      if (hasDisappearDate && card.disappearAt <= this.currentTime) {
-        return false;
-      }
-
-      return true;
-    });
   }
 }

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -4,12 +4,14 @@ import { allChildComponentImports } from '../../allChildComponentImports';
 import { HomeComponent } from './home.component';
 import { HomeRoutingModule } from './home-routing.module';
 import { AsyncPipe } from '@angular/common';
+import {HighlightCardsComponent} from "../highlight-cards/highlight-cards.component";
 
 @NgModule({
   imports: [
     ...allChildComponentImports,
     AsyncPipe,
     HomeRoutingModule,
+    HighlightCardsComponent,
   ],
   declarations: [HomeComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],


### PR DESCRIPTION
![image](https://github.com/thebiggive/donate-frontend/assets/159481/24f58afe-24aa-461a-b67b-39c45e9e6232)

There are currently no highlight cards on our staging environment, so I added some hard-coded ones to test this. Kept that part out of the commit of course.

I've coded it to only show the highlight cards on the explore page if there are no more than 6 explore cards, and if there is no search term - I thought probably if someones doing a search then we want to just let them focus on that search. It might be worth also setting to only show the highlight cards if the are no filters turned on.

Also if there are no campaigns found from a search or selected filters (or if we just have no campaigns at all to show) we currently show "We can't find any campaigns matching this search but there are lots more to choose from.". I guess we don't want that at the same time as the highlight cards, but as coded so far this will show both together in that case:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/25f451a8-16b4-4859-877d-3e13aa859fbf)

