### PR TITLE
MAT-379: Stop directly creating matchbot donor accounts

### DIFF
--- a/src/app/donor-account.service.ts
+++ b/src/app/donor-account.service.ts
@@ -2,7 +2,6 @@ import {Injectable} from "@angular/core";
 import {Observable, of} from "rxjs";
 import { HttpClient, HttpHeaders } from "@angular/common/http";
 import {environment} from "../environments/environment";
-import {Person} from "./person.model";
 import {IdentityService} from "./identity.service";
 import {DonorAccount} from "./donorAccount.model";
 import {switchMap} from "rxjs/operators";
@@ -15,25 +14,6 @@ export class DonorAccountService {
     private http: HttpClient,
     private identityService: IdentityService,
   ) {
-  }
-
-  createAccount(donor: Person): Observable<unknown> {
-    const jwt = this.identityService.getJWT();
-    if (!jwt) {
-      throw new Error("Missing JWT, can't create donor account");
-    }
-
-    return this.http.post(
-      `${environment.donationsApiPrefix}/people/${donor.id}/donor-account`,
-      {
-        emailAddress: donor.email_address,
-        donorName: {
-          firstName: donor.first_name,
-          lastName: donor.last_name,
-        }
-      },
-      {headers: new HttpHeaders({'X-Tbg-Auth': jwt})}
-    );
   }
 
   /**

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -238,11 +238,6 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
         this.accountHolderName = response.bank_transfer.financial_addresses[0]!.sort_code.account_holder_name;
       });
 
-      this.donorAccountService.createAccount(this.donor).subscribe({
-        next: () => {console.log("Account created")},
-        error () {}, // no need to do anything, possibly matchbot just doesn't have the account creation route yet.
-      });
-
       this.createAndFinaliseTipDonation();
     }
   }


### PR DESCRIPTION
We can now rely on these accounts being created via the Identity service