### PR TITLE
Remove non-working social share links from Mandate view page

### DIFF
--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -122,38 +122,6 @@
           }
         </div>
       </div>
-      <hr class="shorter" aria-hidden="true">
-      <div class="socials">
-        <p>Boost your impact by sharing on social media</p>
-        <div class="social-icons-wrapper">
-          <span class="separator"></span>
-          <biggive-social-icon
-            service="Facebook"
-            label-prefix="Share"
-            url="https://www.facebook.com/sharer/sharer.php?u={{ encodedShareUrl }}" background-colour="tertiary"
-            icon-colour="black"
-            wide="true"
-          ></biggive-social-icon>
-          <span class="separator"></span>
-          <biggive-social-icon
-            service="Twitter"
-            label-prefix="Share"
-            url="https://x.com/intent/post?url={{ encodedShareUrl }}&text={{ encodedPrefilledText }}"
-            background-colour="tertiary"
-            icon-colour="black"
-            wide="true"
-          ></biggive-social-icon>
-          <span class="separator"></span>
-          <biggive-social-icon
-            service="LinkedIn"
-            label-prefix="Share"
-            url="https://www.linkedin.com/cws/share?url={{ encodedShareUrl }}"
-            background-colour="tertiary"
-            icon-colour="black"
-            wide="true"
-          ></biggive-social-icon>
-        </div>
-      </div>
     </div>
   </div>
 </main>

--- a/src/app/mandate/mandate.component.scss
+++ b/src/app/mandate/mandate.component.scss
@@ -185,46 +185,8 @@ div.clearfix {
   }
 }
 
-.socials {
-  display: grid;
+#mandate {
   margin-bottom: 50px;
-  p {
-    text-align: center;
-    max-width: 220px;
-    margin: auto;
-  }
-
-  .social-icons-wrapper {
-    display: flex;
-    justify-content: center;
-    margin-top: 20px;
-    margin-right: 0;
-    margin-left: 0;
-    margin-bottom: 40px;
-
-    span.separator {
-      width: 30px
-    }
-  }
-
-  a {
-    margin: auto;
-  }
-
-  a, p {
-    @media #{abstract.$breakpoint-sm} {
-      font-size: 1rem;
-    }
-    @media #{abstract.$breakpoint-md} {
-      font-size: 1.1rem;
-    }
-    @media #{abstract.$breakpoint-lg} {
-      font-size: 1.2rem;
-    }
-    @media #{abstract.$breakpoint-xl} {
-      font-size: 1.4rem;
-    }
-  }
 }
 
 #mandate.cancelled {

--- a/src/app/mandate/mandate.component.ts
+++ b/src/app/mandate/mandate.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 import {ComponentsModule} from "@biggive/components-angular";
 import {DatePipe} from "@angular/common";
 import {Mandate} from "../mandate.model";
@@ -18,11 +18,8 @@ import {myRegularGivingPath} from '../app-routing';
     styleUrl: './mandate.component.scss'
 })
 export class MandateComponent {
-  protected encodedShareUrl: string = '';
-  protected encodedPrefilledText: string = '';
   protected mandate!: Mandate;
   protected readonly cancelPath;
-
 
   constructor(
     private route: ActivatedRoute


### PR DESCRIPTION
As discussed today on Slack #develop

Before:

![image](https://github.com/user-attachments/assets/48635afb-c0f9-4375-a2df-2ec487c04fa4)

(but clicking the links doesn't work because we never programmed them to share anything specific)

After:

![image](https://github.com/user-attachments/assets/3f87b140-4bcb-49fb-ab47-f0acc020c6bd)
