### PR TITLE
Revert "Try `checkout` before ECS updates"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,6 @@ orbs:
   slack: circleci/slack@4.14.0
 
 jobs:
-  checkout:
-    machine:
-      enabled: true
-    steps:
-      - checkout
-
   test:
     resource_class: large
     docker:
@@ -137,7 +131,6 @@ workflows:
                 event: fail
                 template: basic_fail_1
                 mentions: <@here>
-      - checkout
       - aws-ecs/deploy_service_update:
           name: "Deploy Regression ECS with new image"
           auth:
@@ -191,7 +184,6 @@ workflows:
                 event: fail
                 template: basic_fail_1
                 mentions: <@here>
-      - checkout
       - aws-ecs/deploy_service_update:
           name: "Deploy Staging ECS with new image"
           auth:
@@ -268,7 +260,6 @@ workflows:
                 event: fail
                 template: basic_fail_1
                 mentions: <@here>
-      - checkout
       - aws-ecs/deploy_service_update:
           name: "Deploy Production ECS with new image"
           auth:


### PR DESCRIPTION
Reverts thebiggive/donate-frontend#1697 – possibly implicated in wrong environment deployment steps running