### PR TITLE
BG2-2739: A/B test adding test for zero tip

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -116,7 +116,9 @@
                                 We transform your tips into match funds. Since 2022, charities have received over £200,000 in match funding from Big Give.
                               </li>
                             </ul>
+                            @if (this.zeroTipTextABTestVariant === 'A') {
                             Even £1.50 makes a big difference. Thank you!
+                            }
                           </div>
                         }
                         <div [style]="showCustomTipInput ? '' : 'display: none;'" class="donation-input donation-input-main">
@@ -141,7 +143,11 @@
                         <!-- The text below is not shown if we have the slider because it would just repeat content that's already displayed on the slider itself -->
                         @if (!customTip() && donationAmount && donationAmount > 0 && tipControlStyle !== 'slider') {
                           <mat-hint>
+                            @if (tipAmountField?.valid && zeroTipTextABTestVariant === 'B' && tipValue === 0) {
+                              Even £1 makes a big difference to Big Give
+                            } @else if (tipAmountField?.valid) {
                             <p>{{ tipValue | exactCurrency:campaign.currencyCode }} donation to support Big Give</p>
+                            }
                           </mat-hint>
                         }
                         @if (customTip() && donationAmount && donationAmount > 0) {

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -253,6 +253,8 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
   friendlyCaptcha: ElementRef<HTMLElement>|undefined;
   protected shouldShowCaptcha: boolean = true;
   protected isSavedPaymentMethodSelected: boolean = false;
+  protected zeroTipTextABTestVariant: 'A'|'B' = 'A';
+  private manuallySelectedABTestVariant: string | null = null;
 
   constructor(
     public cardIconsService: CardIconsService,
@@ -282,6 +284,16 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     this.tipControlStyle = (queryParams?.tipControl?.toLowerCase() === 'slider')
       ? 'slider' : 'dropdown';
+
+
+    if (! environment.production) {
+      this.manuallySelectedABTestVariant = queryParams?.selectABTestVariant;
+    }
+
+
+    if (this.manuallySelectedABTestVariant == 'B') {
+      this.zeroTipTextABTestVariant = 'B';
+    }
   }
 
   ngOnDestroy() {
@@ -311,14 +323,19 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
           variations: [
             {
                 name: 'original',
-                activate: (_event: any) => {
+                activate: (_event: unknown) => {
                   // No change from the original form.
                   console.log('Original test variant active!');
+                  this.zeroTipTextABTestVariant = 'A';
                 }
             },
             {
                 name: environment.matomoAbTest.variantName,
-                activate: (_event: any) => {
+                activate: (_event: unknown) => {
+                  if (this.manuallySelectedABTestVariant) {
+                    return;
+                  }
+                  this.zeroTipTextABTestVariant = 'B';
                   console.log('Copy B test variant active!');
                 }
             },

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -23,7 +23,12 @@ export const environment: Environment = {
   identityApiPrefix: 'https://identity-staging.thebiggivetest.org.uk/v1',
   matomoSiteId: 4,
   matomoNonZeroTipGoalId: 1,
-  matomoAbTest: undefined,
+  matomoAbTest: {
+    name: "zeroTipTextAB",
+    variantName: "B",
+    startDate: '2024/09/25 00:00:00 UTC',
+    endDate: undefined,
+  },
   minimumCreditAmount: 500,
   maximumCreditAmount: 500_000,
   postcodeLookupKey: 'gq9-k9zYakORdv2uoY_yVw33182',


### PR DESCRIPTION
Implemented based on pattern of code removed in
https://github.com/thebiggive/donate-frontend/pull/1535

I noticed an existing problem with the "£# donation to support Big Give"
- we were displaying the end of the sentence without the begining if the tip amount form field was invalid (e.g. blank because not yet filled in)

So the logic I have implemented is:

If tip amount is not filled in with a valid value, show nothing

If running A/B test and in variant B and tip amount is filled in with zero show "Even £1 makes a big difference to Big Give"

If not running A/B test or not in variant B show
show "Even £1 makes a big difference to Big Give show "£0 donation to support Big Give" or "£5 donation to support Big Give" etc.

To test variant B in a non-production environment, add ?selectABTestVariant=B to the donate page address bar and refresh


![image](https://github.com/user-attachments/assets/0e8a00c1-7838-4674-bf68-a0dfddb20508)
