### PR TITLE
DON-1022: Mandate cancellation tweaks

### DIFF
--- a/src/app/bodyStyle.ts
+++ b/src/app/bodyStyle.ts
@@ -1,0 +1,18 @@
+import {isPlatformBrowser} from '@angular/common';
+
+/**
+ * A few components need to manipulate a body class. Using technique from
+ * https://stackoverflow.com/a/52293650/2526181
+ */
+
+export function addBodyClass(platformId: Object, style: 'primary-colour') {
+  if (isPlatformBrowser(platformId)) {
+    document.body.classList.add(style);
+  }
+}
+
+export function removeBodyClass(platformId: Object, style: 'primary-colour') {
+  if (isPlatformBrowser(platformId)) {
+    document.body.classList.remove(style);
+  }
+}

--- a/src/app/cancel-mandate/cancel-mandate.component.ts
+++ b/src/app/cancel-mandate/cancel-mandate.component.ts
@@ -1,5 +1,5 @@
 import {Component, inject, OnDestroy, OnInit, PLATFORM_ID} from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {ComponentsModule} from '@biggive/components-angular';
 import {Mandate} from "../mandate.model";
 import {MoneyPipe} from '../money.pipe';
@@ -12,6 +12,7 @@ import {RegularGivingService} from '../regularGiving.service';
 import {BackendError, errorDescription} from '../backendError';
 import {Toast} from '../toast.service';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {addBodyClass, removeBodyClass} from '../bodyStyle';
 
 @Component({
   selector: 'app-cancel-mandate',
@@ -49,16 +50,11 @@ export class CancelMandateComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.pageMeta.setCommon('Cancel Regular Giving to ' + this.mandate.charityName, '', null);
-    if (isPlatformBrowser(this.platformId)) {
-      console.log("setting body to primary colour");
-      document.body.classList.add('primary-colour');
-    }
+    addBodyClass(this.platformId, 'primary-colour');
   }
 
   ngOnDestroy() {
-    if (isPlatformBrowser(this.platformId)) {
-      document.body.classList.remove('primary-colour');
-    }
+    removeBodyClass(this.platformId, 'primary-colour');
   }
 
   cancel(mandate: Mandate) {

--- a/src/app/cancel-mandate/cancel-mandate.component.ts
+++ b/src/app/cancel-mandate/cancel-mandate.component.ts
@@ -49,6 +49,11 @@ export class CancelMandateComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    if (this.mandate.status === 'cancelled') {
+      void this.router.navigateByUrl(`/my-account/regular-giving/${this.mandate.id}`)
+      return;
+    }
+
     this.pageMeta.setCommon('Cancel Regular Giving to ' + this.mandate.charityName, '', null);
     addBodyClass(this.platformId, 'primary-colour');
   }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -17,6 +17,7 @@ import {registerPath} from "../app-routing";
 import {WidgetInstance} from "friendly-challenge";
 import {NavigationService} from "../navigation.service";
 import {errorDescription, BackendError} from "../backendError";
+import {addBodyClass, removeBodyClass} from '../bodyStyle';
 
 export type LoginNavigationState = {
   /**
@@ -68,17 +69,13 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy{
   }
 
   ngOnDestroy() {
-    if (isPlatformBrowser(this.platformId)) {
-      document.body.classList.remove('primary-colour');
-    }
+    removeBodyClass(this.platformId, 'primary-colour');
   }
 
   ngOnInit() {
     this.pageMeta.setCommon('Login', 'Login to your Big Give account', null);
 
-    if (isPlatformBrowser(this.platformId)) {
-      document.body.classList.add('primary-colour');
-    }
+    addBodyClass(this.platformId, 'primary-colour');
 
     this.loginForm = this.formBuilder.group({
       emailAddress: [null, [

--- a/src/app/mandate.model.ts
+++ b/src/app/mandate.model.ts
@@ -8,6 +8,7 @@ export type Mandate = {
   campaignId: string,
   charityName: string,
   status: 'active'|'pending'|'cancelled',
+  cancellationDate?: string,
   "schedule": {
     "type": "monthly",
     "dayOfMonth": number,

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -19,8 +19,6 @@
       <div id="mandate" class="{{mandate.status}}">
         <div class="donation-summary">
           @if (mandate.status === 'cancelled') {
-            <!-- @todo-regular-giving DON-1117 - add in more details, e.g. cancellation date, maybe distinguish various
-            possible types of cancellation. Probably don't need to show the canceallation reason typed in by donor -->
             <p><strong>Regular Donations Cancelled</strong></p>
             <hr aria-hidden="true">
           }

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -108,6 +108,10 @@
           </table>
         </div>
         <hr class="shorter" aria-hidden="true">
+        <div style="text-align: center">
+        <a [href]="cancelPath">Cancel future donations</a>
+        </div>
+        <hr class="shorter" aria-hidden="true">
       </div>
       <div class="socials">
         <p>Boost your impact by sharing on social media</p>

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -65,6 +65,14 @@
                 <th scope="row">Active from</th>
                 <td id="regularActiveFrom">{{ mandate.schedule.activeFrom | date: 'mediumDate' }}</td>
               </tr>
+
+              @if (mandate.cancellationDate) {
+                <tr>
+                  <th scope="row">Cancelled</th>
+                  <td id="cancelledFrom">{{ mandate.cancellationDate | date: 'mediumDate' }}</td>
+                </tr>
+              }
+
               <tr>
                 <th scope="row">Payment schedule</th>
                 <td id="regularDayOfMonth">Monthly on day #{{ mandate.schedule.dayOfMonth }}</td>

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -16,103 +16,105 @@
         <p class="thank-you-text">Your generous regular donation has been set up.</p>
       </div>
       <hr aria-hidden="true">
-      <div class="donation-summary">
-        @if (mandate.status === 'cancelled') {
-          <!-- @todo-regular-giving DON-1117 - add in more details, e.g. cancellation date, maybe distinguish various
-          possible types of cancellation. Probably don't need to show the canceallation reason typed in by donor -->
-          <p><strong>Regular Donations Cancelled</strong></p>
-          <hr aria-hidden="true">
-        }
-        <p><strong>Your donation summary</strong></p>
-        @if (mandate.isMatched) {
-        <p>Your donation of
-          <strong
-            class="figure">{{ mandate.donationAmount | money }}</strong>
-          is worth
-          <strong
-            class="figure">
-            {{ mandate.totalCharityReceivesPerInitial | money }}</strong>
-            to {{mandate.charityName}}
-            for the first
-          <strong
-            class="figure">
-            {{mandate.numberOfMatchedDonations + ' months!' }}
-          </strong>
-        </p>
-        } @else {
-          <p>Your donation of
-            <strong
-              class="figure">{{ mandate.donationAmount | money }}</strong>
-            is worth
-            <strong
-              class="figure">
-              {{ mandate.totalIncGiftAid | money }}</strong>
-            to {{mandate.charityName}}
-        }
-        <br/>
-        <!--            @todo-regular-giving: consider adding thank you message in matchbot / SF-->
-        <!--            @if (mandate?.thankYouMessage) {-->
-        <!--              <p id="charity-thank-you">{{ mandate?.thankYouMessage }}</p>-->
-        <!--            }-->
-      </div>
-      <div>
-        <div class="receipt">
-          <!-- Date time appears as e.g. "Sep 5, 2023" -->
-          <table>
-            <caption>Your Regular Donation Schedule</caption>
-            <tr>
-              <th scope="row">Active from</th>
-              <td id="regularActiveFrom">{{ mandate.schedule.activeFrom | date: 'mediumDate' }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Payment schedule</th>
-              <td id="regularDayOfMonth">Monthly on day #{{ mandate.schedule.dayOfMonth }}</td>
-            </tr>
-            <td></td>
-            <tr class="donationAmount">
-              <th scope="row">Your donation</th>
-              <td>{{ mandate.donationAmount | money }}</td>
-            </tr>
-            @if (mandate.isMatched) {
-            <tr>
-              <th scope="row">Matched amount</th>
-              <td>{{ mandate.matchedAmount | money }}</td>
-            </tr>
-            }
-            @if (mandate.giftAid) {
-              <tr>
-                <th scope="row">Gift Aid</th>
-                <td>{{ mandate.giftAidAmount | money }}</td>
-              </tr>
-            }
-            <tr>
-              <td colspan="2">
-                <hr aria-hidden="true">
-              </td>
-            </tr>
-            @if (mandate.isMatched) {
-            <tr class="receives">
-              <th scope="row">Months 1-{{mandate.numberOfMatchedDonations}}, charity receives</th>
-              <td>{{ mandate.totalCharityReceivesPerInitial | money }}</td>
-            </tr>
-            <tr class="receives">
-              <th scope="row">From month {{mandate.numberOfMatchedDonations + 1}}, charity receives</th>
-              <td>{{ mandate.totalIncGiftAid | money }}</td>
-            </tr>
-            } @else {
-              <tr class="receives">
-                <th scope="row">Each month, charity receives</th>
-                <td>{{ mandate.totalIncGiftAid | money }}</td>
-              </tr>
-            }
-          </table>
+      <div id="mandate" class="{{mandate.status}}">
+        <div class="donation-summary">
+          @if (mandate.status === 'cancelled') {
+            <!-- @todo-regular-giving DON-1117 - add in more details, e.g. cancellation date, maybe distinguish various
+            possible types of cancellation. Probably don't need to show the canceallation reason typed in by donor -->
+            <p><strong>Regular Donations Cancelled</strong></p>
+            <hr aria-hidden="true">
+          }
+          <p><strong>Your donation summary</strong></p>
+          @if (mandate.isMatched) {
+            <p>Your donation of
+              <strong
+                class="figure">{{ mandate.donationAmount | money }}</strong>
+              is worth
+              <strong
+                class="figure">
+                {{ mandate.totalCharityReceivesPerInitial | money }}</strong>
+              to {{ mandate.charityName }}
+              for the first
+              <strong
+                class="figure">
+                {{ mandate.numberOfMatchedDonations + ' months!' }}
+              </strong>
+            </p>
+          } @else {
+            <p>Your donation of
+              <strong
+                class="figure">{{ mandate.donationAmount | money }}</strong>
+              is worth
+              <strong
+                class="figure">
+                {{ mandate.totalIncGiftAid | money }}</strong>
+              to {{ mandate.charityName }}
+              }
+          <br/>
+          <!--            @todo-regular-giving: consider adding thank you message in matchbot / SF-->
+          <!--            @if (mandate?.thankYouMessage) {-->
+          <!--              <p id="charity-thank-you">{{ mandate?.thankYouMessage }}</p>-->
+          <!--            }-->
         </div>
-        @if (mandate.status !== 'cancelled') {
-          <hr class="shorter" aria-hidden="true">
-          <div style="text-align: center">
-          <a [href]="cancelPath">Cancel future donations</a>
+        <div>
+          <div class="receipt">
+            <!-- Date time appears as e.g. "Sep 5, 2023" -->
+            <table>
+              <caption>Your Regular Donation Schedule</caption>
+              <tr>
+                <th scope="row">Active from</th>
+                <td id="regularActiveFrom">{{ mandate.schedule.activeFrom | date: 'mediumDate' }}</td>
+              </tr>
+              <tr>
+                <th scope="row">Payment schedule</th>
+                <td id="regularDayOfMonth">Monthly on day #{{ mandate.schedule.dayOfMonth }}</td>
+              </tr>
+              <td></td>
+              <tr class="donationAmount">
+                <th scope="row">Your donation</th>
+                <td>{{ mandate.donationAmount | money }}</td>
+              </tr>
+              @if (mandate.isMatched) {
+                <tr>
+                  <th scope="row">Matched amount</th>
+                  <td>{{ mandate.matchedAmount | money }}</td>
+                </tr>
+              }
+              @if (mandate.giftAid) {
+                <tr>
+                  <th scope="row">Gift Aid</th>
+                  <td>{{ mandate.giftAidAmount | money }}</td>
+                </tr>
+              }
+              <tr>
+                <td colspan="2">
+                  <hr aria-hidden="true">
+                </td>
+              </tr>
+              @if (mandate.isMatched) {
+                <tr class="receives">
+                  <th scope="row">Months 1-{{ mandate.numberOfMatchedDonations }}, charity receives</th>
+                  <td>{{ mandate.totalCharityReceivesPerInitial | money }}</td>
+                </tr>
+                <tr class="receives">
+                  <th scope="row">From month {{ mandate.numberOfMatchedDonations + 1 }}, charity receives</th>
+                  <td>{{ mandate.totalIncGiftAid | money }}</td>
+                </tr>
+              } @else {
+                <tr class="receives">
+                  <th scope="row">Each month, charity receives</th>
+                  <td>{{ mandate.totalIncGiftAid | money }}</td>
+                </tr>
+              }
+            </table>
           </div>
-        }
+          @if (mandate.status !== 'cancelled') {
+            <hr class="shorter" aria-hidden="true">
+            <div style="text-align: center">
+              <a [href]="cancelPath">Cancel future donations</a>
+            </div>
+          }
+        </div>
       </div>
       <hr class="shorter" aria-hidden="true">
       <div class="socials">

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -107,12 +107,14 @@
             }
           </table>
         </div>
-        <hr class="shorter" aria-hidden="true">
-        <div style="text-align: center">
-        <a [href]="cancelPath">Cancel future donations</a>
-        </div>
-        <hr class="shorter" aria-hidden="true">
+        @if (mandate.status !== 'cancelled') {
+          <hr class="shorter" aria-hidden="true">
+          <div style="text-align: center">
+          <a [href]="cancelPath">Cancel future donations</a>
+          </div>
+        }
       </div>
+      <hr class="shorter" aria-hidden="true">
       <div class="socials">
         <p>Boost your impact by sharing on social media</p>
         <div class="social-icons-wrapper">

--- a/src/app/mandate/mandate.component.scss
+++ b/src/app/mandate/mandate.component.scss
@@ -227,6 +227,12 @@ div.clearfix {
   }
 }
 
+#mandate.cancelled {
+  background: rgb(0 0 0 / 8%);
+  padding: 2em;
+  border-radius: 4px;
+}
+
 .screenreader-only {
   // additional content for screen readers that is not required for visual presentations.
   position: absolute;

--- a/src/app/mandate/mandate.component.ts
+++ b/src/app/mandate/mandate.component.ts
@@ -4,6 +4,8 @@ import {DatePipe} from "@angular/common";
 import {Mandate} from "../mandate.model";
 import {ActivatedRoute} from "@angular/router";
 import {MoneyPipe} from "../money.pipe";
+import {myRegularGivingPath} from '../app-routing';
+
 
 @Component({
     selector: 'app-mandate',
@@ -15,19 +17,17 @@ import {MoneyPipe} from "../money.pipe";
     templateUrl: './mandate.component.html',
     styleUrl: './mandate.component.scss'
 })
-export class MandateComponent implements OnInit {
+export class MandateComponent {
   protected encodedShareUrl: string = '';
   protected encodedPrefilledText: string = '';
   protected mandate!: Mandate;
+  protected readonly cancelPath;
+
 
   constructor(
     private route: ActivatedRoute
-  ) {}
-
-  ngOnInit() {
+  ) {
     this.mandate = this.route.snapshot.data.mandate;
+    this.cancelPath = `${myRegularGivingPath}/${this.mandate.id}/cancel`;
   }
-
-  // @todo-regular-giving: calculate the total in matchbot and show on template
-  // totalPaid: number = 0;
 }

--- a/src/app/my-regular-giving/my-regular-giving.component.html
+++ b/src/app/my-regular-giving/my-regular-giving.component.html
@@ -15,7 +15,6 @@
         @if (mandates.length > 0) {
           <biggive-grid columnCount="2">
             @for (mandate of mandates; track mandate.id) {
-              <!-- @todo-regular-giving show donor-cancelled mandates here clearly marked as cancelled. Don't show mandates auto-cancelled at creation time that practically never existed. -->
               <biggive-container-card
                 card-colour="white"
                 background-colour="primary"

--- a/src/app/my-regular-giving/my-regular-giving.component.html
+++ b/src/app/my-regular-giving/my-regular-giving.component.html
@@ -20,7 +20,12 @@
                 card-colour="white"
                 background-colour="primary"
               >
-                <div class="mandate">
+                <div class="mandate" class="{{mandate.status}}">
+                  @if (mandate.status === 'cancelled') {
+                    <div class="cancelled">
+                      <strong>Mandate Cancelled</strong>
+                    </div>
+                  }
                   <h3><a href="{{'/campaign/' + mandate.campaignId}}">{{ mandate.charityName }}</a></h3>
                 <ul>
                   <li>Amount: {{mandate.donationAmount | money }}</li>
@@ -31,9 +36,16 @@
                     <li>Total with gift aid {{mandate.totalIncGiftAid | money}}</li>
                   }
                   <li>Payment collection day: {{mandate.schedule.dayOfMonth}} </li>
-                  <li>Next expected payment date: {{ mandate.schedule.expectedNextPaymentDate | date: 'mediumDate'}}</li>
+                  @if (mandate.schedule.expectedNextPaymentDate) {
+                  <li>Next expected payment date:
+                    {{ mandate.schedule.expectedNextPaymentDate | date: 'mediumDate'}}
+                  </li>
+                  }
                   <li>Active from: {{ mandate.schedule.activeFrom | date: 'mediumDate'}}</li>
-                </ul>
+                  @if (mandate.cancellationDate) {
+                    <li>Cancelled: {{ mandate.cancellationDate | date: 'mediumDate'}}</li>
+                  }
+                    </ul>
                 </div>
 
                 <biggive-button

--- a/src/app/my-regular-giving/my-regular-giving.component.scss
+++ b/src/app/my-regular-giving/my-regular-giving.component.scss
@@ -14,6 +14,7 @@ main > div {
 }
 
 div.mandate {
+    position: relative;
     a:link, a:visited, a:hover {
       color: inherit !important;
       text-decoration: none;
@@ -23,4 +24,15 @@ div.mandate {
       list-style-type: none;
       margin-top: auto;
     }
+
+  div.cancelled {
+    background-color: abstract.$colour-secondary;
+    text-align: center;
+    position: absolute;
+    top: -3em;
+    left: 0;
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -20,6 +20,7 @@ import type {LoginNavigationState} from "../login/login.component";
 import {PageMetaService} from '../page-meta.service';
 import {NavigationService} from "../navigation.service";
 import {BackendError, errorDescription, errorDetails} from "../backendError";
+import {addBodyClass, removeBodyClass} from '../bodyStyle';
 
 @Component({
     selector: 'app-register',
@@ -58,17 +59,13 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngOnDestroy() {
-    if (isPlatformBrowser(this.platformId)) {
-      document.body.classList.remove('primary-colour');
-    }
+    removeBodyClass(this.platformId, 'primary-colour');
   }
 
   ngOnInit() {
     this.pageMeta.setCommon('Register', 'Register for a Big Give account', null);
 
-    if (isPlatformBrowser(this.platformId)) {
-      document.body.classList.add('primary-colour');
-    }
+    addBodyClass(this.platformId, 'primary-colour');
 
     this.registrationForm = this.formBuilder.group({
       firstName: [null, [Validators.required]],


### PR DESCRIPTION
AFAIK this does everything we need in FE about cancelled & cancelling mandates:

- Adds a link from mandate detail / thanks page to cancellation form (if not already cancelled)
- Adds the cancellation date to the donation schedule on the donation detail/thanks page
- Adds a cancelled heading on the mandate detail page
- Adds a grey background for a cancelled mandate on the detail page
- Adds a cancelled heading in the mandate box on the list of mandates page
- Adds the cancellation date in the mandates box on the list of mandates page
- Removes the next payment date on the list of mandates page when n/a
- Auto redirects from the cancellation form back to mandate detail if donor navigates to form for an already-cancelled mandate

![image](https://github.com/user-attachments/assets/ed372ae1-58f3-4389-9b3d-046cf84c21b2)

![image](https://github.com/user-attachments/assets/c61a6201-19d7-4a8c-b620-8fd91b9d1526)

![image](https://github.com/user-attachments/assets/b76d4883-1110-45da-acf9-596b84ee0aef)
