### PR TITLE
MAT-409: Cancel donation on failed card 3DS authentication

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -61,7 +61,6 @@ import {updateDonationFromForm} from "../updateDonationFromForm";
 import {sanitiseCurrency} from "../sanitiseCurrency";
 import {PaymentReadinessTracker} from "./PaymentReadinessTracker";
 import {requiredNotBlankValidator} from "../../validators/notBlank";
-import {flags} from "../../featureFlags";
 import {WidgetInstance} from "friendly-challenge";
 import {Toast} from "../../toast.service";
 import {GIFT_AID_FACTOR} from '../../Money';
@@ -912,16 +911,23 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
         if (!result.paymentIntent.client_secret) {
           throw new Error("payment intent requires action but client secret missing")
         }
+
         const {
           error,
         } = await this.stripeService.handleNextAction(result.paymentIntent!.client_secret);
-        if (!error) {
-          await this.exitPostDonationSuccess(this.donation, this.selectedPaymentMethodType);
-          return;
-        } else {
+        if (error) {
           // Next action (e.g. 3D Secure) was run by Stripe.js, and failed.
           result = {error: error};
           this.submitting = false;
+
+          // As the donation is now attached to a payment intent that will have status requires_action, its not really
+          // usable. Stripe won't allow that PI to be confirmed, and the donor may want to try a different card. Best we
+          // can do is clear the donation out and let them start a new one.
+
+          this.clearDonation(this.donation, {clearAllRecord: true, jumpToStart: false});
+        } else {
+          await this.exitPostDonationSuccess(this.donation, this.selectedPaymentMethodType);
+          return;
         }
       } // Else there's a `paymentMethod` which is already successful or errored » both handled later.
     } else {
@@ -2240,7 +2246,6 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
     return (this.creditPenceToUse > 0) ? 'customer_balance' : 'card';
   }
 
-  protected readonly flags = flags;
   protected showCardReuseMessage = false;
   protected summariseAddressSuggestion = AddressService.summariseAddressSuggestion;
 


### PR DESCRIPTION
Unless we want to make changes in matchbot as well we need to abandon this donation and create a new one to allow the donor to try using a different card.

Attemping to confirm a donation a second time after 3DS authentication has been attempted leads to Stripe throwing this exception at matchbot:

  InvalidRequestException: This PaymentIntent's capture_method could not be
  updated because it has a status of requires_action. You may only update the
  capture_method of a PaymentIntent with one of the following statuses:
  requires_payment_method, requires_confirmation.