### PR TITLE
Fix flex justify & align compatibility warnings

### DIFF
--- a/src/app/my-account/my-account.component.scss
+++ b/src/app/my-account/my-account.component.scss
@@ -46,7 +46,7 @@ main > div {
 
 .logout-row {
   display: flex;
-  align-items: end;
+  align-items: flex-end;
   justify-content: right;
   gap: 17px;
 }

--- a/src/app/my-account/my-account.component.scss
+++ b/src/app/my-account/my-account.component.scss
@@ -36,7 +36,7 @@ main > div {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   gap: 17px;
 }
 


### PR DESCRIPTION
`flex-start` has wider support, e.g. medium-old Safari