### PR TITLE
Meta campaign page for regular giving

### DIFF
--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -1,5 +1,5 @@
 <main>
-  @if (tickerMainMessage || tickerItems.length > 0) {
+  @if ((tickerMainMessage || tickerItems.length > 0) && ! metaCampaign?.isRegularGiving) {
     <biggive-totalizer
       primary-colour="primary"
       primary-text-colour="white"
@@ -67,26 +67,52 @@
           (scrolled)="onScroll()"
           [scrollWindow]="true"
           >
-          @for (campaign of individualCampaigns; track campaign.id) {
-            <div>
-              <biggive-campaign-card
-                [banner]="campaign.imageUri | optimisedImage:830 | async"
-                [campaignType]="campaign.isMatched ? 'Match Funded' : null"
-                [campaignTitle]="campaign.title"
-                [donateButtonUrl]="'/donate/' + campaign.id"
-                [moreInfoButtonUrl]="'/campaign/' + campaign.id"
-                [organisationName]="campaign.charity.name"
-                primary-figure-label="Match Funds Remaining"
-                [primaryFigureAmount]="this.metaCampaign?.usesSharedFunds ? null : (campaign.matchFundsRemaining | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)"
-                [progressBarCounter]="getPercentageRaised(campaign)"
-                secondary-figure-label="Total Funds Raised"
-                [secondaryFigureAmount]="this.metaCampaign?.usesSharedFunds ? null : (campaign.amountRaised | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)"
-                [isFutureCampaign]="isInFuture(campaign)"
-                [isPastCampaign]="isInPast(campaign)"
-                [datetime]="getRelevantDateAsStr(campaign)">
-                id="campaign-{{campaign.id}}"
-              </biggive-campaign-card>
-            </div>
+          @if (this.metaCampaign?.isRegularGiving) {
+            <!-- We assume that we show regular giving campaigns only iff we are looking at a regular giving
+            metacampaign page -->
+            @for (campaign of individualCampaigns; track campaign.id) {
+              <div>
+                <biggive-campaign-card
+                  [banner]="campaign.imageUri | optimisedImage:830 | async"
+                  [campaignType]="campaign.isMatched ? 'Match Funded' : null"
+                  [campaignTitle]="campaign.title"
+                  [donateButtonUrl]="'/regular-giving/' + campaign.id"
+                  [donateButtonLabel]="'Donate monthly'"
+                  [moreInfoButtonUrl]="'/charity/' + campaign.charity.id"
+                  [organisationName]="campaign.charity.name"
+                  [progressBarCounter]="getPercentageRaised(campaign)"
+                  primary-figure-label="Total Funds Raised"
+                  [primaryFigureAmount]="this.metaCampaign?.usesSharedFunds ? null : (campaign.amountRaised | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)"
+                  [isFutureCampaign]="isInFuture(campaign)"
+                  [isPastCampaign]="isInPast(campaign)"
+                  [datetime]="getRelevantDateAsStr(campaign)">
+                  id="campaign-{{campaign.id}}"
+                </biggive-campaign-card>
+              </div>
+            }
+          } @else {
+            @for (campaign of individualCampaigns; track campaign.id) {
+              <div>
+                <biggive-campaign-card
+                  [banner]="campaign.imageUri | optimisedImage:830 | async"
+                  [campaignType]="campaign.isMatched ? 'Match Funded' : null"
+                  [campaignTitle]="campaign.title"
+                  [donateButtonUrl]="('/donate/' + campaign.id) "
+                  [donateButtonLabel]="'Donate now'"
+                  [moreInfoButtonUrl]="'/campaign/' + campaign.id"
+                  [organisationName]="campaign.charity.name"
+                  primary-figure-label="Match Funds Remaining"
+                  [primaryFigureAmount]="this.metaCampaign?.usesSharedFunds ? null : (campaign.matchFundsRemaining | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)"
+                  [progressBarCounter]="getPercentageRaised(campaign)"
+                  secondary-figure-label="Total Funds Raised"
+                  [secondaryFigureAmount]="this.metaCampaign?.usesSharedFunds ? null : (campaign.amountRaised | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)"
+                  [isFutureCampaign]="isInFuture(campaign)"
+                  [isPastCampaign]="isInPast(campaign)"
+                  [datetime]="getRelevantDateAsStr(campaign)">
+                  id="campaign-{{campaign.id}}"
+                </biggive-campaign-card>
+              </div>
+            }
           }
         </biggive-grid>
       }

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -35,7 +35,6 @@ import {SESSION_STORAGE, StorageService} from "ngx-webstorage-service";
 const openPipeToken = 'TimeLeftToOpenPipe';
 const endPipeToken = 'timeLeftToEndPipe';
 
-/** @todo Reduce overlap duplication w/ MetaCampaignComponent - see https://www.typescriptlang.org/docs/handbook/mixins.html */
 @Component({
   selector: 'app-explore',
   templateUrl: './explore.component.html',

--- a/src/app/navigation.service.ts
+++ b/src/app/navigation.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
-
 /**
- * Support scroll resoration when using custom 'back' links e.g. to MetacampaignComponent.
+ * Support scroll resoration when using custom 'back' links e.g. to ExploreComponent showing campaign.
  */
 @Injectable({
   providedIn: 'root',


### PR DESCRIPTION
Only a few adjustments to the existing meta-campaign page for the regular giving case.  Specifically removing the ticker, removing the match Funds Remaining indication on each card, changing "Donate now" to "Donate monthly", and changing the "find out more" link target.

This is how it looks with our test campaign. (I added a banner from unsplash & a definition from OED):

![image](https://github.com/user-attachments/assets/0e29c754-dcd3-4771-b0e9-b7237e0648fe)

I think as it doesn't have those changes we'll also need to either exclude regular giving campaigns from the general explore page, or (IMHO less likely what we want) allow that page to show a mix of regular giving and ad-hoc giving campaigns.