### PR TITLE
BG2-2775: Don't adjust CC URL after start of Feb 2025

### DIFF
--- a/src/app/highlight-cards/HighlightCard.spec.ts
+++ b/src/app/highlight-cards/HighlightCard.spec.ts
@@ -113,6 +113,10 @@ describe('highlightCard', () => {
   });
 
   it('should replace CC24 link with metacampaign page', () => {
+    if (new Date() > new Date('2025-02-01')) {
+      pending('Implementation was only made for 2024');
+    }
+
     const cardFromApi = cardLinkingTo("https://example-blog.com/christmas-challenge/");
 
     const highlightCardForHomepage = SFAPIHighlightCardToHighlightCard(

--- a/src/app/highlight-cards/HighlightCard.ts
+++ b/src/app/highlight-cards/HighlightCard.ts
@@ -62,7 +62,7 @@ export const SFAPIHighlightCardToHighlightCard = (experienceUriPrefix: string, b
   let href = replaceURLOrigin(experienceUriPrefix, blogUriPrefix, donateUriPrefix, sfApiHighlightCard.button.href);
 
   // temp fix for 2024. Will need to think of something better and probably move this logic to SF for next year.
-  if (href.pathname.includes('christmas-challenge')) {
+  if (href.pathname.includes('christmas-challenge') && (new Date() < new Date('2025-02-01')))  {
     href = new URL(donateUriPrefix + '/christmas-challenge-2024');
   }
 


### PR DESCRIPTION
The implementation we have of this at the moment is specific to 2024