### PR TITLE
DON-1102: Refactor: Explicitly implement Angular's Resolve interface …

### DIFF
--- a/src/app/campaign-stats-resolver.ts
+++ b/src/app/campaign-stats-resolver.ts
@@ -1,4 +1,4 @@
-import {ActivatedRouteSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {first, Observable, ReplaySubject} from 'rxjs';
 import {CampaignStats} from './campaign-stats.model';
 import {CampaignService} from "./campaign.service";
@@ -12,7 +12,7 @@ type FormattedCampaignStats = {
 @Injectable(
   {providedIn: 'root'}
 )
-export class CampaignStatsResolver {
+export class CampaignStatsResolver implements Resolve<FormattedCampaignStats | null>{
   constructor(private campaignService: CampaignService) {}
 
   resolve(_route: ActivatedRouteSnapshot): Observable<FormattedCampaignStats | null> {

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable, makeStateKey, TransferState } from '@angular/core';
-import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve, Router} from '@angular/router';
 import { EMPTY, Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -10,7 +10,7 @@ import {SearchService} from "./search.service";
 @Injectable(
   {providedIn: 'root'}
 )
-export class CampaignResolver  {
+export class CampaignResolver implements Resolve<Campaign>  {
   constructor(
     public campaignService: CampaignService,
     public searchService: SearchService,

--- a/src/app/charity-campaigns.resolver.ts
+++ b/src/app/charity-campaigns.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve, Router} from '@angular/router';
 
 import { CampaignService } from './campaign.service';
 import { EMPTY, Observable, of } from 'rxjs';
@@ -9,7 +9,7 @@ import { catchError } from 'rxjs/operators';
 @Injectable(
   {providedIn: 'root'}
 )
-export class CharityCampaignsResolver  {
+export class CharityCampaignsResolver implements Resolve<CampaignSummary[]> {
   constructor(private campaignService: CampaignService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<CampaignSummary[]> {

--- a/src/app/donor-account.resolver.ts
+++ b/src/app/donor-account.resolver.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs';
 
 import {DonorAccountService} from './donor-account.service';
@@ -8,7 +8,7 @@ import {DonorAccount} from './donorAccount.model';
 @Injectable(
   {providedIn: 'root'}
 )
-export class DonorAccountResolver {
+export class DonorAccountResolver implements Resolve<DonorAccount | null> {
   constructor(private donorAccountService: DonorAccountService) {}
 
   resolve(_route: ActivatedRouteSnapshot): Observable<DonorAccount | null> {

--- a/src/app/highlight-cards-resolver.ts
+++ b/src/app/highlight-cards-resolver.ts
@@ -1,5 +1,5 @@
 import {HighlightCard} from "./highlight-cards/HighlightCard";
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {CampaignService} from "./campaign.service";
 import {catchError} from "rxjs/operators";
 import {Observable, of} from 'rxjs';
@@ -8,10 +8,10 @@ import {Injectable} from '@angular/core';
 @Injectable(
   {providedIn: 'root'}
 )
-export class HighlightCardsResolver {
+export class HighlightCardsResolver implements Resolve<readonly HighlightCard[]>{
   constructor(private campaignService: CampaignService) {}
 
-  resolve(_route: ActivatedRoute) : Observable<readonly HighlightCard[]> {
+  resolve(_route: ActivatedRouteSnapshot) : Observable<readonly HighlightCard[]> {
     return this.campaignService.getHomePageHighlightCards().pipe(
       // If the HighlightCards API has any error we still want to show the rest of the homepage, so we catch the error
       catchError(error => {

--- a/src/app/logged-in-person.resolver.ts
+++ b/src/app/logged-in-person.resolver.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs';
 
 import {IdentityService} from './identity.service';
@@ -8,7 +8,7 @@ import {Person} from './person.model';
 @Injectable(
   {providedIn: 'root'}
 )
-export class LoggedInPersonResolver {
+export class LoggedInPersonResolver implements Resolve<Person | null> {
   constructor(private identityService: IdentityService) {}
 
   resolve(_route: ActivatedRouteSnapshot): Observable<Person|null> {

--- a/src/app/mandate.resolver.ts
+++ b/src/app/mandate.resolver.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs';
 
 import {Mandate} from './mandate.model';
@@ -8,7 +8,7 @@ import {RegularGivingService} from './regularGiving.service';
 @Injectable(
   {providedIn: 'root'}
 )
-export class MandateResolver {
+export class MandateResolver implements Resolve<Mandate> {
   constructor(private regularGivingService: RegularGivingService) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<Mandate> {

--- a/src/app/past-donations.resolver.ts
+++ b/src/app/past-donations.resolver.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs';
 
 import {DonationService} from './donation.service';
@@ -8,7 +8,7 @@ import {CompleteDonation} from './donation.model';
 @Injectable(
   {providedIn: 'root'}
 )
-export class PastDonationsResolver {
+export class PastDonationsResolver implements Resolve<CompleteDonation[]>{
   constructor(private donationService: DonationService) {}
 
   resolve(_route: ActivatedRouteSnapshot): Observable<CompleteDonation[]> {

--- a/src/app/payment-methods.resolver.ts
+++ b/src/app/payment-methods.resolver.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {from, Observable} from 'rxjs';
 
 import {DonationService} from './donation.service';
@@ -8,7 +8,7 @@ import {PaymentMethod} from '@stripe/stripe-js';
 @Injectable(
   {providedIn: 'root'}
 )
-export class PaymentMethodsResolver {
+export class PaymentMethodsResolver implements Resolve<PaymentMethod[]> {
   constructor(private donationService: DonationService) {}
 
   resolve(_route: ActivatedRouteSnapshot): Observable<PaymentMethod[]> {


### PR DESCRIPTION
…on resolver classes

Doing this also forced me to fix the type of one of the unused _route params.

There's effectively no type checking on resolvers used in app-routing.ts I think since they're used in a union with DeprecatedGuard which is a union with `any`.

See comment at https://github.com/thebiggive/donate-frontend/pull/1870#issuecomment-2662994284