### PR TITLE
DON-1070 – add post-script copy when `optInCharityEmail` choice is Yes

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -493,6 +493,10 @@
                     Please note that you might continue to receive communications from the charity if you have already shared your details with them via other methods.
                   </p>
                 }
+                @if (marketingGroup.value.optInCharityEmail === true) {
+                  <p aria-live="polite" class="no-margin-top b-rt-sm b-grey">
+                    As you are providing personal information directly to {{ campaign.charity.name }}, please make sure you read and agree to their privacy statement.</p>
+                }
               </mat-hint>
               <p class="binary-question-header b-bold b-rt-0" id="optInTbgEmail-label">Would you be happy to receive emails from <span class="colour-primary">Big Give</span>?</p>
               <mat-radio-group aria-labelledby="optInTbgEmail-label" formControlName="optInTbgEmail">

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -495,7 +495,7 @@
                 }
                 @if (marketingGroup.value.optInCharityEmail) {
                   <p aria-live="polite" class="no-margin-top b-rt-sm b-grey">
-                    As you are providing personal information directly to {{ campaign.charity.name }}, please make sure you read and agree to their privacy statement.</p>
+                    As you are providing personal information to {{ campaign.charity.name }}, please make sure you read and agree to their privacy statement.</p>
                 }
               </mat-hint>
               <p class="binary-question-header b-bold b-rt-0" id="optInTbgEmail-label">Would you be happy to receive emails from <span class="colour-primary">Big Give</span>?</p>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -493,7 +493,7 @@
                     Please note that you might continue to receive communications from the charity if you have already shared your details with them via other methods.
                   </p>
                 }
-                @if (marketingGroup.value.optInCharityEmail === true) {
+                @if (marketingGroup.value.optInCharityEmail) {
                   <p aria-live="polite" class="no-margin-top b-rt-sm b-grey">
                     As you are providing personal information directly to {{ campaign.charity.name }}, please make sure you read and agree to their privacy statement.</p>
                 }


### PR DESCRIPTION
Adds copy like the example shown below on my local.

<img width="490" alt="Screenshot 2024-11-22 at 16 11 27" src="https://github.com/user-attachments/assets/6b19412c-02cb-42ca-b6c9-c92682df9e00">

Personally I think it looks a bit cramped, but this is the most consistent appearance vs. other copy we put in similar places so probably the safest option for now.