### PR TITLE
DON-1102 – try previous optimisation settings

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -68,7 +68,23 @@
                   "maximumWarning": "80kb"
                 }
               ],
-              "outputHashing": "all"
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              },
+              "outputHashing": "all",
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "hidden": true,
+                "vendor": true
+              },
+              "namedChunks": true,
+              "extractLicenses": true
             },
             "staging": {
               "fileReplacements": [
@@ -92,7 +108,23 @@
                   "maximumWarning": "80kb"
                 }
               ],
-              "outputHashing": "all"
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              },
+              "outputHashing": "all",
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "hidden": true,
+                "vendor": true
+              },
+              "namedChunks": true,
+              "extractLicenses": true
             },
             "regression": {
               "fileReplacements": [
@@ -116,7 +148,23 @@
                   "maximumWarning": "80kb"
                 }
               ],
-              "outputHashing": "all"
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              },
+              "outputHashing": "all",
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "hidden": true,
+                "vendor": true
+              },
+              "namedChunks": true,
+              "extractLicenses": true
             },
             "development": {
               "optimization": false,


### PR DESCRIPTION
Most notably, turn off `optimization.styles.inlineCritical` which might be implicated in new CSP style-related errors which Chrome shows under `script-src-attr`

Will merge to see if this has any effect. Also open to reverting and/or discussing the other choices in more detail.

I think that the attr in question is from `<link href="styles-ETLS2D33.css" media="print" onload="this.media='all'" rel="stylesheet">` – something with no direct counterpart in Production. It's possible this is a general change in Angular but I think it may be more likely to do with our config around inlining styles.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr