### PR TITLE
DON-896: Update stripe-js library to be able to pass `customerSession…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@fortawesome/pro-duotone-svg-icons": "^6.2.0",
         "@fortawesome/pro-solid-svg-icons": "^6.2.0",
-        "@stripe/stripe-js": "^2.1.0",
+        "@stripe/stripe-js": "^4.4.0",
         "compression": "^1.7.4",
         "express": "^4.19.2",
         "friendly-challenge": "^0.9.16",
@@ -5861,9 +5861,12 @@
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-2.4.0.tgz",
-      "integrity": "sha512-WFkQx1mbs2b5+7looI9IV1BLa3bIApuN3ehp9FP58xGg7KL9hCHDECgW3BwO9l9L+xBPVAD7Yjn1EhGe6EDTeA=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.4.0.tgz",
+      "integrity": "sha512-p1WeTOwnAyXQ9I5/YC3+JXoUB6NKMR4qGjBobie2+rgYa3ftUTRS2L5qRluw/tGACty5SxqnfORCdsaymD1XjQ==",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@fortawesome/pro-duotone-svg-icons": "^6.2.0",
     "@fortawesome/pro-solid-svg-icons": "^6.2.0",
-    "@stripe/stripe-js": "^2.1.0",
+    "@stripe/stripe-js": "^4.4.0",
     "compression": "^1.7.4",
     "express": "^4.19.2",
     "friendly-challenge": "^0.9.16",

--- a/src/app/my-account/my-account.component.spec.ts
+++ b/src/app/my-account/my-account.component.spec.ts
@@ -65,6 +65,7 @@ describe('MyAccountComponent', () => {
           name: null,
         },
         card: {
+          networks: null,
           checks: null,
           country: null,
           exp_month: 5,


### PR DESCRIPTION
…ClientSecret` to stripe elements

Feature introduced in 4.1.0 (
https://github.com/stripe/stripe-js/releases/tag/v4.1.0 ) but we may as well upgrade straight to 4.4.0