### PR TITLE
Don 1074 card resue checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "donate-frontend",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.1",

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -396,8 +396,14 @@
                     </div>
                   }
                   <div>
-                    @if (showCardReuseMessage) {
-                      Your card will only be saved for reuse if you set a password on the next page.
+                    @if (showCardReuseCheckBox) {
+                      <mat-checkbox
+                        id="saveCardForReuse"
+                        formControlName="saveCardForReuse"
+                        [checked]="true"
+                      >
+                        Save card for reuse
+                      </mat-checkbox>
                     }
                   </div>
                 </div>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -435,7 +435,7 @@ describe('DonationStartForm', () => {
       sut.loadPerson({cash_balance: {gbp: 0}}, 'personID', 'jwt');
     });
 
-    await sut.payWithStripe();
+    await sut.payWithStripe({saveCardForReuse});
 
     expect(finaliseCashBalancePurchaseCalled).toBe(false)
   });

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -356,13 +356,14 @@ export class DonationService {
     );
   }
 
-  confirmCardPayment(donation: Donation, {confirmationToken, paymentMethod}: {confirmationToken?: ConfirmationToken, paymentMethod?: PaymentMethod}):
+  confirmCardPayment(donation: Donation, {confirmationToken, paymentMethod, saveCardForReuse}: {confirmationToken?: ConfirmationToken, paymentMethod?: PaymentMethod, saveCardForReuse: boolean}):
     Observable<{ paymentIntent: { status: PaymentIntent.Status; client_secret: string } }>
   {
     return this.http.post<{paymentIntent: {status: PaymentIntent.Status, client_secret: string}}>(
       `${environment.donationsApiPrefix}/donations/${donation.donationId}/confirm`, {
         stripePaymentMethodId: paymentMethod?.id,
         stripeConfirmationTokenId: confirmationToken?.id,
+        saveCardForReuse
       },
       this.getAuthHttpOptions(donation),
     );


### PR DESCRIPTION
Currently WIP

See related https://github.com/thebiggive/matchbot/pull/1020

At the moment this doesn't work - ticking the new checkbox results in the error as below:

![image](https://github.com/user-attachments/assets/7078d4b8-7cbf-4964-8a72-381851983dbc)

Not sure yet how to get around this - I think Stripe doesn't really want us to avoid their checkbox and implement our own, so without using their checkbox it may be hard to implement a system where we don't know in advance of the donor entering their card details whether or not we're going to save them.

