### PR TITLE
MAT-376: Display collection time not creation time for donations on "…

### DIFF
--- a/src/app/donation-thanks/donation-thanks.component.spec.ts
+++ b/src/app/donation-thanks/donation-thanks.component.spec.ts
@@ -60,6 +60,7 @@ describe('DonationThanksComponent', () => {
 
   function donationOf(donationAmount: number, currencyCode: string): CompleteDonation {
     return {
+      collectedTime: "collected-time-not-used-here",
       totalPaid: donationAmount,
       firstName: 'first name',
       lastName: 'last name',

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -92,6 +92,11 @@ export interface Donation {
     createdTime?: string;
 
     /**
+     * ISO 8601 formatted datetime
+     */
+    collectedTime?: string
+
+    /**
      * Unique ID for a donation, in Salesforce case-insensitive format. 18 character string.
      * Assigned earlier than PSP's `transactionId`.
      */
@@ -141,6 +146,11 @@ export interface CompleteDonation extends Donation {
    */
   totalPaid: number;
   status: typeof completeStatuses[number]
+
+  /**
+   * ISO 8601 formatted datetime
+   */
+  collectedTime: string
 }
 
 /**

--- a/src/app/my-donations/my-donations.component.html
+++ b/src/app/my-donations/my-donations.component.html
@@ -64,7 +64,7 @@
                       <li>Charity receives: {{donation.totalValue | exactCurrency:donation.currencyCode }}</li>
                     </ul>
                     <ul>
-                      <li>Date: {{ donation.createdTime | date: 'mediumDate' }}</li>
+                      <li>Date: {{ donation.collectedTime | date: 'mediumDate' }}</li>
                       <li>Payment Reference: <span class="reference">{{ donation.transactionId }}</span></li>
                     </ul>
                 </div>


### PR DESCRIPTION
…my donations"

Distinction will be important especially for regular giving, when donations may be created weeks or months before they are collected. Donor will only be interested in when they were collected.