### PR TITLE
BG2-2776: Remove special priorty handling for CC highlight card

### DIFF
--- a/src/app/highlight-cards/HighlightCard.spec.ts
+++ b/src/app/highlight-cards/HighlightCard.spec.ts
@@ -2,7 +2,6 @@ import {
   campaignFamilyName,
   SfApiHighlightCard,
   SFAPIHighlightCardToHighlightCard,
-  SFHighlightCardsToFEHighlightCards
 } from "./HighlightCard";
 
 describe('highlightCard', () => {
@@ -146,40 +145,4 @@ describe('highlightCard', () => {
     expect(highlightCardForHomepage.background.image.href).toBe('https://example.com/assets/images/join-mailing-list.webp');
     expect(highlightCardForHomepage.icon?.color).toBe('primary');
     });
-});
-
-describe('SFHighlightCardsToFEHighlightCards', () => {
-  it('Sorts Christmas to the top', () => {
-    const exampleSFCardList: SfApiHighlightCard[] = [
-      {
-        campaignFamily: 'emergencyMatch',
-        cardStyle: 'DONATE_NOW',
-        headerText:  "header",
-        bodyText: "Emergency card body",
-        button: {text: "button text", href: 'https://biggive.org/some-path'}
-      },
-      {
-        campaignFamily: 'christmasChallenge',
-        cardStyle: 'DONATE_NOW',
-        headerText:  "header",
-        bodyText: "Christmas card body",
-        button: {text: "button text", href: 'https://biggive.org/some-path'}
-      },
-      {
-        campaignFamily: 'greenMatchFund',
-        cardStyle: 'DONATE_NOW',
-        headerText:  "header",
-        bodyText: "Green card body",
-        button: {text: "button text", href: 'https://biggive.org/some-path'}
-      },
-    ] as const;
-
-    const FECards = SFHighlightCardsToFEHighlightCards(exampleSFCardList);
-
-    expect(FECards.map((card) => card.bodyText)).toEqual([
-      'Christmas card body',
-      'Emergency card body',
-      'Green card body',
-    ]);
-  })
 });

--- a/src/app/highlight-cards/HighlightCard.ts
+++ b/src/app/highlight-cards/HighlightCard.ts
@@ -115,17 +115,7 @@ function backgroundImage(sfApiHighlightCard: SfApiHighlightCard, donateUriPrefix
 }
 
 export function SFHighlightCardsToFEHighlightCards(apiHighlightCards: SfApiHighlightCard[]): HighlightCard[] {
-  function isChristmasChallenge(card: SfApiHighlightCard) {
-    return card.campaignFamily === "christmasChallenge";
-  }
-
-  // Array.prototype.sort is specified as being stable since (or ECMAScript 2019). I don't think we support any browsers
-  // too old to have that, and we can cope with the possibility of none CC cards being in the wrong order in very old
-  const cardsSortedCCFirst = apiHighlightCards.sort((a, b) => {
-    return +isChristmasChallenge(b) - +isChristmasChallenge(a);
-  });
-
-  return cardsSortedCCFirst.map(
+  return apiHighlightCards.map(
   card => SFAPIHighlightCardToHighlightCard(
     environment.experienceUriPrefix,
     environment.blogUriPrefix,


### PR DESCRIPTION
Logic for highlight cards should be consolidated inside SF once again

Before:

![image](https://github.com/user-attachments/assets/cbd0e23b-0b53-4f75-9936-957234e4b1b0)


After:

![image](https://github.com/user-attachments/assets/a184bbbe-d57e-4479-ab80-8815ed82bf0d)
