### PR TITLE
Try adding `server.ts` to includes just for linting

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -36,7 +36,6 @@
     "src/polyfills.ts"
   ],
   "include": [
-    "src/**/*.d.ts",
-    "server.ts",
+    "src/**/*.d.ts"
   ]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.app.json",
   "include": [
-    "**/*.ts"
+    "**/*.ts",
+    "server.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
And not main build, which I think has maybe added warnings like "Warning: /home/circleci/******/server.ts is part of the TypeScript compilation but it's unused. Add only entry points to the 'files' or 'include' properties in your tsconfig."