### PR TITLE
DON-1102: Fix breakage at /my-account/regular-giving

### DIFF
--- a/src/app/all-active-mandates.resolver.ts
+++ b/src/app/all-active-mandates.resolver.ts
@@ -1,0 +1,8 @@
+import {RegularGivingService} from './regularGiving.service';
+import {inject} from '@angular/core';
+import {ResolveFn} from '@angular/router';
+import {Mandate} from './mandate.model';
+
+export const allActiveMandatesResolver: ResolveFn<readonly Mandate[]> = () => {
+  return inject(RegularGivingService).getActiveMandates();
+};

--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -24,6 +24,8 @@ import { LoggedInPersonResolver } from './logged-in-person.resolver';
 import { DonorAccountResolver } from './donor-account.resolver';
 import {MyRegularGivingComponent} from './my-regular-giving/my-regular-giving.component';
 import {NavigationService} from './navigation.service';
+import {RegularGivingService} from './regularGiving.service';
+import {allActiveMandatesResolver} from './all-active-mandates.resolver';
 export const registerPath = 'register';
 export const myAccountPath = 'my-account';
 export const transferFundsPath = 'transfer-funds';
@@ -294,7 +296,7 @@ if (flags.regularGivingEnabled) {
     {
       path: myRegularGivingPath,
       resolve: {
-        mandates: MandateResolver,
+        mandates: allActiveMandatesResolver,
       },
       pathMatch: 'full',
       component: MyRegularGivingComponent,


### PR DESCRIPTION
As found by by Dom and noted on ticket.

This resolver is simple enough that I think it's fine inline in app-routing.ts, but I wanted to check whether we're still able to use ResolveFn and inject with a resolver defined in a separate module. Looks like we can.