### PR TITLE
DON-1115: Remove blank campaign info page sections

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -166,6 +166,7 @@
 
       <div class="c-tabs">
         <mat-tab-group class="c-tab-group" animationDuration="0ms" [color]="'primary'">
+          @if (campaign.problem?.trim() || campaign.solution?.trim()) {
           <mat-tab label="Campaign overview">
             <div class="c-details">
 
@@ -230,6 +231,7 @@
               </ul>
             }
           </mat-tab>
+          }
 
           @if (campaign.updates.length > 0) {
             <mat-tab label="Updates">
@@ -305,6 +307,7 @@
             </mat-tab>
           }
 
+          @if (campaign.impactReporting?.trim() || campaign.impactSummary?.trim()) {
           <mat-tab label="Impact &amp; reporting">
             <div class="c-impact">
               <biggive-heading
@@ -332,6 +335,7 @@
               <p class="c-impact__description">{{ campaign.impactReporting }}</p>
             </div>
           </mat-tab>
+          }
         </mat-tab-group>
       </div>
     </div>

--- a/src/app/campaign-info/campaign-info.component.html
+++ b/src/app/campaign-info/campaign-info.component.html
@@ -15,32 +15,36 @@
   </biggive-campaign-highlights>
 
   <div class="icon-container">
-    <h5>Categories</h5>
-    <hr>
+    @if (campaign.categories.length > 0) {
+      <h5>Categories</h5>
+      <hr>
       <div class="icons">
         @for (category of campaign.categories; track $index) {
           <li class="icon-wrapper">
             <fa-icon [title]="category" [icon]="getCategoryIcon(category)"></fa-icon>
             <span class="c-icon-title">
-              <!-- add zero width space to allow line break -->
+                <!-- add zero width space to allow line break -->
               {{ category.split('/').join('/\u200B') }}
-            </span>
+              </span>
           </li>
         }
       </div>
+    }
 
+    @if (campaign.beneficiaries.length > 0) {
       <h5>Beneficiaries</h5>
       <hr>
-        <ul class="icons">
-          @for (beneficiary of campaign.beneficiaries; track $index) {
-            <li class="icon-wrapper">
-              <fa-icon [title]="beneficiary" [icon]="getBeneficiaryIcon(beneficiary)"></fa-icon>
-              <span class="c-icon-title">
+      <ul class="icons">
+        @for (beneficiary of campaign.beneficiaries; track $index) {
+          <li class="icon-wrapper">
+            <fa-icon [title]="beneficiary" [icon]="getBeneficiaryIcon(beneficiary)"></fa-icon>
+            <span class="c-icon-title">
                 <!-- add zero width space to allow line break -->
-                {{ beneficiary.split('/').join('/\u200B') }}
+              {{ beneficiary.split('/').join('/\u200B') }}
               </span>
-            </li>
-          }
-        </ul>
-      </div>
-    </div>
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</div>

--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -33,16 +33,16 @@ export interface Campaign {
      * ISO 8601 formatted datetime
      **/
     endDate: string;
-    impactReporting: string;
-    impactSummary: string;
+    impactReporting: string | null;
+    impactSummary: string | null;
     isMatched: boolean;
     matchFundsRemaining: number;
     matchFundsTotal: number;
     parentUsesSharedFunds: boolean;
-    problem: string;
+    problem: string | null;
     quotes: Array<{person: string, quote: string}>;
     ready: boolean;
-    solution: string;
+    solution: string | null;
 
     /**
      * ISO 8601 formatted datetime


### PR DESCRIPTION
We're not expecting these to be filled in for regular giving campaigns, so we don't want to show headings for empty sections on a page.

Similarly for categories and beneficiaries, we shouldn't show the heading if there is no data recorded.


Before:

![image](https://github.com/user-attachments/assets/5d911d08-5454-4cf7-a2ef-1cec9037ab43)


After:

![image](https://github.com/user-attachments/assets/ada99cce-dcbe-4ac5-8018-078691fe5b4c)
