### PR TITLE
DON-1072: Add space above friendly captcha widget on login page

### DIFF
--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -5,7 +5,8 @@
   background-image: url(../../assets/images/grey-header.jpg);
 }
 
-@include friendly-captcha();
-div.frc-captcha {
-  margin-top: 2em;
+div.actions {
+  margin-bottom: 1em;
 }
+
+@include friendly-captcha();


### PR DESCRIPTION
Fixing issue noted on ticket.

Before
![image](https://github.com/user-attachments/assets/8d927803-69d7-440f-86cf-38eab29b6114)

After
![image](https://github.com/user-attachments/assets/2031193b-b319-4210-bb18-3369369a21c6)
