### PR TITLE
DON-998: Create mostly page to hold regular giving mandate creation form

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -1,4 +1,4 @@
-import {ActivatedRouteSnapshot, Router, Routes} from '@angular/router';
+import {ActivatedRouteSnapshot, CanActivateFn, Router, Routes} from '@angular/router';
 
 import {CampaignListResolver} from './campaign-list.resolver';
 import {CampaignResolver} from './campaign.resolver';
@@ -15,6 +15,7 @@ import {MyDonationsComponent} from "./my-donations/my-donations.component";
 import {DonationService} from "./donation.service";
 import {MyRegularGivingComponent} from "./my-regular-giving/my-regular-giving.component";
 import {MandateService} from "./mandate.service";
+import {RegularGivingComponent} from "./regular-giving/regular-giving.component";
 
 export const registerPath = 'register';
 export const myAccountPath = 'my-account';
@@ -35,7 +36,7 @@ const redirectIfAlreadyLoggedIn = (snapshot: ActivatedRouteSnapshot) => {
   }
 };
 
-const requireLogin = (activatedRoute: ActivatedRouteSnapshot) => {
+const requireLogin: CanActivateFn = (_activatedRouteSnapshot, routerStateSnapshot) => {
   if (! isPlatformBrowser(inject(PLATFORM_ID))) {
     // Pages that require auth should not be server side rendered - we do not have auth creds on the server side.
     return false;
@@ -51,7 +52,8 @@ const requireLogin = (activatedRoute: ActivatedRouteSnapshot) => {
   // on successful login the login page redirects back to My Account by default.
   // If we need to redirect to any other pages in future, we can take an ActivatedRouteSnapshot param here
   // and pass it to the login page as an 'r' query param.
-  const redirectPath = activatedRoute?.routeConfig?.path;
+
+  const redirectPath = routerStateSnapshot.url
   if (redirectPath) {
     const query = new URLSearchParams({r: redirectPath})
     const url = '/login?' + query.toString();
@@ -247,6 +249,20 @@ if (flags.regularGivingEnabled) {
       ],
     },
   );
+
+  routes.unshift(
+    {
+      path: 'regular-giving/:campaignId',
+      pathMatch: 'full',
+      component: RegularGivingComponent,
+      canActivate: [
+        requireLogin,
+      ],
+      resolve: {
+        campaign: CampaignResolver,
+      },
+    },
+  )
 }
 
 export {routes};

--- a/src/app/regular-giving/regular-giving.component.cy.ts
+++ b/src/app/regular-giving/regular-giving.component.cy.ts
@@ -1,0 +1,7 @@
+import { RegularGivingComponent } from './regular-giving.component'
+
+describe('RegularGivingComponent', () => {
+  it('should mount', () => {
+    cy.mount(RegularGivingComponent)
+  })
+})

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -1,0 +1,21 @@
+<main class="b-container">
+  <div class="c-form-container">
+    <div class="b-primary-column">
+      <biggive-page-section>
+      <biggive-heading
+        space-above=0
+        space-below=3
+        colour="black"
+        html-element="h1"
+        size="1"
+        align="left"
+        text="Regular giving to {{campaign.charity.name}} for {{campaign.title}}"
+      >
+      </biggive-heading>
+      </biggive-page-section>
+      <biggive-page-section>
+        <p>Todo - create regular giving form here</p>
+      </biggive-page-section>
+    </div>
+  </div>
+</main>

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -2,18 +2,6 @@
   <div class="c-form-container">
     <div class="b-primary-column">
       <biggive-page-section>
-      <biggive-heading
-        space-above=0
-        space-below=3
-        colour="black"
-        html-element="h1"
-        size="1"
-        align="left"
-        text="Regular giving to {{campaign.charity.name}} for {{campaign.title}}"
-      >
-      </biggive-heading>
-      </biggive-page-section>
-      <biggive-page-section>
         <form
           class="c-regular-giving-form"
           (keydown.enter)="interceptSubmitAndProceedInstead($event)"
@@ -30,6 +18,17 @@
               formGroupName="amounts"
               label="Your regular donation"
               class="c-your-donation">
+
+              <div class="donationInfoWrapper">
+                <div>
+                  <p class="b-rt-0 b-m-0">You are supporting:</p>
+                  <p class="b-rt-0 b-m-0 b-bold">{{ campaign.charity.name }}</p>
+                </div>
+                <div>
+                  <p class="b-rt-0 b-m-0">for:</p>
+                  <p class="b-rt-0 b-m-0 b-bold">{{ campaign.title }}</p>
+                </div>
+              </div>
 
               <div class="donation-input donation-input-main">
 

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -17,5 +17,33 @@
         <p>Todo - create regular giving form here</p>
       </biggive-page-section>
     </div>
+    <div class="b-secondary-column">
+      <!-- On this page, we agreed that this info is best to hide entirely on mobile. So
+      this has no `mobile` counterpart but we still use the mixin that hides this on mobile. -->
+        <div
+          id="campaign-highlights-beneficiaries-and-categories-desktop"
+        >
+          <div class="match-funded-badge-wrapper">
+            @if (campaign.matchFundsRemaining > 0) {
+              <div class="match-funded-badge">
+                Match Funded
+              </div>
+            }
+          </div>
+          @if (bannerUri$ | async; as bannerUri) {
+          <div class="c-banner">
+            @if (bannerUri) {
+              <img
+                class="c-banner__image b-w-100"
+                [src]="bannerUri"
+                alt=""
+                role="presentation"
+              >
+            }
+          </div>
+          }
+          <app-campaign-info [campaign]="campaign"></app-campaign-info>
+        </div>
+    </div>
   </div>
 </main>

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -14,7 +14,81 @@
       </biggive-heading>
       </biggive-page-section>
       <biggive-page-section>
-        <p>Todo - create regular giving form here</p>
+        <form
+          class="c-regular-giving-form"
+          (keydown.enter)="interceptSubmitAndProceedInstead($event)"
+          [formGroup]="mandateForm"
+        >
+          <mat-vertical-stepper
+            id="stepper"
+            linear
+            #stepper
+            (selectionChange)="stepChanged($event)"
+            [@.disabled]
+          >
+            <mat-step
+              formGroupName="amounts"
+              label="Your regular donation"
+              class="c-your-donation">
+
+              <div class="donation-input donation-input-main">
+
+                <biggive-text-input currency="{{campaign.currencyCode}}">
+                  <label
+                    class="label-with-limited-space"
+                    slot="label"
+                    for="donationAmount"
+                  >
+                    Monthly donation to {{campaign.charity.name}}
+                  </label>
+                  <input
+                    maxlength="10"
+                    formControlName="donationAmount" id="donationAmount" matInput
+                    slot="input"
+                  />
+                </biggive-text-input>
+              </div>
+              <p>This amount will be taken from your account today and once every month in future</p>
+
+              <div style="text-align: center">
+                <button style="width: 40%;"
+                        type="button"
+                        class="continue b-w-100 b-rt-0"
+                        mat-raised-button
+                        color="primary"
+                        (click)="next()"
+                >Continue</button>
+              </div>
+
+            </mat-step>
+            <mat-step
+              label="Confirm"
+              class="c-make-your-donation"
+            >
+              <p class="b-rt-0 b-m-0 b-mt-40">By clicking on the <span class="b-bold">Start regular giving now</span> button, you agree to
+                Big Give's Terms and Conditions and Privacy Statement. <br/>
+                <a [href]="termsUrl" target="_blank">
+                  <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                  Read our Terms and Conditions,
+                </a>
+                <a [href]="privacyUrl" target="_blank">
+                  <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                  read our Privacy Statement.</a>
+              </p>
+              <p>(todo: add link to regular giving terms & conditions)</p>
+
+              <button
+                (click)="submit()"
+                (keyup.enter)="submit()"
+                class="c-donate-button b-donate-button b-w-100 b-rt-1"
+                mat-raised-button
+                color="primary"
+              >
+                Start regular giving now
+              </button>
+            </mat-step>
+          </mat-vertical-stepper>
+        </form>
       </biggive-page-section>
     </div>
     <div class="b-secondary-column">

--- a/src/app/regular-giving/regular-giving.component.scss
+++ b/src/app/regular-giving/regular-giving.component.scss
@@ -3,7 +3,10 @@
 @include vary-campaign-info-layout();
 
 // code below duplicated from donation-start-container.component.scss
-// consider refactoring to remove duplication.
+// consider refactoring to remove duplication. However not dedupling just yet as we may want
+// to make changes specific to this usage - e.g. do we want to show a match funded banner or not,
+// given that we need to explain a more specific message for regular giving that the first donations
+// will be match funded and later ones will not be.
 .c-form-container {
   display: flex;
   flex-direction: column;
@@ -33,3 +36,42 @@
   font-weight: bold;
   top: 30px;
 }
+
+.mat-stepper-horizontal, .mat-stepper-vertical {
+  background: none;
+  box-shadow: $box-shadow-soft;
+  @include b-rt-0;
+}
+
+.donation-input.donation-input-main {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 400px;
+  clear: both;
+
+  input {
+    text-align: right;
+    font-size: 24px;
+    line-height: 30px;
+    font-weight: bolder;
+
+    @media (max-width: 370px) {
+      // on very narrow screens we need to give space for the prompt text above the input.
+      margin-top: 30px;
+    }
+  }
+}
+
+input {
+  @include b-rt-0;
+}
+
+input {
+  outline: none;
+  border: none;
+  background-color: $colour-background;
+  width: 100%;
+  padding: 0; // We rely on containing element margin, and don't want vendor-dependent extra padding.
+};

--- a/src/app/regular-giving/regular-giving.component.scss
+++ b/src/app/regular-giving/regular-giving.component.scss
@@ -1,0 +1,35 @@
+@import '../../abstract';
+
+@include vary-campaign-info-layout();
+
+// code below duplicated from donation-start-container.component.scss
+// consider refactoring to remove duplication.
+.c-form-container {
+  display: flex;
+  flex-direction: column;
+
+  @media #{$breakpoint-lg} {
+    flex-direction: row;
+  }
+}
+
+.match-funded-badge-wrapper {
+  position  : block;
+  width     : 100%;
+  height    : 100%;
+  text-align: center;
+}
+
+.match-funded-badge {
+  position: relative;
+  display: inline-block;
+  text-align: center;
+  background: $colour-highlight;
+  color: $colour-black;
+  width  : 140px;
+  padding: 0.3rem 0.5rem;
+  margin-bottom: 1rem !important;
+  font-size: 1rem;
+  font-weight: bold;
+  top: 30px;
+}

--- a/src/app/regular-giving/regular-giving.component.scss
+++ b/src/app/regular-giving/regular-giving.component.scss
@@ -116,3 +116,20 @@ input {
   // no need for the margin since we don't have the vertical line.
   margin-left: 0;
 }
+
+div.donationInfoWrapper {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  margin-bottom: 40px;
+  flex-direction: column;
+  gap: 40px;
+
+  div {
+    flex-basis: 40%;
+  }
+
+  @media #{$breakpoint-md} {
+    flex-direction: row;
+  }
+}

--- a/src/app/regular-giving/regular-giving.component.scss
+++ b/src/app/regular-giving/regular-giving.component.scss
@@ -75,3 +75,44 @@ input {
   width: 100%;
   padding: 0; // We rely on containing element margin, and don't want vendor-dependent extra padding.
 };
+
+:host ::ng-deep .mat-step-header {
+  // ng-deep is deprecated, but I'm not sure how else to apply our style choices inside the stepper.
+  background-color: white;
+  font-weight: bold;
+  margin-top: 15px;
+  padding: 16px 24px;
+
+  .mat-step-text-label {
+    font-weight: bold;
+  }
+
+  .mat-step-icon {
+    color: $colour-black;
+    background-color: transparent !important;
+    border-radius: 0;
+
+    // Borders on three sides like this with the right and
+    // left transparent creates an equilateral triangle.
+    // (left + right) * 86% = bottom
+    // from https://css-tricks.com/snippets/css/css-triangle/
+    width: 0;
+    height: 0;
+    border-left: 17px solid transparent;
+    border-right: 17px solid transparent;
+    border-bottom: 29.2px solid $colour-highlight;
+
+    .mat-step-icon-content {
+      margin-top: 17px;
+    }
+  }
+}
+
+:host ::ng-deep .mat-stepper-vertical-line::before {
+  display: none;
+}
+
+:host ::ng-deep .mat-vertical-content-container {
+  // no need for the margin since we don't have the vertical line.
+  margin-left: 0;
+}

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -2,23 +2,32 @@ import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute} from "@angular/router";
 import {Campaign} from "../campaign.model";
 import {ComponentsModule} from "@biggive/components-angular";
+import {CampaignInfoComponent} from "../campaign-info/campaign-info.component";
+import {ImageService} from "../image.service";
+import {Observable} from "rxjs";
+import {AsyncPipe} from "@angular/common";
 
 @Component({
   selector: 'app-regular-giving',
   standalone: true,
   imports: [
-    ComponentsModule
+    ComponentsModule,
+    CampaignInfoComponent,
+    AsyncPipe
   ],
   templateUrl: './regular-giving.component.html',
-  styleUrl: './regular-giving.component.css'
+  styleUrl: './regular-giving.component.scss'
 })
 export class RegularGivingComponent implements OnInit{
   protected campaign: Campaign;
+  protected bannerUri$: Observable<string|null>;
   constructor(
     private route: ActivatedRoute,
+    private imageService: ImageService,
   ) {
   }
   ngOnInit() {
     this.campaign = this.route.snapshot.data.campaign;
+    this.bannerUri$ = this.imageService.getImageUri(this.campaign.bannerUri, 830);
   }
 }

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -1,0 +1,24 @@
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from "@angular/router";
+import {Campaign} from "../campaign.model";
+import {ComponentsModule} from "@biggive/components-angular";
+
+@Component({
+  selector: 'app-regular-giving',
+  standalone: true,
+  imports: [
+    ComponentsModule
+  ],
+  templateUrl: './regular-giving.component.html',
+  styleUrl: './regular-giving.component.css'
+})
+export class RegularGivingComponent implements OnInit{
+  protected campaign: Campaign;
+  constructor(
+    private route: ActivatedRoute,
+  ) {
+  }
+  ngOnInit() {
+    this.campaign = this.route.snapshot.data.campaign;
+  }
+}

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute} from "@angular/router";
 import {Campaign} from "../campaign.model";
 import {ComponentsModule} from "@biggive/components-angular";
@@ -6,6 +6,13 @@ import {CampaignInfoComponent} from "../campaign-info/campaign-info.component";
 import {ImageService} from "../image.service";
 import {Observable} from "rxjs";
 import {AsyncPipe} from "@angular/common";
+import {FormBuilder, FormGroup, FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {MatStep, MatStepper} from "@angular/material/stepper";
+import {StepperSelectionEvent} from "@angular/cdk/stepper";
+import {MatInput} from "@angular/material/input";
+import {MatButton} from "@angular/material/button";
+import {MatSnackBar} from "@angular/material/snack-bar";
+import {MatIcon} from "@angular/material/icon";
 
 @Component({
   selector: 'app-regular-giving',
@@ -13,21 +20,62 @@ import {AsyncPipe} from "@angular/common";
   imports: [
     ComponentsModule,
     CampaignInfoComponent,
-    AsyncPipe
+    AsyncPipe,
+    FormsModule,
+    MatStep,
+    MatStepper,
+    ReactiveFormsModule,
+    MatInput,
+    MatButton,
+    MatIcon
   ],
   templateUrl: './regular-giving.component.html',
   styleUrl: './regular-giving.component.scss'
 })
-export class RegularGivingComponent implements OnInit{
+export class RegularGivingComponent implements OnInit {
   protected campaign: Campaign;
-  protected bannerUri$: Observable<string|null>;
+  protected bannerUri$: Observable<string | null>;
+  mandateForm: FormGroup;
+  @ViewChild('stepper') private stepper: MatStepper;
+  readonly termsUrl = 'https://biggive.org/terms-and-conditions';
+  readonly privacyUrl = 'https://biggive.org/privacy';
+
   constructor(
     private route: ActivatedRoute,
     private imageService: ImageService,
+    private formBuilder: FormBuilder,
+    private snackBar: MatSnackBar,
   ) {
   }
+
   ngOnInit() {
     this.campaign = this.route.snapshot.data.campaign;
     this.bannerUri$ = this.imageService.getImageUri(this.campaign.bannerUri, 830);
+    this.mandateForm = this.formBuilder.group([]);
+  }
+
+  interceptSubmitAndProceedInstead(event: Event) {
+    event.preventDefault();
+    this.next();
+  }
+
+  next() {
+    this.stepper.next();
+  }
+
+  async stepChanged(_event: StepperSelectionEvent) {
+  }
+
+  submit() {
+    const message = "Sorry we haven't built the system for you to actually start a regular donation just yet. Try again later";
+    this.snackBar.open(
+      message,
+      undefined,
+      {
+        // formula for duration from https://ux.stackexchange.com/a/85898/7211
+        duration: Math.min(Math.max(message.length * 50, 2_000), 7_000),
+        panelClass: 'snack-bar',
+      }
+    );
   }
 }


### PR DESCRIPTION
URI is `/regular-giving/<campaignID>` e.g. `/regular-giving/a05ds000000x4tRAAQ`

Feature flagged to not be available in production.

Features so far:
- The page can only be viewed by a logged in user. Attempt to access without logging in will trigger a redirect through the login form and back to the page

- Heading shows the name of the campaign and charity

Still required:

Everything else! e.g.
- Return 404 or display error if campaign is not set up for regular giving (see BG2-2711)
- Display campaign details and links in a nice way (probably with a sidebar similar to on donation page)
- Create actual form for donor to fill in details of what they want to give and confirm. Also the form needs to reflect back to them some of their logged in account details so they can make sure they're logged in with the details they want to use for this regular giving mandate


![image](https://github.com/user-attachments/assets/54e23707-c318-4553-b38c-fc7865392064)
