### PR TITLE
REG-39: Don't require marketing choices in regtest env

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -336,6 +336,10 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
 
     this.setCampaignBasedVars();
 
+    // As on regular-giving form, these opt-in radio buttons seem awkward to click using our regression testing setup, so cheating
+    // and prefilling them with 'no' values in that case.
+    const marketingBooleansDefaultValue = environment.environmentId === 'regression' ? false : null;
+
     const formGroups: {
       amounts: FormGroup,   // Matching reservation happens at the end of this group.
       giftAid: FormGroup,
@@ -360,9 +364,9 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
         homePostcode: [null], // See setConditionalValidators().
       }),
       marketing: this.formBuilder.group({
-        optInCharityEmail: [null, requiredNotBlankValidator],
-        optInTbgEmail: [null, requiredNotBlankValidator],
-        optInChampionEmail: [null],
+        optInCharityEmail: [marketingBooleansDefaultValue, requiredNotBlankValidator],
+        optInTbgEmail: [marketingBooleansDefaultValue, requiredNotBlankValidator],
+        optInChampionEmail: [marketingBooleansDefaultValue],
       }),
       payment: this.formBuilder.group({
         firstName: [null, [

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -145,7 +145,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit {
 
     this.selectedBillingCountryCode = this.donorAccount.billingCountryCode ?? 'GB';
 
-    // These opt-in radio buttons seem awkward to click using our regression testing setup, so cheating
+    // As on donation start form, these opt-in radio buttons seem awkward to click using our regression testing setup, so cheating
     // and prefilling them with 'no' values in that case.
     const booleansDefaultValue = environment.environmentId === 'regression' ? false : null;
 


### PR DESCRIPTION
Clicking these from regests is not working at present - not sure why not but the code to click them is quite brittle, relying on numeric element identifiers. See https://github.com/thebiggive/regression-tests/blob/eb0748213d1682dde8449b1c78dedaf8f0f86f5a/pages/DonateStartPage.js#L37