### PR TITLE
Update SCSS rules to remove deprecated declarations after nested rule…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,6 +43,11 @@
             "prerender": true,
             "ssr": {
               "entry": "src/server.ts"
+            },
+            "stylePreprocessorOptions": {
+              "sass": {
+                "fatalDeprecations": ["mixed-decls", "color-functions", "global-builtin", "import"],
+              }
             }
           },
           "configurations": {

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.scss
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.scss
@@ -23,10 +23,10 @@
   background: abstract.$colour-black;
   color: white;
   text-align: center;
+  font-size: 15px;
   @media #{abstract.$breakpoint-lg} {
     font-size: 20px;
   }
-  font-size: 15px;
 
   .centered {
     display: flex;
@@ -43,15 +43,15 @@
   }
 
  span.time-left {
-   @media #{abstract.$breakpoint-lg} {
-     font-size: 24px;
-   }
    font-size: 18px;
    margin-left: 1em;
    background-color: abstract.$colour-primary;
    color: white;
    height: 100%;
    padding: 0 1em;
+   @media #{abstract.$breakpoint-lg} {
+     font-size: 24px;
+   }
  }
 }
 

--- a/src/app/donation-thanks/donation-thanks.component.scss
+++ b/src/app/donation-thanks/donation-thanks.component.scss
@@ -15,13 +15,13 @@ mat-spinner.complete-spinner {
 
 hr {
   width: 80%;
+  color: #868686;
   @media #{abstract.$breakpoint-sm} {
     margin: 40px auto;
   }
   @media #{abstract.$breakpoint-lg} {
     margin: 60px auto;
   }
-  color: #868686;
 }
 
 .thank-you {
@@ -159,13 +159,13 @@ hr {
 }
 
 .donation-summary {
-  @media #{abstract.$breakpoint-md} {
-    text-align: center;
-  }
   width: 80%;
   margin-right: auto;
   margin-left: auto;
 
+  @media #{abstract.$breakpoint-md} {
+    text-align: center;
+  }
   p {
     margin: 2rem 0;
     @media #{abstract.$breakpoint-sm} {

--- a/src/app/mandate/mandate.component.scss
+++ b/src/app/mandate/mandate.component.scss
@@ -15,13 +15,13 @@ mat-spinner.complete-spinner {
 
 hr {
   width: 80%;
+  color: #868686;
   @media #{abstract.$breakpoint-sm} {
     margin: 40px auto;
   }
   @media #{abstract.$breakpoint-lg} {
     margin: 60px auto;
   }
-  color: #868686;
 }
 
 .thank-you {
@@ -100,13 +100,12 @@ hr {
 }
 
 .donation-summary {
-  @media #{abstract.$breakpoint-md} {
-    text-align: center;
-  }
   width: 80%;
   margin-right: auto;
   margin-left: auto;
-
+  @media #{abstract.$breakpoint-md} {
+    text-align: center;
+  }
   p {
     margin: 2rem 0;
     @media #{abstract.$breakpoint-sm} {

--- a/src/app/my-account/my-account.component.scss
+++ b/src/app/my-account/my-account.component.scss
@@ -39,10 +39,10 @@ table#personal-details, table#paymentMethods {
   width: 100%;
   td {
     padding-bottom: 15px;
+    vertical-align: bottom;
     @media #{abstract.$breakpoint-lg} {
       min-width: 150px;
     }
-    vertical-align: bottom;
   }
 
   td.cardUpdateButton {

--- a/src/app/my-payment-methods/my-payment-methods.component.scss
+++ b/src/app/my-payment-methods/my-payment-methods.component.scss
@@ -17,10 +17,10 @@ table#paymentMethods {
   width: 100%;
   td {
     padding-bottom: 15px;
+    vertical-align: bottom;
     @media #{abstract.$breakpoint-lg} {
       min-width: 150px;
     }
-    vertical-align: bottom;
   }
 
   td.cardUpdateButton {

--- a/src/app/not-found/not-found.component.scss
+++ b/src/app/not-found/not-found.component.scss
@@ -1,6 +1,6 @@
 @use '../../abstract';
 
 main {
-  @include abstract.make-container;
   margin: 0 0;
+  @include abstract.make-container;
 }

--- a/src/app/regular-giving/regular-giving.component.scss
+++ b/src/app/regular-giving/regular-giving.component.scss
@@ -124,12 +124,12 @@ div.youAreSupporting {
 
 table#personal-details, table#paymentMethods {
   width: 100%;
+  vertical-align: bottom;
   td {
     padding-bottom: 15px;
     @media #{abstract.$breakpoint-lg} {
       min-width: 150px;
     }
-    vertical-align: bottom;
   }
 }
 

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -1,4 +1,5 @@
 @use './variables' as var;
+@use "sass:color";
 
 @mixin size-md {
   font-size: 14px;
@@ -138,9 +139,10 @@
   &:hover,
   &:active,
   &:focus {
-    background-color: darken(var.$colour-primary, 10%);
+    background-color: color.adjust(var.$colour-primary, $lightness: -10%);
   }
 }
+
 
 @mixin make-back-button {
   display: inline-block;

--- a/src/assets/scss/_utilities.scss
+++ b/src/assets/scss/_utilities.scss
@@ -11,8 +11,8 @@
 
 // Columns
 .b-primary-column {
-  @include mixins.make-primary-column;
   margin-bottom: 50px;
+  @include mixins.make-primary-column;
 }
 .b-secondary-column {
   @include mixins.make-secondary-column;
@@ -20,12 +20,12 @@
 
 // Responsive headings
 .b-rh-1 {
-  @include mixins.b-rt-3;
   color: vars.$colour-black;
+  @include mixins.b-rt-3;
 }
 .b-rh-2 {
-  @include mixins.b-rt-2;
   color: vars.$colour-black;
+  @include mixins.b-rt-2;
 }
 
 // Font weights

--- a/src/assets/scss/auth-common.scss
+++ b/src/assets/scss/auth-common.scss
@@ -3,8 +3,8 @@
 @use '../../abstract';
 
 main {
-  @include abstract.make-container;
   margin: 0 0;
+  @include abstract.make-container;
 }
 
 form {
@@ -23,7 +23,6 @@ form {
 }
 
 input {
-  @include abstract.b-rt-0;
   outline: none;
   border: none;
   background-color: abstract.$colour-background;
@@ -33,6 +32,8 @@ input {
   margin: 0 auto;
   display: block;
   font-weight: 700;
+
+  @include abstract.b-rt-0;
 
   // Larger breakpoints only
   .floating-label {
@@ -69,11 +70,12 @@ input {
 }
 
 main > div {
-  @include abstract.make-container;
   box-sizing: border-box;
   color: abstract.$colour-primary;
   background-color: abstract.$colour-background;
   margin-bottom: 125px;
+
+  @include abstract.make-container;
 
   @media #{abstract.$breakpoint-lg} {
     padding-top: 0;
@@ -102,10 +104,10 @@ div.actions {
   #register-button, #reset-password-button {
     margin-bottom: 1em;
     width: 100%;
+    flex-basis: 60%;
     @media #{abstract.$breakpoint-md} {
       margin-bottom: 0;
     }
-    flex-basis: 60%;
   }
 }
 


### PR DESCRIPTION
…s, keep behaviour

The use of declarations after nested rules is currently deprecated in Sass. Moving the declarations above the nested rules preserves the existing behavour in current and future versions of Sass.

See https://sass-lang.com/documentation/breaking-changes/mixed-decls/