### PR TITLE
DON-976: Allow long charity names to show over donation amount input

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -45,27 +45,22 @@
             </div>
           </div>
           <div class="donation-input donation-input-main">
+
             <biggive-text-input currency="{{campaign.currencyCode}}">
-              <!-- If a charity name is more than about 20 chars it may not fit in the label space and would
-              make the input unusable
-              -->
-              @if (campaign.charity.name.length < 20) {
-                <label
-                  class="label-with-limited-space"
-                  slot="label"
-                  for="donationAmount"
-                  >
-                  Donation to {{campaign.charity.name}}
-                </label>
-              } @else {
-                <label slot="label" for="donationAmount">Donation to {{campaign.charity.name.slice(0, 17)}}…</label>
-              }
+              <label
+                class="label-with-limited-space"
+                slot="label"
+                for="donationAmount"
+              >
+                Donation to {{campaign.charity.name}}
+              </label>
               <input
                 maxlength="10"
                 formControlName="donationAmount" id="donationAmount" matInput
                 slot="input"
-                />
+              />
             </biggive-text-input>
+
           </div>
           @if (donationAmountField?.invalid && donationAmountField?.errors && (donationAmountField?.dirty || donationAmountField?.touched)) {
             <div

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -38,11 +38,7 @@ input {
 }
 
 .label-with-limited-space {
-  overflow: hidden;
   display: inline-block;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-
   max-width: 150px;
   @media #{$breakpoint-smallish} {
     max-width: 100%;


### PR DESCRIPTION
This isn't perfect, because the label is sometimes wider than we would like, so occludes a bit more of the border behind it on the right hand side than the left.  But I think it's probably good enough and it's not worth spending lots of time on trying to possibly make something better. Example of the label being a bit wider than we'd like:

![image](https://github.com/thebiggive/donate-frontend/assets/159481/7943f771-728c-4ed7-8a48-6c2249e5ac0d)

To make it easier to review what we've got here I've made several copies of this donation amount input on the same form showing different length copy. The charity name here is also fictionalised. Of course these changes are not going to be checked into git. Video below to show how this looks over a range of screen widths:

[Screencast from 2024-07-08 10-37-01.webm](https://github.com/thebiggive/donate-frontend/assets/159481/9380e5a2-125f-4b4a-ae47-a5271d882495)
