### PR TITLE
DON-713: Show homepage style highlight cards on explore only if no se…

### DIFF
--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -62,7 +62,7 @@
       <mat-spinner color="primary" diameter="30" aria-label="Loading campaigns"></mat-spinner>
     }
 
-    @if (campaigns.length === 0 && !loading) {
+    @if (campaigns.length === 0 && !loading && this.searched) {
       <div>
         <p class="error" aria-live="polite">
           We can't find any campaigns matching this search but there are lots more to choose from.
@@ -71,7 +71,7 @@
       </div>
     }
 
-    @if (campaigns.length <=6 && ! searchService.selected.term && !loading && highlightCards.length > 0) {
+    @if (campaigns.length <=6 && ! this.searched && !loading && highlightCards.length > 0) {
       <p>Can't find any campaigns to support? Find out what's next at Big Give</p>
         <app-highlight-cards
           [highlightCards]="highlightCards">


### PR DESCRIPTION
…arch or filter

Screenshots are with some uncommitted code to limit the length of the `this.campaigns` array to six:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/a2e288cb-7497-451a-b2e7-15fd5211e59c)

![image](https://github.com/thebiggive/donate-frontend/assets/159481/47aba687-0012-4965-a21f-80ab06c1a327)
