### PR TITLE
ID-47: Allow donor to view post-donation registration form

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -28,6 +28,7 @@ import {myMandatesResolver} from './my-mandates.resolver';
 import {CancelMandateComponent} from './cancel-mandate/cancel-mandate.component';
 import {ChangeRegularGivingComponent} from './change-regular-giving/change-regular-giving.component';
 import {setupIntentResolver} from './setupIntent.resolver';
+import {EmailVerificationTokenResolver} from './email-verification-token.resolver';
 export const registerPath = 'register';
 export const myAccountPath = 'my-account';
 export const transferFundsPath = 'transfer-funds';
@@ -271,6 +272,9 @@ export const routes: Routes = [
     canActivate: [
       redirectIfAlreadyLoggedIn,
     ],
+    resolve: {
+      emailVerificationToken: EmailVerificationTokenResolver,
+    },
   },
   /** For use when donor clicks logout in the menu on the wordpress site **/
   {

--- a/src/app/donation-thanks/donation-thanks-set-password-dialog.html
+++ b/src/app/donation-thanks/donation-thanks-set-password-dialog.html
@@ -6,8 +6,8 @@
       <p>Email address: <strong>{{ data.person.email_address }}</strong></p>
 
       <p>
-        <strong>Your last payment card</strong> will be saved for reuse, if you selected "
-            Save payment details for future purchases". It is held securely only with Stripe.
+        <strong>Your last payment card</strong> will be saved for reuse, if you selected
+            "Save payment details for future purchases". It is held securely only with Stripe.
         <a href="https://stripe.com/docs/security/stripe" target="_blank">
           <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
           Learn more about Stripe

--- a/src/app/email-verification-token.resolver.ts
+++ b/src/app/email-verification-token.resolver.ts
@@ -1,0 +1,49 @@
+import {Injectable} from '@angular/core';
+import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
+
+import {IdentityService} from './identity.service';
+
+export type EmailVerificationToken =
+  {
+    valid: false
+    person_uuid?: string,
+    email_address?: string,
+    first_name?: string
+    last_name?: string
+    secretNumber?: string
+  } |
+  {
+    valid: true,
+    person_uuid: string,
+    email_address: string,
+    first_name: string
+    last_name: string
+    secretNumber: string
+  }
+
+@Injectable(
+  {providedIn: 'root'}
+)
+export class EmailVerificationTokenResolver implements Resolve<EmailVerificationToken | null> {
+  constructor(private identityService: IdentityService) {}
+
+  async resolve(route: ActivatedRouteSnapshot): Promise<EmailVerificationToken|null> {
+    const secretNumber = route.queryParams['c'];
+    const personUUID = route.queryParams['u'];
+
+    if (!secretNumber || ! personUUID) {
+      return null;
+    }
+
+    try {
+      return {
+        ...await this.identityService.getEmailVerificationTokenDetails({secretNumber, personUUID}),
+        person_uuid: personUUID,
+        secretNumber: secretNumber
+      };
+    } catch (error) {
+      console.log(error);
+      return {valid: false}
+    }
+  }
+}

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -3,8 +3,8 @@ import {EventEmitter, Inject, Injectable, InjectionToken} from '@angular/core';
 import jwtDecode from 'jwt-decode';
 import {CookieService} from 'ngx-cookie-service';
 import {MatomoTracker} from 'ngx-matomo-client';
-import {Observable, of} from 'rxjs';
-import {delay, retry, tap} from 'rxjs/operators';
+import {firstValueFrom, Observable, of} from 'rxjs';
+import {delay, map, retry, tap} from 'rxjs/operators';
 
 import {Credentials} from './credentials.model';
 import {environment} from '../environments/environment';
@@ -12,6 +12,7 @@ import {IdentityJWT} from './identity-jwt.model';
 import {Person} from './person.model';
 import {FundingInstruction} from './fundingInstruction.model';
 import {STRIPE_SESSION_SECRET_COOKIE_NAME} from "./donation.service";
+import {EmailVerificationToken} from './email-verification-token.resolver';
 
 @Injectable({
   providedIn: 'root',
@@ -251,6 +252,15 @@ export class IdentityService {
         'X-Tbg-Auth': jwt,
       }),
     };
+  }
+
+  async getEmailVerificationTokenDetails({secretNumber, personUUID}: {
+    secretNumber: string | undefined;
+    personUUID: string | undefined
+  }): Promise<EmailVerificationToken> {
+    const uri = `${environment.identityApiPrefix}/emailVerificationToken/${secretNumber}/${personUUID}`;
+
+    return firstValueFrom(this.http.get(uri).pipe(map(((response: any) => response.token))));
   }
 }
 export function getPersonAuthHttpOptions(jwt?: string): { headers: HttpHeaders } {

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -15,7 +15,7 @@
       @if (redirectPath.startsWith('/regular-giving')) {
         <p>Please register for a a Big Give donation account to set up your regular giving agreement.</p>
         <p>You will be able to log-in any time to see your donations or cancel the agreement.</p>
-      } @else {
+      } @else if (! this.emailVerificationToken){
       <p>
         Registering for a Donor Account is quick and easy.
       </p>
@@ -42,6 +42,70 @@
 
         </app-verify-email>
 
+      } @else if (this.emailVerificationToken?.valid) {
+        <p>
+          For a smoother giving experience create a Big Give account. Your information will be saved securely, making
+          future donations quicker and easier.
+        </p>
+
+        <p>
+          <strong>Your payment card</strong> will be saved for reuse, if you selected "
+          Save payment details for future purchases" when making your donation.
+          It is held securely only with Stripe.
+          <a href="https://stripe.com/docs/security/stripe" target="_blank">
+            <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+            Learn more about Stripe
+          </a>.
+        </p>
+
+        <form
+          [formGroup]="registerPostDonationForm"
+          (keydown.enter)="registerPostDonation()"
+        >
+          <div class="savedDetails">
+          <div class="label">
+            Email Address</div>
+            <div class="value"> <strong>{{this.emailVerificationToken?.email_address}}</strong>
+            </div>
+          <div class="label">
+            Name
+          </div>
+            <div class="value"> {{this.emailVerificationToken?.first_name}} {{this.emailVerificationToken?.last_name}}
+            </div>
+
+          </div>
+
+          <biggive-text-input spaceBelow="4">
+            <label slot="label" for="password">Password *</label>
+            <input
+              slot="input"
+              matInput type="password" id="password-post-donation" formControlName="password">
+          </biggive-text-input>
+
+          <div class="register-button-container">
+            <div aria-live="polite">
+              @if (processing) {
+                <mat-spinner color="primary" diameter="30" aria-label="Processing"></mat-spinner>
+              }
+            </div>
+
+            @if (!processing) {
+              <biggive-button
+                id="register-button-post-donation"
+                space-above="5"
+                spaceBelow="0"
+                colour-scheme="primary"
+                label="Register"
+                full-width="true"
+                disabled="!registrationForm.valid"
+                size="medium"
+                rounded="false"
+                (click)="registerPostDonation()"
+              />
+            }
+          </div>
+
+        </form>
       } @else {
       <form
         [formGroup]="registrationForm"
@@ -105,7 +169,7 @@
           data-puzzle-endpoint="https://api.friendlycaptcha.com/api/v1/puzzle, https://eu-api.friendlycaptcha.eu/api/v1/puzzle"
           #frccaptcha
         ></div>
-        <div id="register-button-container">
+        <div class="register-button-container">
           <div aria-live="polite">
             @if (processing) {
               <mat-spinner color="primary" diameter="30" aria-label="Processing"></mat-spinner>
@@ -130,8 +194,10 @@
         </div>
       </div>
       }
+      @if (!emailVerificationToken) {
       <hr style="margin: 20px auto;">
       Already have an account? <a href="{{loginLink}}">Login here</a>
+      }
     </biggive-page-section>
   </div>
 </main>

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -106,6 +106,14 @@
           </div>
 
         </form>
+      } @else if (this.emailVerificationToken && ! this.emailVerificationToken.valid) {
+        <p>Sorry, we couldn't find your details. Your account registration link may have expired.</p>
+        <p>
+          <!-- href not routerlink because this component was built with a bit too much of an imperative style
+               and won't react to the change params properly if we allow angular to re-use it.
+          -->
+          <a href="/register">Register a new Big Give account</a>
+        </p>
       } @else {
       <form
         [formGroup]="registrationForm"

--- a/src/app/register/register.component.scss
+++ b/src/app/register/register.component.scss
@@ -10,3 +10,13 @@ form {
 }
 
 @include abstract.friendly-captcha();
+
+.savedDetails {
+  .label {
+    margin-top: 1em;
+  }
+  .value {
+    padding-top: 5px;
+    border-bottom: 1px solid abstract.$colour-primary;
+  }
+}

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -1,4 +1,14 @@
-import {AfterViewInit, Component, ElementRef, Inject, OnDestroy, OnInit, PLATFORM_ID, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Inject,
+  Input,
+  OnDestroy,
+  OnInit,
+  PLATFORM_ID,
+  ViewChild
+} from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
 import {ComponentsModule} from "@biggive/components-angular";
 import {MatButtonModule} from "@angular/material/button";
@@ -22,10 +32,12 @@ import {NavigationService} from "../navigation.service";
 import {BackendError, errorDescription, errorDetails} from "../backendError";
 import {addBodyClass, removeBodyClass} from '../bodyStyle';
 import {VerifyEmailComponent} from '../verify-email/verify-email.component';
+import {EmailVerificationToken} from '../email-verification-token.resolver';
+import {MatIcon} from '@angular/material/icon';
 
 @Component({
     selector: 'app-register',
-  imports: [ComponentsModule, MatButtonModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatProgressSpinnerModule, ReactiveFormsModule, MatAutocompleteModule, VerifyEmailComponent],
+  imports: [ComponentsModule, MatButtonModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatProgressSpinnerModule, ReactiveFormsModule, MatAutocompleteModule, VerifyEmailComponent, MatIcon],
     templateUrl: './register.component.html',
     styleUrl: 'register.component.scss'
 })
@@ -39,6 +51,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   protected processing = false;
   protected error?: string;
   registrationForm!: FormGroup;
+  registerPostDonationForm!: FormGroup;
   private readyToLogIn = false;
   protected errorHtml: SafeHtml | undefined;
   private friendlyCaptchaSolution: string|undefined;
@@ -47,7 +60,9 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   protected redirectPath: string = 'my-account';
   protected loginLink!: string;
   protected verificationLinkSentToEmail? : string;
+
   protected verificationCodeSupplied?: string;
+  protected emailVerificationToken?: EmailVerificationToken;
 
   constructor(
     private readonly formBuilder: FormBuilder,
@@ -58,6 +73,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
     private readonly activatedRoute: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: Object,
   ) {
+    this.emailVerificationToken = this.activatedRoute.snapshot.data.emailVerificationToken;
   }
 
   ngOnDestroy() {
@@ -228,6 +244,11 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get readyToTakeAccountDetails(): boolean {
-    return !!this.verificationCodeSupplied || ! flags.requireEmailVerification
+    return !!this.verificationCodeSupplied || this.emailVerificationToken?.valid || ! flags.requireEmailVerification
+  }
+
+  registerPostDonation() {
+    alert(
+      "Function still to be built to register using donor UUID and Password and secret token, UUID: " + this.emailVerificationToken?.person_uuid + " secret token: " + this.emailVerificationToken?.secretNumber)
   }
 }


### PR DESCRIPTION
The plan is they will click a link in the donation thanks email (link generation not yet implemented) to a URI that includes the six digit secret token and their identity UUID, e.g.
/register?c=019816&u=1f0161fa-63ea-6fa8-888d-b1edd20e1c85

Donate then queries the identity backend for the details of the person, and displays in the registration form as implemented in this commit.

The next step is to create a route in identity to allow registration to be done using those details plus the newly chosen password, and implement calling that route here.

![image](https://github.com/user-attachments/assets/7a9166f6-b30c-4842-8336-627e8fbf2da3)
