### PR TITLE
DON-1073: Restore code to avoid making donors give billing address de…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -401,22 +401,22 @@
                     }
                   </div>
                 </div>
-                <div>
-                  <biggive-form-field-select
-                    [prompt]="'Billing country'"
-                    [options]="countryOptionsObject"
-                    [selectedValue]="selectedCountryCode"
-                    [backgroundColour]="'grey'"
-                    [selectionChanged]="setSelectedCountry"
-                    [spaceBelow]="3"
-                    [selectedOptionColour]="'inherit'"
-                    >
-                  </biggive-form-field-select>
+                <div [style.display]="isSavedPaymentMethodSelected ? 'none' : 'block'">
+                    <biggive-form-field-select
+                      [prompt]="'Billing country'"
+                      [options]="countryOptionsObject"
+                      [selectedValue]="selectedCountryCode"
+                      [backgroundColour]="'grey'"
+                      [selectionChanged]="setSelectedCountry"
+                      [spaceBelow]="3"
+                      [selectedOptionColour]="'inherit'"
+                      >
+                    </biggive-form-field-select>
+                  <biggive-text-input>
+                    <label slot="label" for="billingPostcode">Billing postcode</label>
+                    <input slot="input" formControlName="billingPostcode" id="billingPostcode" matInput (change)="onBillingPostCodeChanged($event)" autocapitalize="characters" autocomplete="postal-code">
+                  </biggive-text-input>
                 </div>
-                <biggive-text-input>
-                  <label slot="label" for="billingPostcode">Billing postcode</label>
-                  <input slot="input" formControlName="billingPostcode" id="billingPostcode" matInput (change)="onBillingPostCodeChanged($event)" autocapitalize="characters" autocomplete="postal-code">
-                </biggive-text-input>
               </div>
               @if (stripeError) {
                 <p class="stripeError" aria-live="assertive">


### PR DESCRIPTION
…tails with saved card

Previously reverted because it seemed to be causing DON-1073, but newer evidence suggests that is unrelated so we may as well put this back in.