### PR TITLE
COM-99: Focus state on expansion panel & buttons on donate page

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -284,6 +284,16 @@ input {
   padding: 0; // We rely on containing element margin, and don't want vendor-dependent extra padding.
 };
 
+// I we would like to apply the :focus-visible-within pseduo-class but that doesn't exist. See
+// https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class
+mat-expansion-panel:has(:focus-visible){
+  outline: 1px solid $colour-secondary;
+}
+
+button:focus-visible {
+  outline: 1px solid $colour-secondary;
+}
+
 #giftAidAddressContainer {
   margin-top: 60px;
 }


### PR DESCRIPTION
This is maybe expanding the scope of the ticket a bit, but we should have consistent focus state indication across the page.

Adds a coral border around the expansion panel headed "How does Big Give use tips?" and also the buttons on the page (mostly marked Continue) when focused using the keyboard. Doesn't add if its focused using a mouse or finger since that's generally unnecessary.

[Screencast from 2024-10-07 11-54-47.webm](https://github.com/user-attachments/assets/776f74e3-c10c-482f-b77a-27d0b6b4d383)
