### PR TITLE
DON-1068: Use different GA copy for tip or no tip

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -240,7 +240,11 @@
                   <div class="binary-options">
                     <div class="binary-option">
                       <mat-radio-button class="b-mr-2 gift-aid" labelPosition="after" [value]="true">
-                        <strong>Yes</strong>, I want to Gift Aid my donation to {{ campaign.charity.name }} and any associated tip to Big Give.
+                        @if (this.tipValue) {
+                          <strong>Yes</strong>, I want to Gift Aid my donation to {{ campaign.charity.name }} and the tip to Big Give.
+                        } @else {
+                          <strong>Yes</strong>, I want to Gift Aid my donation to {{ campaign.charity.name }}.
+                        }
                       </mat-radio-button>
                     </div>
                     <div class="binary-option">


### PR DESCRIPTION
Adds some complexity as if the donor declares that they want to claim GA without a tip we now need to forget that declaration if they go back in the form and add a tip

![image](https://github.com/user-attachments/assets/7ce0f2ba-2b86-4a8d-8ef6-13a1f8b19745)

![image](https://github.com/user-attachments/assets/a5b7d346-7a12-4362-8331-96e86dffdcdf)
