### PR TITLE
Increment circleci cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v5-dependencies-with-chrome-{{ checksum "package-lock.json" }}
+            - v6-dependencies-with-chrome-{{ checksum "package-lock.json" }}
 
       - run: npm install --quiet
 
@@ -37,7 +37,7 @@ jobs:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: v5-dependencies-with-chrome-{{ checksum "package-lock.json" }}
+          key: v6-dependencies-with-chrome-{{ checksum "package-lock.json" }}
 
       - run: npm run ci
 
@@ -61,14 +61,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - v5-dependencies-{{ checksum "package-lock.json" }}
+            - v6-dependencies-{{ checksum "package-lock.json" }}
       - run: env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --quiet
       - save_cache:
           paths:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: v5-dependencies-{{ checksum "package-lock.json" }}
+          key: v6-dependencies-{{ checksum "package-lock.json" }}
 
       - run: npm run build:staging
 
@@ -104,14 +104,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - v5-dependencies-{{ checksum "package-lock.json" }}
+            - v6-dependencies-{{ checksum "package-lock.json" }}
       - run: env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --quiet
       - save_cache:
           paths:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: v5-dependencies-{{ checksum "package-lock.json" }}
+          key: v6-dependencies-{{ checksum "package-lock.json" }}
 
       - run: npm run build:regression
 
@@ -147,14 +147,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - v5-dependencies-{{ checksum "package-lock.json" }}
+            - v6-dependencies-{{ checksum "package-lock.json" }}
       - run: env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --quiet
       - save_cache:
           paths:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: v5-dependencies-{{ checksum "package-lock.json" }}
+          key: v6-dependencies-{{ checksum "package-lock.json" }}
 
       - run: npm run build:production
 


### PR DESCRIPTION
Hoping this might fix deployments to staging, where currently we have a broken link to the 404 at https://donate-staging.thebiggivetest.org.uk/d/runtime.12d4213f76a8d54f.js instead of the working URL https://donate-staging.thebiggivetest.org.uk/d/runtime.30bb5c716ee70850.js