### PR TITLE
Duplicate files suppress warnings

### DIFF
--- a/src/assets/scss/_mat-theme.scss
+++ b/src/assets/scss/_mat-theme.scss
@@ -1,5 +1,9 @@
 @use '@angular/material' as mat;
 
+// suppressing warnings about duplicate styles:
+// https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md
+mat.$theme-ignore-duplication-warnings: true;
+
 $tbg-primary: (
   100: #2C089B,
   200: #2C089B,


### PR DESCRIPTION
Further reduces `npm run ci` output length from 1,115 lines down to 248 lines.