### PR TITLE
DON-1089: Add do not track param for vimeo embed on campaign detail page

### DIFF
--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -107,7 +107,7 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
     if (campaign.video && campaign.video.provider === 'youtube') {
       this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://www.youtube-nocookie.com/embed/${campaign.video.key}`);
     } else if (campaign.video && campaign.video.provider === 'vimeo') {
-      this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://player.vimeo.com/video/${campaign.video.key}`);
+      this.videoEmbedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`https://player.vimeo.com/video/${campaign.video.key}?dnt=1`); // dnt = do not track
     }
 
     if (campaign.hidden) {


### PR DESCRIPTION
Another possibly better way to do might be using our video component as we do on other parts of the site, but I was in a mood for a quick small change rather than finding the best solution.