### PR TITLE
Fix CSP warnings on start

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -95,7 +95,7 @@ export function app(): express.Express {
           'www.gstatic.com',
           // Vimeo's iframe embed seems to need script access to not error with our current embed approach.
           'https://player.vimeo.com',
-          'wasm-unsafe-eval','self', // for friendly-captcha, see https://docs.friendlycaptcha.com/#/csp
+          `'wasm-unsafe-eval'`,`'self'`, // for friendly-captcha, see https://docs.friendlycaptcha.com/#/csp
         ],
         'worker-src': [
           'blob:', // friendly-captcha


### PR DESCRIPTION
"Content-Security-Policy got directive value `self` which should be single-quoted and changed to `'self'`. This will be an error in future versions of Helmet." and wasm-unsafe-eval equivalent