### PR TITLE
BG2-2745: Allow registration via registration page without viewing do…

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -137,7 +137,7 @@
           #frccaptcha
         ></div>
         <hr style="margin: 20px auto;">
-        <a href="{{'/' + registerPath}}">Create new Donation Funds account</a>
+        <a href="{{registerLink}}">Create new donation account</a>
       </biggive-page-section>
     </div>
   </main>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -47,6 +47,7 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy{
   /** Used to prevent displaying the page before all parts are ready **/
   public pageInitialised = false;
   private captchaCode: string | undefined;
+  protected registerLink: string;
 
   constructor(
     private readonly formBuilder: FormBuilder,
@@ -89,8 +90,10 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy{
 
     // allowed chars in URL to redirect to: a-z, A-Z, 0-9, - _ /
     if (redirectParam && isAllowableRedirectPath(redirectParam)) {
-      this.redirectPath = '/' + redirectParam;
+      this.redirectPath = '/' + redirectParam.replace(/^\/+/, ''); // strips any leading slashes
     }
+
+    this.registerLink = `/${registerPath}?r=` + encodeURIComponent(this.redirectPath);
 
     this.pageInitialised = true;
   }

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -16,6 +16,7 @@
         Registering for a Donor Account is quick and easy.
       </p>
 
+      @if (redirectPath === transferFundsPath) {
       <p>
         When you have registered, you will be shown the Transfer Funds page. Here, you can:
       </p>
@@ -29,6 +30,7 @@
 
         <li>Choose whether you would like to join Big Give’s mailing list</li>
       </ul>
+      }
 
       <form
         [formGroup]="registrationForm"

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -10,12 +10,13 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from "@angular/
 import {IdentityService} from "../identity.service";
 import {environment} from "../../environments/environment";
 import {EMAIL_REGEXP} from "../validators/patterns";
-import {Router} from "@angular/router";
+import {ActivatedRoute, Router} from "@angular/router";
 import {MatAutocompleteModule} from "@angular/material/autocomplete";
 import {DomSanitizer, SafeHtml} from "@angular/platform-browser";
 import {transferFundsPath} from "../app-routing";
 import {WidgetInstance} from "friendly-challenge";
 import {flags} from "../featureFlags";
+import {isAllowableRedirectPath} from "../login/login.component";
 
 @Component({
   selector: 'app-register',
@@ -28,6 +29,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('frccaptcha', { static: false })
   protected friendlyCaptcha: ElementRef<HTMLElement>;
   friendlyCaptchaSiteKey = environment.friendlyCaptchaSiteKey;
+  protected readonly transferFundsPath = transferFundsPath;
 
 
   protected processing = false;
@@ -38,6 +40,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   private friendlyCaptchaSolution: string|undefined;
   protected readonly flags = flags;
   private friendlyCaptchaWidget: WidgetInstance;
+  protected redirectPath: string = 'my-account';
 
 
   constructor(
@@ -45,6 +48,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
     private readonly identityService: IdentityService,
     private readonly router: Router,
     private sanitizer: DomSanitizer,
+    private readonly activatedRoute: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: Object,
   ) {
   }
@@ -69,6 +73,13 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
         Validators.pattern(EMAIL_REGEXP),
       ]],
     });
+
+    const redirectParam = this.activatedRoute.snapshot.queryParams.r as string|undefined;
+
+    // allowed chars in URL to redirect to: a-z, A-Z, 0-9, - _ /
+    if (redirectParam && isAllowableRedirectPath(redirectParam)) {
+      this.redirectPath = redirectParam.replace(/^\/+/, ''); // strips any leading slashes;
+    }
   }
 
   async ngAfterViewInit() {
@@ -152,7 +163,8 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
             next: () => {
               // We can't re-use a captcha code twice, so auto-login won't work right now. For now we just
               // redirect to the login form
-              window.location.href = "/login";
+              const newPath = "/login" + '?r=' + encodeURIComponent(this.redirectPath);
+              window.location.href = newPath;
             },
             error: (error) => {
               extractErrorMessage(error);


### PR DESCRIPTION
…nation funds form

By default after registering new donor account holders will now be directed to the "my account" page.

I've kept the copy about transfering funds on the registration page but only in the special case where a donor is on the way to view the transfer funds form. It might be better to move this copy to the top of that actual form - although people need to see it without logging in so maybe even more ideally we'd allow at least part of the form to be viewed without logging in. More than we want to change now.

I've also kept the "quick and easy" copy, although I'm not convinced its helpful.