### PR TITLE
Stop many error messages showing up `npm run ci output`

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -19,10 +19,12 @@ import { InMemoryStorageService } from "ngx-webstorage-service";
 import { AppComponent } from "./app.component";
 import { TBG_DONATE_STORAGE } from "./donation.service";
 import { TBG_DONATE_ID_STORAGE } from "./identity.service";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe("AppComponent", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [AppComponent],
       imports: [
         AsyncPipe,

--- a/src/app/campaign-details/campaign-details.component.spec.ts
+++ b/src/app/campaign-details/campaign-details.component.spec.ts
@@ -14,6 +14,7 @@ import { OptimisedImagePipe } from '../optimised-image.pipe';
 import { TimeLeftPipe } from '../time-left.pipe';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('CampaignDetailsComponent', () => {
   let component: CampaignDetailsComponent;
@@ -21,6 +22,7 @@ describe('CampaignDetailsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     void TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [
         CampaignDetailsComponent,
       ],

--- a/src/app/charity/charity.component.spec.ts
+++ b/src/app/charity/charity.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 
 import { CharityComponent } from './charity.component';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('CharityComponent', () => {
   let component: CharityComponent;
@@ -10,6 +11,7 @@ describe('CharityComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [],
       providers: [
         { provide: ActivatedRoute, useValue: { snapshot: { data: { campaigns: [] }} } },

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClientTesting } from "@angular/common/http/testing";
-import { Component } from "@angular/core";
+import {Component, CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatDialogModule } from "@angular/material/dialog";
 import { ActivatedRoute } from "@angular/router";
@@ -38,6 +38,7 @@ describe("DonationStartContainer", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [
         DonationStartContainerComponent,
         DonationStartFormStubComponent,

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -23,7 +23,7 @@ import {IdentityService, TBG_DONATE_ID_STORAGE} from '../../identity.service';
 import {TimeLeftPipe} from "../../time-left.pipe";
 import {DonationStartFormComponent} from "./donation-start-form.component";
 import {CardIconsService} from "../../card-icons.service";
-import {ChangeDetectorRef, ElementRef} from "@angular/core";
+import {ChangeDetectorRef, CUSTOM_ELEMENTS_SCHEMA, ElementRef} from "@angular/core";
 import {ConversionTrackingService} from "../../conversionTracking.service";
 import {PageMetaService} from "../../page-meta.service";
 import {PostcodeService} from "../../postcode.service";
@@ -155,6 +155,7 @@ describe('DonationStartForm', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [FormsModule,
         MatButtonModule, // Not required but makes test DOM layout more realistic
         MatCheckboxModule,

--- a/src/app/donation-start/donation-start-form/donation-tipping-slider/donation-tipping-slider.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-tipping-slider/donation-tipping-slider.component.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NgZone, Renderer2} from '@angular/core';
+import {CUSTOM_ELEMENTS_SCHEMA, NgZone, Renderer2} from '@angular/core';
 
 import {DonationTippingSliderComponent} from './donation-tipping-slider.component';
 import {ViewportRuler} from "@angular/cdk/scrolling";
@@ -14,6 +14,7 @@ describe('DonationTippingSliderComponent', () => {
 
   it('should create', async () => {
     await TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [ DonationTippingSliderComponent ]
     })
     .compileComponents();

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.spec.ts
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 
 import { DonationStartLoginComponent } from './donation-start-login.component';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('DonationStartLoginComponent', () => {
   let component: DonationStartLoginComponent;
@@ -9,6 +10,7 @@ describe('DonationStartLoginComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [ DonationStartLoginComponent ],
       imports: [MatDialogModule]
     })

--- a/src/app/donation-thanks/donation-thanks.component.spec.ts
+++ b/src/app/donation-thanks/donation-thanks.component.spec.ts
@@ -16,6 +16,7 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from "@angular/common/http";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe("DonationThanksComponent", () => {
   let component: DonationThanksComponent;
@@ -23,6 +24,7 @@ describe("DonationThanksComponent", () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [],
       imports: [
         MatButtonModule,

--- a/src/app/explore/explore.component.spec.ts
+++ b/src/app/explore/explore.component.spec.ts
@@ -17,6 +17,7 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from "@angular/common/http";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe("ExploreComponent", () => {
   let component: ExploreComponent;
@@ -24,6 +25,7 @@ describe("ExploreComponent", () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [],
       imports: [
         AsyncPipe,

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -14,6 +14,7 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from "@angular/common/http";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe("HomeComponent", () => {
   let component: HomeComponent;
@@ -21,6 +22,7 @@ describe("HomeComponent", () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [HomeComponent],
       imports: [
         AsyncPipe,

--- a/src/app/login-modal/login-modal.component.spec.ts
+++ b/src/app/login-modal/login-modal.component.spec.ts
@@ -11,6 +11,7 @@ import { LoginModalComponent } from './login-modal.component';
 import { TBG_DONATE_ID_STORAGE } from '../identity.service';
 import {MatomoModule} from "ngx-matomo-client";
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('LoginModalComponent', () => {
   let component: LoginModalComponent;
@@ -18,6 +19,7 @@ describe('LoginModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     declarations: [],
     imports: [FormsModule,
         MatButtonModule,

--- a/src/app/meta-campaign/meta-campaign.component.spec.ts
+++ b/src/app/meta-campaign/meta-campaign.component.spec.ts
@@ -6,7 +6,7 @@ import {
   ViewportScroller,
 } from "@angular/common";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
-import { TransferState } from "@angular/core";
+import {CUSTOM_ELEMENTS_SCHEMA, TransferState} from "@angular/core";
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
@@ -100,6 +100,7 @@ describe("MetaCampaignComponent", () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [MetaCampaignComponent],
       imports: [
         AsyncPipe,

--- a/src/app/popup-standalone/popup-standalone.component.spec.ts
+++ b/src/app/popup-standalone/popup-standalone.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopupStandaloneComponent } from './popup-standalone.component';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('PopupStandaloneComponent', () => {
   let component: PopupStandaloneComponent;
@@ -8,6 +9,7 @@ describe('PopupStandaloneComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [ PopupStandaloneComponent ]
     })
     .compileComponents();

--- a/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/app/reset-password/reset-password.component.spec.ts
@@ -14,6 +14,7 @@ import { TBG_DONATE_ID_STORAGE } from '../identity.service';
 import { ResetPasswordComponent } from './reset-password.component';
 import {MatomoModule} from "ngx-matomo-client";
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
@@ -21,6 +22,7 @@ describe('ResetPasswordComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [
       ],
       imports: [
@@ -54,6 +56,7 @@ describe('ResetPasswordComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 }).compileComponents();

--- a/src/app/time-left.pipe.spec.ts
+++ b/src/app/time-left.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, PLATFORM_ID } from '@angular/core';
+import {ChangeDetectorRef, PLATFORM_ID} from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TimeLeftPipe } from './time-left.pipe';

--- a/src/app/transfer-funds/transfer-funds.component.spec.ts
+++ b/src/app/transfer-funds/transfer-funds.component.spec.ts
@@ -19,6 +19,7 @@ import { InMemoryStorageService } from 'ngx-webstorage-service';
 import { TBG_DONATE_STORAGE } from '../donation.service';
 import { TBG_DONATE_ID_STORAGE } from '../identity.service';
 import { TransferFundsComponent } from './transfer-funds.component';
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('TransferFundsComponent', () => {
   let component: TransferFundsComponent;
@@ -26,6 +27,7 @@ describe('TransferFundsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     void TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [
         FormsModule,
         MatButtonModule,
@@ -62,6 +64,7 @@ describe('TransferFundsComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 }).compileComponents();

--- a/src/app/update-card-modal/update-card-modal.component.spec.ts
+++ b/src/app/update-card-modal/update-card-modal.component.spec.ts
@@ -6,6 +6,7 @@ import {MatDialogModule, MatDialogRef} from "@angular/material/dialog";
 import {NoopAnimationsModule} from "@angular/platform-browser/animations";
 import {InMemoryStorageService} from "ngx-webstorage-service";
 import {TBG_DONATE_ID_STORAGE} from "../identity.service";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
 describe('UpdateCardModalComponent', () => {
   let component: UpdateCardModalComponent;
@@ -13,6 +14,7 @@ describe('UpdateCardModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [],
       imports: [
         FormsModule,


### PR DESCRIPTION
Before this change we had many hundreds of lines of errors showing up, as we ran tests, e.g.:

	ERROR: 'NG0304: 'swiper-slide' is not a known element (used in the 'HomeComponent' component template):
	1. If 'swiper-slide' is an Angular component, then verify that it is a part of an @NgModule where this component is declared.
	2. If 'swiper-slide' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'

and
	ERROR: 'NG0303: Can't bind to 'logo' since it isn't a known property of 'biggive-hero-image' (used in the 'MetaCampaignComponent' component template).
	1. If 'biggive-hero-image' is an Angular component and it has the 'logo' input, then verify that it is a part of an @NgModule where this component is declared.
	2. If 'biggive-hero-image' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.
	3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.'
	
	
**This reduces the length of the `npm run ci` output in CircleCI from 1,930 lines down to "just" 1,115 lines.**