### PR TITLE
DON-979: Use no-cookie version of youtube embed

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -86,7 +86,7 @@ export function app(): express.Express {
           'js.stripe.com',
           'recaptcha.net',
           'www.gstatic.com',
-          // Both Vimeo's iframe embeds seem to need script access to not error with our current embed approach.
+          // Vimeo's iframe embed seems to need script access to not error with our current embed approach.
           'https://player.vimeo.com',
         ],
       },

--- a/server.ts
+++ b/server.ts
@@ -63,7 +63,8 @@ export function app(): express.Express {
           'player.vimeo.com',
           'recaptcha.net',
           'www.recaptcha.net',
-          'www.youtube.com',
+        ],
+        "frame-src": [
           'www.youtube-nocookie.com',
         ],
         'img-src': [

--- a/server.ts
+++ b/server.ts
@@ -64,6 +64,7 @@ export function app(): express.Express {
           'recaptcha.net',
           'www.recaptcha.net',
           'www.youtube.com',
+          'www.youtube-nocookie.com.com',
         ],
         'img-src': [
           `'self'`,
@@ -88,6 +89,7 @@ export function app(): express.Express {
           // Both video services' iframe embeds seem to need script access to not error with our current embed approach.
           'https://player.vimeo.com',
           'https://www.youtube.com/',
+          'https://www.youtube-nocookie.com',
         ],
       },
     },

--- a/server.ts
+++ b/server.ts
@@ -64,7 +64,7 @@ export function app(): express.Express {
           'recaptcha.net',
           'www.recaptcha.net',
           'www.youtube.com',
-          'www.youtube-nocookie.com.com',
+          'www.youtube-nocookie.com',
         ],
         'img-src': [
           `'self'`,

--- a/server.ts
+++ b/server.ts
@@ -86,10 +86,8 @@ export function app(): express.Express {
           'js.stripe.com',
           'recaptcha.net',
           'www.gstatic.com',
-          // Both video services' iframe embeds seem to need script access to not error with our current embed approach.
+          // Both Vimeo's iframe embeds seem to need script access to not error with our current embed approach.
           'https://player.vimeo.com',
-          'https://www.youtube.com/',
-          'https://www.youtube-nocookie.com',
         ],
       },
     },

--- a/server.ts
+++ b/server.ts
@@ -63,8 +63,7 @@ export function app(): express.Express {
           'player.vimeo.com',
           'recaptcha.net',
           'www.recaptcha.net',
-        ],
-        "frame-src": [
+          'www.youtube.com',
           'www.youtube-nocookie.com',
         ],
         'img-src': [

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -105,7 +105,7 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
 
     // As per https://angular.io/guide/security#bypass-security-apis constructing `SafeResourceUrl`s with these appends should be safe.
     if (campaign.video && campaign.video.provider === 'youtube') {
-      this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://www.youtube.com/embed/${campaign.video.key}`);
+      this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://www.youtube-nocookie.com.com/embed/${campaign.video.key}`);
     } else if (campaign.video && campaign.video.provider === 'vimeo') {
       this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://player.vimeo.com/video/${campaign.video.key}`);
     }

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -105,7 +105,7 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
 
     // As per https://angular.io/guide/security#bypass-security-apis constructing `SafeResourceUrl`s with these appends should be safe.
     if (campaign.video && campaign.video.provider === 'youtube') {
-      this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://www.youtube-nocookie.com.com/embed/${campaign.video.key}`);
+      this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://www.youtube-nocookie.com/embed/${campaign.video.key}`);
     } else if (campaign.video && campaign.video.provider === 'vimeo') {
       this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://player.vimeo.com/video/${campaign.video.key}`);
     }


### PR DESCRIPTION
This does seem to have the downside that the embed won't work on dev workstations, since we are not loading the site with HTTPs there, and fixing that doesn't seem that straightforward. But still should give some privacy improvement, and should work ok in staging etc. Looks like it's not trivial to get HTTPs working in dev: https://stackoverflow.com/questions/39210467/get-angular-cli-to-ng-serve-over-https

![image](https://github.com/thebiggive/donate-frontend/assets/159481/3508ed6c-804a-4c30-a65d-1fc7d7192959)
