### PR TITLE
DON-713: Remove obsolete `onlyMatching` param in search query sent to…

### DIFF
--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -130,11 +130,7 @@ export class CampaignService {
   }
 
   search(searchQuery: SearchQuery): Observable<CampaignSummary[]> {
-    let params = new HttpParams(
-      // To-do: DON-713 Remove onlyMatching field once SF backend has been modified to always return
-      // only matched campaigns.
-      {fromObject: {onlyMatching: 'true'}}
-    );
+    let params = new HttpParams();
 
     if (searchQuery.limit) {
       params = params.append('limit', searchQuery.limit.toString());


### PR DESCRIPTION
… SF.

SF now ignores this.