### PR TITLE
DON-1085: Improve validation UX in donation funds form

### DIFF
--- a/src/app/transfer-funds/transfer-funds.component.html
+++ b/src/app/transfer-funds/transfer-funds.component.html
@@ -24,7 +24,8 @@
             </mat-form-field>
             @if (creditAmountField?.errors && creditAmountField?.invalid && (creditAmountField?.dirty || creditAmountField?.touched)) {
               <p class="error">
-                Must be between {{ minimumCreditAmount | exactCurrency:currency }} and {{ maximumCreditAmount | exactCurrency:currency }} inclusive.
+                Please enter a whole number of pounds between {{ minimumCreditAmount | exactCurrency:currency }} and
+                {{ maximumCreditAmount | exactCurrency:currency }} inclusive.
               </p>
             }
             @if (donorHasPendingTipBalance) {

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -1,6 +1,6 @@
 import {isPlatformBrowser} from '@angular/common';
 import {AfterContentInit, Component, Inject, OnInit, PLATFORM_ID} from '@angular/core';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSelectChange} from '@angular/material/select';
@@ -83,14 +83,19 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
       marketing: FormGroup,
     } = {
       amounts: this.formBuilder.group({
-        creditAmount: [null, [
-          Validators.required,
-          getCurrencyMinValidator(environment.minimumCreditAmount), // overrides the min amount to value from env file
-          getCurrencyMaxValidator(environment.maximumCreditAmount),
-          Validators.pattern('^[£$]?[0-9]+?(\\.00)?$'),
-        ]],
-        tipPercentage: [this.initialTipSuggestedPercentage],
-        customTipAmount: [null, [
+        creditAmount: new FormControl(
+          null, {
+            validators: [
+              Validators.required,
+              getCurrencyMinValidator(environment.minimumCreditAmount), // overrides the min amount to value from env file
+              getCurrencyMaxValidator(environment.maximumCreditAmount),
+              Validators.pattern('^[£$]?[0-9]+?(\\.00)?$'),
+            ],
+            updateOn: "blur",
+          }),
+        tipPercentage: new FormControl(this.initialTipSuggestedPercentage, {updateOn: "blur"}),
+        customTipAmount: new FormControl(null, {
+          validators: [
           // Explicitly enforce minimum custom tip amount of £0. This is already covered by the regexp
           // validation rule below, but it's good to add the explicit check for future-proofness
           getCurrencyMinValidator(), // no override, so custom tip amount min is £0 (default)
@@ -99,7 +104,9 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
           // See MAT-266 and the Slack thread linked in its description for more context.
           getCurrencyMaxValidator(maximumDonationAmountForFundedDonation),
           Validators.pattern('^[£$]?[0-9]+?(\\.00)?$'),
-        ]],
+          ],
+          updateOn: "blur",
+        }),
       }),
       giftAid: this.formBuilder.group({
         giftAid: [null],


### PR DESCRIPTION
Only tangentially related to the ticket but as we're looking at this form to QA it seems like we may as well make these improvements

- Adjusted error copy to account for possible error of using a non-whole number of pounds. Potentially we could do a smallish amount of extra work to show the specific error in each case, but I don't think we need to now. We could also show the min and max amount at all times on the form as part of the instructions instead of only as an error but again that's a bigger change.

- Adjusted form components to only update on blur instead of in real time as the user types. This means the validation error message will only appear when they blur the input, which is quite a bit more user friendly. See https://ux.stackexchange.com/questions/48268/validate-on-blur-or-keypress


![image](https://github.com/user-attachments/assets/c2ac01c7-c57d-4ddc-bf4b-f776d52d9fe3)
