### PR TITLE
DON-1066: Move mandate link on donation to bottom-right of card

### DIFF
--- a/src/app/my-donations/my-donations.component.html
+++ b/src/app/my-donations/my-donations.component.html
@@ -46,12 +46,7 @@
               >
                 <div class="donation">
                   <div>
-                    <p>{{this.displayMethodType(donation)}}
-                    @if (donation.mandate) {
-                      <br />
-                      <a href="{{myRegularGivingPath + '/' + donation.mandate.uuid}}">Regular giving since {{donation.mandate.activeFrom  | date: 'mediumDate'}}</a>
-                    }
-                    </p>
+                    <p>{{this.displayMethodType(donation)}}</p>
                     <h3>{{ donation.charityName }}</h3>
                   </div>
                     <ul>
@@ -73,6 +68,11 @@
                       <li>Payment Reference: <span class="reference">{{ donation.transactionId }}</span></li>
                     </ul>
                 </div>
+                @if (donation.mandate) {
+                  <div class="mandate">
+                    <a href="{{myRegularGivingPath + '/' + donation.mandate.uuid}}">See Mandate</a>
+                  </div>
+                }
               </biggive-container-card>
             }
           </biggive-grid>

--- a/src/app/my-donations/my-donations.component.scss
+++ b/src/app/my-donations/my-donations.component.scss
@@ -15,6 +15,10 @@ p:not(biggive-container-card *) {
   }
 }
 
+.mandate {
+  text-align: right;
+}
+
 div.donation-container {
   display: flex;
   justify-content: left;


### PR DESCRIPTION
As requested in recent comment on ticket

The donation.mandate.activeFrom property is now unused - so we could optimise by removing it and not making matchbot fetch that data, but I think it's OK to leave for now.

![image](https://github.com/user-attachments/assets/29f431f5-4ce3-4859-be5b-1dcb98cc6f2e)
