### PR TITLE
DON-1073: Add check for consistent node version across ECR and SE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - node20.13.1-dependencies-with-chrome-{{ checksum "package-lock.json" }}
+            - dependencies-with-chrome-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
 
       - run: npm install --quiet
 
@@ -37,7 +37,9 @@ jobs:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: node20.13.1-dependencies-with-chrome-{{ checksum "package-lock.json" }}
+          key: dependencies-with-chrome-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
+
+      - run: node --test src/app/node-version.spec.mjs
 
       - run: npm run ci
 
@@ -62,14 +64,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - node20.13.1-dependencies-{{ checksum "package-lock.json" }}
+            - dependencies-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
       - run: env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --quiet
       - save_cache:
           paths:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: node20.13.1-dependencies-{{ checksum "package-lock.json" }}
+          key: dependencies-{{ checksum "package-lock.json" }}{{ checksum "src/app/node-version.spec.mjs"}}
 
       - run: node --version
       - run: npm run build:staging
@@ -107,14 +109,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - node20.13.1-dependencies-{{ checksum "package-lock.json" }}
+            - dependencies-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
       - run: env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --quiet
       - save_cache:
           paths:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: node20.13.1-dependencies-{{ checksum "package-lock.json" }}
+          key: dependencies-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
 
       - run: npm run build:regression
 
@@ -151,14 +153,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - node20.13.1-dependencies-{{ checksum "package-lock.json" }}
+            - dependencies-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
       - run: env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --quiet
       - save_cache:
           paths:
             - node_modules
             - /home/circleci/.cache/Cypress
             - /home/circleci/.cache/puppeteer
-          key: node20.13.1-dependencies-{{ checksum "package-lock.json" }}
+          key: dependencies-{{ checksum "package-lock.json" }}-{{ checksum "src/app/node-version.spec.mjs"}}
 
       - run: npm run build:production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Ensure updates are mirrored in `.circleci/config.yml`.
 # Always specify a 3-part version, even if it's x.x.0.
-FROM node:20.13.1
+FROM node:20.13.0
 RUN node --version
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Ensure updates are mirrored in `.circleci/config.yml`.
 # Always specify a 3-part version, even if it's x.x.0.
-FROM node:20.13.0
+FROM node:20.13.1
 RUN node --version
 
 WORKDIR /usr/src/app

--- a/src/app/node-version.spec.mjs
+++ b/src/app/node-version.spec.mjs
@@ -1,0 +1,29 @@
+/**
+ * When we build the site for deployment to AWS S3 and AWS ECR/ECS we need to use a consistent node version,
+ * partly for compatibility with our code, but also to make sure that all generated js chunk checksums match up
+ * so that the two builds will work together as one app and not fall over with 404 errors as we saw in DON-1073
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from 'path'
+import {readFileSync} from "node:fs";
+const expectedNodeVersion = '20.13.1';
+
+const modulePath = dirname(fileURLToPath(import.meta.url));
+
+test('should only have the expected node version mentioned in circle config for S3 build', async () => {
+  const circleConfig = readFileSync(resolve(modulePath, '../../.circleci/config.yml')).toString();
+  const nodeMentions = [...circleConfig.matchAll(/node[0-9\\.]+/g)];
+  nodeMentions.forEach(match => {
+    assert.equal(match[0], `node${expectedNodeVersion}`);
+  })
+});
+
+test('should have the expected node version mentioned in Dockerfile for ECR/ECS build', async () => {
+  const dockerFile = readFileSync(resolve(modulePath, '../../Dockerfile')).toString();
+  const nodeMentions = [...dockerFile.matchAll(/node:[0-9\\.]+/g)];
+  nodeMentions.forEach(match => {
+    assert.equal(match[0], `node:${expectedNodeVersion}`);
+  })})

--- a/src/app/node-version.spec.mjs
+++ b/src/app/node-version.spec.mjs
@@ -13,8 +13,8 @@ const modulePath = dirname(fileURLToPath(import.meta.url));
 
 const expectedNodeVersion = '20.13.1';
 
-function assertAllNodeMentionsAreExpectedVersion(circleConfig) {
-  const nodeMentions = [...circleConfig.matchAll(/node:[0-9\\.]+/g)];
+function assertAllNodeMentionsAreExpectedVersion(fileContent) {
+  const nodeMentions = [...fileContent.matchAll(/node:[0-9\\.]+/g)];
   assert(nodeMentions.length > 0);
   nodeMentions.forEach(match => {
     assert.equal(match[0], `node:${expectedNodeVersion}`);

--- a/src/app/node-version.spec.mjs
+++ b/src/app/node-version.spec.mjs
@@ -9,21 +9,24 @@ import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from 'path'
 import {readFileSync} from "node:fs";
+const modulePath = dirname(fileURLToPath(import.meta.url));
+
 const expectedNodeVersion = '20.13.1';
 
-const modulePath = dirname(fileURLToPath(import.meta.url));
+function assertAllNodeMentionsAreExpectedVersion(circleConfig) {
+  const nodeMentions = [...circleConfig.matchAll(/node:[0-9\\.]+/g)];
+  assert(nodeMentions.length > 0);
+  nodeMentions.forEach(match => {
+    assert.equal(match[0], `node:${expectedNodeVersion}`);
+  })
+}
 
 test('should only have the expected node version mentioned in circle config for S3 build', async () => {
   const circleConfig = readFileSync(resolve(modulePath, '../../.circleci/config.yml')).toString();
-  const nodeMentions = [...circleConfig.matchAll(/node[0-9\\.]+/g)];
-  nodeMentions.forEach(match => {
-    assert.equal(match[0], `node${expectedNodeVersion}`);
-  })
+  assertAllNodeMentionsAreExpectedVersion(circleConfig);
 });
 
 test('should have the expected node version mentioned in Dockerfile for ECR/ECS build', async () => {
   const dockerFile = readFileSync(resolve(modulePath, '../../Dockerfile')).toString();
-  const nodeMentions = [...dockerFile.matchAll(/node:[0-9\\.]+/g)];
-  nodeMentions.forEach(match => {
-    assert.equal(match[0], `node:${expectedNodeVersion}`);
-  })})
+  assertAllNodeMentionsAreExpectedVersion(dockerFile);
+});


### PR DESCRIPTION
Our existing tests run in the browser. This new test is really static anysis using a test framework, so it needs access to the filesystem which isn't possible in the browser. Hence running it separately, using the node built-in test framework.