### PR TITLE
BG2-2850: Add message about issue to top of donate and campaign pages

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -38,6 +38,13 @@
     </biggive-formatted-text>
   </div>
 
+  <div class="old-browser-issue" style="padding-bottom: 1em; font-size: 18px">
+      We are aware of an issue affecting some donors with iPhones running iOS 16
+      or earlier. We are currently working on a fix. If do not see a donate button
+      below please try again later, try with a different device if possible, or
+      update your device software.
+  </div>
+
   <div class="c-details-container">
     <div class="b-primary-column">
       <biggive-branded-image

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.html
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.html
@@ -16,6 +16,13 @@
       Back to campaign
     </a>
   </div>
+  <div class="old-browser-issue" style="padding-bottom: 1em; font-size: 18px">
+    We are aware of an issue some donors with iPhones running
+    iOS 16 or earlier. We are currently working on a fix.
+    If you are not able to use the form below please try later,
+    try with a different device if possible, or
+    update your device software.
+  </div>
   <div class="c-form-container">
     <div class="b-primary-column">
       <app-donation-start-login


### PR DESCRIPTION
Slightly different messages on the two pages.

On donate page:

> We are aware of an issue some donors with iPhones running iOS 16 or earlier. We are currently working on a fix. If you are not able to use the form below please try later, try with a different device if possible, or update your device software. 

On campaign page:

>  We are aware of an issue affecting some donors with iPhones running iOS 16 or earlier. We are currently working on a fix. If do not see a donate button below please try again later, try with a different device if possible, or update your device software. 

![image](https://github.com/user-attachments/assets/8f337e1f-dd7c-4837-ab8b-81b9813680a4)

![image](https://github.com/user-attachments/assets/3453572f-8b2b-41cb-b514-38db52d19bab)

![image](https://github.com/user-attachments/assets/0aed4dc9-625d-483e-a7a8-7902a77c63b1)

![image](https://github.com/user-attachments/assets/9d25fdc4-4fa2-4b45-8a5d-a6174a526a2a)

