### PR TITLE
Safer resumable donation loading

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -90,10 +90,11 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit{
 
     this.donationStartForm.hideCaptcha();
     this.identityService.get(id, jwt).subscribe({
-      next: (person: Person) => {
+      next: async (person: Person) => {
         this.donor = person; // Should mean donations are attached to the Stripe Customer.
         this.loggedInEmailAddress = person.email_address;
-        this.donationStartForm.loadPerson(person, id, jwt);
+        // `await` to ensure that credit balance is set before checking for resumable donations.
+        await this.donationStartForm.loadPerson(person, id, jwt);
         this.donationStartForm.resumeDonationsIfPossible();
 
         if (this.identityService.isTokenForFinalisedUser(jwt)) {


### PR DESCRIPTION
I've had this in memory on my local for a while, can't remember if I saw a real issue on Staging or just developed a suspicion that the resume logic may not be totally safe when donation credits are involved. It seems like either way this change should be harmless even if not strictly necessary, and it does seem to me like it may well be required for donors who either currently or recently had credits to have donation resumption work properly.