### PR TITLE
DON-1126: Split mandate page into two variants: one for immediate con…

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -148,6 +148,20 @@ export const routes: Routes = [
     redirectTo: 'donate/:campaignId',
   },
   {
+    path: `${myRegularGivingPath}/:mandateId/thanks`,
+    pathMatch: 'full',
+    component: MandateComponent,
+    data: {
+      isThanks: true
+    },
+    canActivate: [
+      requireLogin,
+    ],
+    resolve: {
+      mandate:  MandateResolver,
+    },
+  },
+  {
     path: `${myRegularGivingPath}/:mandateId`,
     pathMatch: 'full',
     component: MandateComponent,

--- a/src/app/donation-thanks/donation-thanks.component.scss
+++ b/src/app/donation-thanks/donation-thanks.component.scss
@@ -24,7 +24,7 @@ hr {
   }
 }
 
-.thank-you {
+.header-box {
   background-color: abstract.$colour-primary;
   padding: 75px 0;
   position: relative;

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -15,6 +15,7 @@
   <div id="banner-thank-you"></div>
 
   <div>
+    @if (isThanksPage) {
     <div aria-live="polite">
       <div>
         <div class="screenreader-only">
@@ -22,10 +23,16 @@
         </div>
       </div>
     </div>
+    }
     <div>
-      <div class="thank-you">
+      <div class="header-box">
+        @if (isThanksPage) {
         <h2>Thank you!</h2>
         <p class="thank-you-text">Your generous regular donation has been set up.</p>
+        } @else {
+          <h2>Regular Giving Mandate</h2>
+          <p class="thank-you-text">Your regular donation to {{ mandate.charityName }}</p>
+        }
       </div>
       <hr aria-hidden="true">
       <div id="mandate" class="{{mandate.status}}">
@@ -35,7 +42,9 @@
             <p><strong>{{statusMessage}}</strong></p>
             <hr aria-hidden="true">
           }
-          <p><strong>Your donation summary</strong></p>
+          @if (isThanksPage) {
+            <p><strong>Your regular donation to {{ mandate.charityName }}</strong></p>
+          }
           @if (mandate.isMatched) {
             <p>Your donation of
               <strong
@@ -131,6 +140,12 @@
             <hr class="shorter" aria-hidden="true">
             <div style="text-align: center">
               <a [href]="cancelPath">Cancel future donations</a>
+            </div>
+          }
+          @if (isThanksPage) {
+            <hr class="shorter" aria-hidden="true">
+            <div style="text-align: center">
+              <a href="/my-account">Your Big Give Donor Account</a>
             </div>
           }
         </div>

--- a/src/app/mandate/mandate.component.scss
+++ b/src/app/mandate/mandate.component.scss
@@ -24,7 +24,7 @@ hr {
   }
 }
 
-.thank-you {
+.header-box {
   background-color: abstract.$colour-primary;
   padding: 75px 0;
   position: relative;

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -383,7 +383,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
           }
         }
 
-        await this.router.navigateByUrl(`/${myRegularGivingPath}/${response.mandate.id}`);
+        await this.router.navigateByUrl(`/${myRegularGivingPath}/${response.mandate.id}/thanks`);
       },
       error: (error: BackendError) => {
         const message = errorDescription(error);


### PR DESCRIPTION
…firmation / thanks and one for later review

Before the mandate page always appeared the same, whether viewed as a redirect from creating the mandate or found at a later date via My account:

![image](https://github.com/user-attachments/assets/a59a82c1-7e43-4c60-b72f-b6db373bd859)

_______


After this PR this splits into two variants. Changes are mostly to reflect the different use cases of confirming/thanking for a new mandate and reviewing an old one, but also include some other stuff I noticed like replacing "Your Donation Summary" with "Your Regular Donation to {{charityName}}" which I think is clearer.


Thanks variant:

![image](https://github.com/user-attachments/assets/160c3b24-a331-456e-9c55-eb5fb92245e5)


Non-thanks variant:

![image](https://github.com/user-attachments/assets/710f5a64-088e-4386-b002-836f50541056)


There is also an automatic redirect from the thanks variant to non-thanks in case the mandate is more than 24 hours old.