### PR TITLE
DON-1025: Adjust layout of my regular giving page to use big give cards

### DIFF
--- a/src/app/my-regular-giving/my-regular-giving.component.html
+++ b/src/app/my-regular-giving/my-regular-giving.component.html
@@ -13,19 +13,20 @@
     </biggive-page-section>
      <biggive-page-section>
         @if (mandates.length > 0) {
-          <div class="mandates-container">
+          <biggive-grid columnCount="2">
             @for (mandate of mandates; track mandate.id) {
-                <div class="mandate">
-                  <a href="/campaign/{{mandate.campaignId}}">{{ mandate.charityName }}</a> <br/>
-                  Monthly payment day: {{ mandate.schedule.dayOfMonth }} <br/>
-                  Active From: {{ mandate.schedule.activeFrom | date: 'mediumDate'}} <br/>
-                  Amount: {{ mandate.amount.amountInPence / 100 | exactCurrency:mandate.amount.currency }} <br />
-                  @if (mandate.giftAid) {
-                    Gift Aid applied
-                  }
-                </div>
+              <biggive-basic-card
+                [icon]="false"
+                [textColour]="'primary'"
+                [mainImageUrl]="''"
+                [mainTitle]="mandate.charityName"
+                subtitle="{{(mandate.amount.amountInPence / 100) | exactCurrency:mandate.amount.currency }}, {{ordinal(mandate.schedule.dayOfMonth)}} of each month, {{mandate.giftAid ? 'with Gift Aid, ' : ''}} since {{ mandate.schedule.activeFrom | date: 'mediumDate'}}"
+                [buttonUrl]="'/campaign/' + mandate.campaignId"
+                [buttonAlign]="'center'"
+              >
+              </biggive-basic-card>
             }
-          </div>
+          </biggive-grid>
         } @else {
           <p>No regular giving mandates active</p>
         }

--- a/src/app/my-regular-giving/my-regular-giving.component.ts
+++ b/src/app/my-regular-giving/my-regular-giving.component.ts
@@ -23,6 +23,17 @@ import {Mandate} from "../mandate.model";
 export class MyRegularGivingComponent implements OnInit{
   protected mandates: Mandate[];
 
+  /** @convert number to ordinal, e.g 1st, 2nd*/
+  protected ordinal = (d: number) => {
+    if (d > 3 && d < 21) return d + 'th';
+    switch (d % 10) {
+      case 1:  return d + "st";
+      case 2:  return d + "nd";
+      case 3:  return d + "rd";
+      default: return d + "th";
+    }
+  };
+
   constructor(
     private pageMeta: PageMetaService,
     private route: ActivatedRoute,


### PR DESCRIPTION
I think this can probably complete the ticket.

Before:

![image](https://github.com/user-attachments/assets/4cb9aa88-0105-48ba-b642-25709cb06671)

After:

![image](https://github.com/user-attachments/assets/879e0195-d41f-49c6-99bf-838386787f80)

![image](https://github.com/user-attachments/assets/4c66274c-8265-43d7-9cae-c776b64a5e06)

The cards link to the campaign page. At some point before we launch regular giving I think we will probably need to make a dedicated page for viewing each individual agreement with some facilities to manage it (e.g. end the agreement, maybe see a list of donations taken so far and perhaps upcoming in relation to it), so at that point we might link to that instead, and we might add a button to each card.
