### PR TITLE
DON-1128: Start displaying mandate cancellation form while mandate lo…

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -179,9 +179,6 @@ export const routes: Routes = [
     canActivate: [
       requireLogin,
     ],
-    resolve: {
-      mandate:  MandateResolver,
-    },
   },
   {
     path: 'metacampaign/:campaignId',

--- a/src/app/cancel-mandate/cancel-mandate.component.html
+++ b/src/app/cancel-mandate/cancel-mandate.component.html
@@ -2,6 +2,7 @@
 <main>
   <div>
     <biggive-page-section>
+      @if(mandate$ | async; as mandate) {
       <div class="heading-wrapper">
         <biggive-heading
           colour="tertiary"
@@ -10,7 +11,6 @@
           [text]="'Cancel regular giving to ' + mandate.charityName"
         ></biggive-heading>
       </div>
-      <!-- @todo  DON-1022 replace form with message if mandate is already cancelled has a non-cancelable status    -->
       <p>
         You are currently giving <strong>{{ mandate.donationAmount | money }}</strong> to
         <strong>{{ mandate.charityName }}</strong>,
@@ -32,7 +32,7 @@
 
         <div class="actions">
           <div>
-            <a href="/my-account/regular-giving/{{mandate.id}}">Back to mandate details</a>
+            <a routerLink="/my-account/regular-giving/{{mandate.id}}">Back to mandate details</a>
           </div>
           <div>
             @if (processing) {
@@ -50,8 +50,24 @@
               />
             }
           </div>
+
         </div>
       </form>
+      } @else {
+        <div style="min-height: 10em">
+        @defer (on timer(1000ms)) {
+        <div class="heading-wrapper">
+          <biggive-heading
+            colour="tertiary"
+            size="1"
+            align="center"
+            text="Cancel regular giving..."
+          ></biggive-heading>
+        </div>
+          <mat-spinner color="primary" diameter="30" aria-label="Loading mandate"></mat-spinner>
+        }
+        </div>
+      }
     </biggive-page-section>
   </div>
 </main>

--- a/src/app/cancel-mandate/cancel-mandate.component.ts
+++ b/src/app/cancel-mandate/cancel-mandate.component.ts
@@ -54,8 +54,6 @@ export class CancelMandateComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.mandateSubscription = this.mandate$.subscribe(mandate => {
-      console.log({mandate});
-
       if (mandate.status === 'cancelled') {
         void this.router.navigateByUrl(`/my-account/regular-giving/${mandate.id}`)
         return;

--- a/src/app/cancel-mandate/cancel-mandate.component.ts
+++ b/src/app/cancel-mandate/cancel-mandate.component.ts
@@ -1,18 +1,19 @@
 import {Component, inject, OnDestroy, OnInit, PLATFORM_ID} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute, Router, RouterLink} from '@angular/router';
 import {ComponentsModule} from '@biggive/components-angular';
 import {Mandate} from "../mandate.model";
 import {MoneyPipe} from '../money.pipe';
 import {OrdinalPipe} from '../ordinal.pipe';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatInput} from '@angular/material/input';
-import {isPlatformBrowser} from '@angular/common';
+import {AsyncPipe, isPlatformBrowser} from '@angular/common';
 import {PageMetaService} from '../page-meta.service';
 import {RegularGivingService} from '../regularGiving.service';
 import {BackendError, errorDescription} from '../backendError';
 import {Toast} from '../toast.service';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {addBodyClass, removeBodyClass} from '../bodyStyle';
+import {Observable, Subscription} from 'rxjs';
 
 @Component({
   selector: 'app-cancel-mandate',
@@ -23,13 +24,15 @@ import {addBodyClass, removeBodyClass} from '../bodyStyle';
     FormsModule,
     MatInput,
     ReactiveFormsModule,
-    MatProgressSpinner
+    MatProgressSpinner,
+    RouterLink,
+    AsyncPipe
   ],
   templateUrl: './cancel-mandate.component.html',
   styleUrl: './cancel-mandate.component.scss'
 })
 export class CancelMandateComponent implements OnInit, OnDestroy {
-  protected mandate: Mandate;
+  protected mandate$: Observable<Mandate>;
   protected readonly reasonMaxLength = 500;
   protected cancellationForm = new FormGroup({
     reason: new FormControl('', [Validators.maxLength(this.reasonMaxLength)]),
@@ -37,6 +40,7 @@ export class CancelMandateComponent implements OnInit, OnDestroy {
 
   private platformId = inject(PLATFORM_ID);
   protected processing = false;
+  private mandateSubscription?: Subscription;
 
   public constructor(
     route: ActivatedRoute,
@@ -45,21 +49,27 @@ export class CancelMandateComponent implements OnInit, OnDestroy {
     private readonly router: Router,
     private readonly toaster: Toast
   ) {
-    this.mandate = route.snapshot.data.mandate;
+    this.mandate$ = this.regularGivingService.getActiveMandate(route.snapshot.paramMap.get('mandateId') || '');
   }
 
   ngOnInit() {
-    if (this.mandate.status === 'cancelled') {
-      void this.router.navigateByUrl(`/my-account/regular-giving/${this.mandate.id}`)
-      return;
-    }
+    this.mandateSubscription = this.mandate$.subscribe(mandate => {
+      console.log({mandate});
 
-    this.pageMeta.setCommon('Cancel Regular Giving to ' + this.mandate.charityName, '', null);
+      if (mandate.status === 'cancelled') {
+        void this.router.navigateByUrl(`/my-account/regular-giving/${mandate.id}`)
+        return;
+      }
+
+      this.pageMeta.setCommon('Cancel Regular Giving to ' + mandate.charityName, '', null);
+    })
+
     addBodyClass(this.platformId, 'primary-colour');
   }
 
   ngOnDestroy() {
     removeBodyClass(this.platformId, 'primary-colour');
+    this.mandateSubscription?.unsubscribe()
   }
 
   cancel(mandate: Mandate) {
@@ -67,8 +77,8 @@ export class CancelMandateComponent implements OnInit, OnDestroy {
     this.regularGivingService.cancel(mandate, {cancellationReason: this.cancellationForm.controls.reason.value || ''}).subscribe(
       {
         next: async () => {
-          this.toaster.showSuccess("Your regular donations to " + this.mandate.charityName + " will now stop");
-          void this.router.navigateByUrl(`/my-account/regular-giving/${this.mandate.id}`);
+          this.toaster.showSuccess("Your regular donations to " + mandate.charityName + " will now stop");
+          void this.router.navigateByUrl(`/my-account/regular-giving/${mandate.id}`);
         },
         error: (error: BackendError) => {
           this.toaster.showError(errorDescription(error));

--- a/src/app/mandate.resolver.ts
+++ b/src/app/mandate.resolver.ts
@@ -8,7 +8,7 @@ import {RegularGivingService} from './regularGiving.service';
 @Injectable(
   {providedIn: 'root'}
 )
-export class MandateResolver implements Resolve<Mandate> {
+export class MandateResolver implements Resolve<Observable<Mandate>> {
   constructor(private regularGivingService: RegularGivingService) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<Mandate> {

--- a/src/app/mandate/mandate.component.html
+++ b/src/app/mandate/mandate.component.html
@@ -139,7 +139,7 @@
           @if (showCancelLink) {
             <hr class="shorter" aria-hidden="true">
             <div style="text-align: center">
-              <a [href]="cancelPath">Cancel future donations</a>
+              <a [routerLink]="cancelPath">Cancel future donations</a>
             </div>
           }
           @if (isThanksPage) {

--- a/src/app/mandate/mandate.component.ts
+++ b/src/app/mandate/mandate.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {ComponentsModule} from "@biggive/components-angular";
 import {DatePipe} from "@angular/common";
 import {Mandate} from "../mandate.model";
-import {ActivatedRoute, Router} from "@angular/router";
+import {ActivatedRoute, Router, RouterLink} from "@angular/router";
 import {MoneyPipe} from "../money.pipe";
 import {myRegularGivingPath} from '../app-routing';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
@@ -14,7 +14,8 @@ import {RegularGivingService} from '../regularGiving.service';
     ComponentsModule,
     DatePipe,
     MoneyPipe,
-    MatProgressSpinner
+    MatProgressSpinner,
+    RouterLink
   ],
     templateUrl: './mandate.component.html',
     styleUrl: './mandate.component.scss'


### PR DESCRIPTION
…ading

Previously none of the form displayed until the mandate was returned from the server, meaning we only showed the header and footer of the page in that time. Although I had anticipated that the component would be delayed loading until the resolver resolves the mandate, that didn't really happen as the resolver was only returning an observable of the mandate, not the mandate itself.

There must be something built in to Angular that's implicitly unwrapping the observable so we can use the mandate on this page.

I wasn't sure what the best way to fix this was and ended up being a bit indecsive. The solution here is to display a lot more of the page before the mandate is loaded, so that users get a better idea of what's happening and can start to understand the new context while they wait for loading to finish. If the mandate doesn't load within 1 second then I also show a placeholder title and a spinner. I didn't want to go the effort of building a full skelton UI.

Although this improves the Cancel Mandate page I think we still have the same issue on the View Mandate page - so would be worth discussing how to deal with this type of issue generally on the site.

Othere options I looked at were:

-  Making the observable return a promise of a mandate instead of an observable. This has the advantage of fully stopping the loading of the component page until the mandate is there, so we don't have to handle the case of it not being loaded within the component. Would simplify things especially if we used that pattern on several pages. But it has the problem that there is no visible indication of loading - the URI doesn't update while waiting for the resolve as we use the default 'deferred'  urlUpdateStrategy, not 'eager'. If we wanted to use this method I think we'd also need to create a visible loading indication in the App component, maybe with something like https://blog.angular-university.io/angular-loading-indicator/ . It might need to be built into the main menu component.

- Caching the mandate so we don't have to wait for it to load. We might want to do something similar to how the CampaignResolver uses an inject TransferState (although this wouldn't be transferred from the server) to cache copies of Campaigns, or maybe something more like how DonationService stores donation data in local storage (although I think storage attached to the Window object is probably enough for mandates, we don't to use Local Storage). This has a risk of showing outdated mandate details if we don't get it quite right. I tried using a record mapping mandate IDs observables with the shareReplay pipe in the Mandate service to do something like this, but didn't quite get it to work. But that is why links between two mandate pages now use routerLink instead of href - href links destroy service state, which routerLinks don't.