### PR TITLE
DON-1008: Show gift aid amount on regular giving mandate viewing page

### DIFF
--- a/src/app/exact-currency.pipe.ts
+++ b/src/app/exact-currency.pipe.ts
@@ -27,7 +27,7 @@ export class ExactCurrencyPipe implements PipeTransform {
     // Donor inputs get passed to this pipe directly, so we need to ensure non-numeric
     // input can't crash the app.
     value = Number(value);
-    if (isNaN(value)) {
+    if (! Number.isFinite(value)) {
       return undefined;
     }
 

--- a/src/app/mandate.model.ts
+++ b/src/app/mandate.model.ts
@@ -1,10 +1,13 @@
+export type Money = {
+  "amountInPence": number,
+  "currency": "GBP"
+};
+
 export interface Mandate {
   id: string,
   campaignId: string,
   charityName: string,
   status: 'active'|'pending',
-  // @todo-regular-giving-DON-1008 : we might want to keep the total donated amount as part of the regular giving mandate
-  // giftAidAmount: number = 0;
   "schedule": {
     "type": "monthly",
     "dayOfMonth": number,
@@ -13,12 +16,8 @@ export interface Mandate {
   },
   numberOfMatchedDonations: number,
   giftAid: boolean,
-  donationAmount: {
-    "amountInPence": number,
-    "currency": "GBP"
-  },
-  matchedAmount: {
-    "amountInPence": number,
-    "currency": "GBP"
-  }
+  donationAmount: Money,
+  matchedAmount: Money,
+  totalCharityReceivesPerInitial: Money,
+  giftAidAmount: Money,
 }

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -20,11 +20,11 @@
         <p><strong>Your donation summary</strong></p>
         <p>Your donation of
           <strong
-            class="figure">{{ mandate.donationAmount.amountInPence / 100 | exactCurrency:mandate.donationAmount.currency }}</strong>
+            class="figure">{{ mandate.donationAmount | money }}</strong>
           is worth
           <strong
             class="figure">
-            {{ ((mandate.donationAmount.amountInPence + mandate.matchedAmount.amountInPence) / 100 | exactCurrency:mandate.donationAmount.currency)}}</strong>
+            {{ mandate.totalCharityReceivesPerInitial | money }}</strong>
             to {{mandate.charityName}}
             for the first
           <strong
@@ -54,19 +54,18 @@
             <td></td>
             <tr class="donationAmount">
               <th scope="row">Your donation</th>
-              <td>{{ mandate.donationAmount.amountInPence / 100 | exactCurrency:mandate.donationAmount.currency }}</td>
+              <td>{{ mandate.donationAmount | money }}</td>
             </tr>
             <tr>
               <th scope="row">Matched amount</th>
-              <td>{{ mandate.matchedAmount.amountInPence / 100 | exactCurrency:mandate.donationAmount.currency }}</td>
+              <td>{{ mandate.matchedAmount | money }}</td>
             </tr>
-            <!--  @todo-regular-giving-DON-1008: consider displaying gift Aid and tip amount on the template (format copied from one-off cmpaign thank you page -->
-            <!--                @if (giftAidAmount > 0) {-->
-            <!--                  <tr>-->
-            <!--                    <th scope="row">Gift Aid Amount</th>-->
-            <!--                    <td>{{ giftAidAmount | exactCurrency:donation.currencyCode }}</td>-->
-            <!--                  </tr>-->
-            <!--                }-->
+            @if (mandate.giftAid) {
+              <tr>
+                <th scope="row">Gift Aid</th>
+                <td>{{ mandate.giftAidAmount | money }}</td>
+              </tr>
+            }
             <tr>
               <td colspan="2">
                 <hr aria-hidden="true">
@@ -76,11 +75,11 @@
             <!-- @todo-regular-giving-DON-1003: Add extra rows when necessary below to show partially matched donations when we allow them -->
             <tr class="receives">
               <th scope="row">Months 1-3, charity receives</th>
-              <td>{{ (mandate.donationAmount.amountInPence + mandate.matchedAmount.amountInPence) / 100 + ' ' | exactCurrency:mandate.donationAmount.currency }}</td>
+              <td>{{ mandate.totalCharityReceivesPerInitial | money }}</td>
             </tr>
             <tr class="receives">
               <th scope="row">From month 4, charity receives</th>
-              <td>{{ mandate.donationAmount.amountInPence / 100 + ' ' | exactCurrency:mandate.donationAmount.currency }}</td>
+              <td>{{ mandate.donationAmount | money }}</td>
             </tr>
           </table>
         </div>

--- a/src/app/mandate/mandate.component.ts
+++ b/src/app/mandate/mandate.component.ts
@@ -4,6 +4,7 @@ import {DatePipe} from "@angular/common";
 import {Mandate} from "../mandate.model";
 import {ExactCurrencyPipe} from "../exact-currency.pipe";
 import {ActivatedRoute} from "@angular/router";
+import {MoneyPipe} from "../money.pipe";
 
 @Component({
   selector: 'app-mandate',
@@ -11,7 +12,8 @@ import {ActivatedRoute} from "@angular/router";
   imports: [
     ComponentsModule,
     DatePipe,
-    ExactCurrencyPipe
+    ExactCurrencyPipe,
+    MoneyPipe
   ],
   templateUrl: './mandate.component.html',
   styleUrl: './mandate.component.scss'

--- a/src/app/money.pipe.ts
+++ b/src/app/money.pipe.ts
@@ -1,0 +1,27 @@
+import {Pipe, PipeTransform} from "@angular/core";
+import {Money} from "./mandate.model";
+import {ExactCurrencyPipe} from "./exact-currency.pipe";
+
+/**
+ * Formats a money object as a string. Currently, the money object is only used in regular giving mandates, (hence
+ * the type being defined in the mandate model file) but it may be expanded to much wider use in future).
+ */
+@Pipe({
+  standalone: true,
+  name: 'money',
+})
+export class MoneyPipe implements PipeTransform {
+  transform(money: Money): string {
+    const exactCurrencyPipe = new ExactCurrencyPipe();
+
+    // Delegate actual work to pre-existing pipe that takes a number. At some point we can consider removing the
+    // old pipe, maybe first swapping the delegation relationship around.
+    const formatted = exactCurrencyPipe.transform(money.amountInPence / 100, money.currency);
+
+    if (typeof formatted !== "string") {
+      throw new Error("Could not format money value: " + money.toString());
+    }
+
+    return formatted;
+  }
+}


### PR DESCRIPTION
In principle has to wait behind
https://github.com/thebiggive/matchbot/pull/1200 although since regular giving isn't possible yet on prod the prod deployment order doesn't matter.

![image](https://github.com/user-attachments/assets/498c85ac-e1ca-44a3-ab8d-e4d151cbb506)
