### PR TITLE
DON-999: Restore ticker for metacampaign page

### DIFF
--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -1,5 +1,5 @@
 <main>
-  @if ((tickerMainMessage || tickerItems.length > 0) && ! metaCampaign?.isRegularGiving) {
+  @if (tickerMainMessage || tickerItems.length > 0) {
     <biggive-totalizer
       primary-colour="primary"
       primary-text-colour="white"


### PR DESCRIPTION
Previously removed in https://github.com/thebiggive/donate-frontend/pull/1819

![image](https://github.com/user-attachments/assets/d913ab12-0ae2-4f2f-afab-0cd0f8bad4d6)
