### PR TITLE
DON-1008: Show GA inclusive figure for charity reciepts from regular …

### DIFF
--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -79,7 +79,7 @@
             </tr>
             <tr class="receives">
               <th scope="row">From month 4, charity receives</th>
-              <td>{{ mandate.donationAmount | money }}</td>
+              <td>{{ mandate.totalIncGiftAid | money }}</td>
             </tr>
           </table>
         </div>


### PR DESCRIPTION
…giving

Making my-account/regular-giving/12ccf96e-b4d5-4c68-8963-b727f6abe212 use the same figure we show as "Total with gift aid " at /my-account/regular-giving

____



Changing the last line in this screenshot to show £12.50 instead of £10.00

![image](https://github.com/user-attachments/assets/ad71c13b-7cf7-4512-ab58-3208d7bd7df5)




This page is unchanged:

![image](https://github.com/user-attachments/assets/096b2e10-703d-432a-b565-1c81a2502f54)
