### PR TITLE
DON-1078: Fix stripe error for mismatched donor ID on stripe element …

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -506,12 +506,13 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
               'cancel_auto',
               `Donation cancelled due to donor authentication change`,
             );
-
+            this.destroyStripeElements();
             if (this.donation) {
               // We already know the requested amount, so no need to jump back.
               this.clearDonation(this.donation, {clearAllRecord: true, jumpToStart: false});
             }
             this.createDonationAndMaybePerson();
+            this.prepareStripeElements();
           });
           return;
         }


### PR DESCRIPTION
…& donation

When a donor logs in after starting a donation we cancel that donation and create a new one. We also need to recreate the stripe elements on the page, so that they can confirm the donation and also so they get access to any saved cards on their account