### PR TITLE
ID-47: Stop offering new accounts post donation in dev env

### DIFF
--- a/src/app/donation-thanks/donation-thanks-set-password-dialog.component.ts
+++ b/src/app/donation-thanks/donation-thanks-set-password-dialog.component.ts
@@ -43,6 +43,9 @@ export class DonationThanksSetPasswordDialogComponent implements OnInit {
   }
 
   ngOnInit() {
+    if (! flags.offerNewAccountAfterDonation) {
+      throw new Error('Delete this component when unused in all envs');
+    }
     this.form = this.formBuilder.group({
       password: [null, [
         Validators.required,

--- a/src/app/donation-thanks/donation-thanks.component.ts
+++ b/src/app/donation-thanks/donation-thanks.component.ts
@@ -95,6 +95,10 @@ export class DonationThanksComponent implements OnInit {
 
   protected get showRegistrationPrompt(): boolean
   {
+    if (! this.flags.offerNewAccountAfterDonation) {
+      return false;
+    }
+
     return !this.registrationComplete &&  // if they already registered they can't register again.
       !this.loggedIn && // if they registered and logged in they can't register again
       !!this.person // if we don't know who they are any more they can't register.
@@ -218,6 +222,10 @@ export class DonationThanksComponent implements OnInit {
   }
 
   private setPassword(password: string, stayLoggedIn: boolean) {
+    if (! flags.offerNewAccountAfterDonation) {
+      throw new Error("Donor not expected to set password this way now.")
+    }
+
     if (!this.person) {
       this.matomoTracker.trackEvent('identity_error', 'person_password_set_missing_data', 'No person in component');
       this.registerError = 'Cannot set password without a person';

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -14,6 +14,11 @@ const flagsForEnvironment = (environmentId: EnvironmentID) => {
     // before this is enabled in prod the registration form needs to actually do realy verification with the backend.
     // Need to update test for regular giving when enabling this in regression environment.
     requireEmailVerification: environmentId !== 'production' && environmentId !== 'regression',
+
+    // Offering new accounts immediately after donation in FE is being phased out - instead the email sent by
+    // matchbot will offer the donor a new account. It's fine to have an overlap, so the matchbot feature should be
+    // turned on before this is turned off.
+    offerNewAccountAfterDonation: environmentId !== 'development'
   } as const;
 }
 

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -1,25 +1,40 @@
 import {environment} from "../environments/environment";
 import {EnvironmentID} from "../environments/environment.interface";
 
-const flagsForEnvironment = (environmentId: EnvironmentID) => {
-  return {
-    regularGivingEnabled: environmentId !== 'production',
+type flags = {
+  readonly regularGivingEnabled: boolean;
 
-    /**
-     * Replaces our own custom display of saved cards that are fetch from Identity, with saved cards
-     * inside the stripe payment element on the donation page.
-     */
-    stripeElementCardChoice: true,
+ /**
+  * Replaces our own custom display of saved cards that are fetch from Identity, with saved cards
+  * inside the stripe payment element on the donation page.
+  */
+  readonly stripeElementCardChoice: true;
 
-    // before this is enabled in prod the registration form needs to actually do realy verification with the backend.
-    // Need to update test for regular giving when enabling this in regression environment.
-    requireEmailVerification: environmentId !== 'production' && environmentId !== 'regression',
+  /**
+   * before this is enabled in prod the registration form needs to actually do really verification with the backend.
+   * Need to update test for regular giving when enabling this in regression environment.
+   */
+  readonly requireEmailVerification: boolean;
 
-    // Offering new accounts immediately after donation in FE is being phased out - instead the email sent by
-    // matchbot will offer the donor a new account. It's fine to have an overlap, so the matchbot feature should be
-    // turned on before this is turned off.
-    offerNewAccountAfterDonation: environmentId !== 'development'
-  } as const;
+  /**
+   * Offering new accounts immediately after donation in FE is being phased out - instead the email sent by
+   * matchbot will offer the donor a new account. It's fine to have an overlap, so the matchbot feature should be
+   * turned on before this is turned off.
+   */
+  readonly offerNewAccountAfterDonation: boolean
+};
+
+const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmentId: EnvironmentID) => {
+  switch (environmentId) {
+    case 'development':
+      return {regularGivingEnabled: true, stripeElementCardChoice: true, requireEmailVerification: true, offerNewAccountAfterDonation: false};
+    case 'regression':
+      return {regularGivingEnabled: true, stripeElementCardChoice: true, requireEmailVerification: false, offerNewAccountAfterDonation: true};
+    case "staging":
+      return {regularGivingEnabled: true, stripeElementCardChoice: true, requireEmailVerification: true, offerNewAccountAfterDonation: true};
+    case "production":
+      return {regularGivingEnabled: false, stripeElementCardChoice: true, requireEmailVerification: false, offerNewAccountAfterDonation: true};
+  }
 }
 
 export const flags = flagsForEnvironment(environment.environmentId);

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -4,16 +4,15 @@ import {EnvironmentID} from "../environments/environment.interface";
 type flags = {
   readonly regularGivingEnabled: boolean;
 
- /**
-  * Replaces our own custom display of saved cards that are fetch from Identity, with saved cards
-  * inside the stripe payment element on the donation page.
-  */
-  readonly stripeElementCardChoice: true;
-
   /**
    * before this is enabled in prod the registration form needs to actually do really verification with the backend.
    * Need to update test for regular giving when enabling this in regression environment.
    */
+
+ /**
+  * Replaces our own custom display of saved cards that are fetch from Identity, with saved cards
+  * inside the stripe payment element on the donation page.
+  */
   readonly requireEmailVerification: boolean;
 
   /**
@@ -27,13 +26,13 @@ type flags = {
 const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmentId: EnvironmentID) => {
   switch (environmentId) {
     case 'development':
-      return {regularGivingEnabled: true, stripeElementCardChoice: true, requireEmailVerification: true, offerNewAccountAfterDonation: false};
+      return {regularGivingEnabled: true, requireEmailVerification: true, offerNewAccountAfterDonation: false};
     case 'regression':
-      return {regularGivingEnabled: true, stripeElementCardChoice: true, requireEmailVerification: false, offerNewAccountAfterDonation: true};
+      return {regularGivingEnabled: true, requireEmailVerification: false, offerNewAccountAfterDonation: true};
     case "staging":
-      return {regularGivingEnabled: true, stripeElementCardChoice: true, requireEmailVerification: true, offerNewAccountAfterDonation: true};
+      return {regularGivingEnabled: true, requireEmailVerification: true, offerNewAccountAfterDonation: true};
     case "production":
-      return {regularGivingEnabled: false, stripeElementCardChoice: true, requireEmailVerification: false, offerNewAccountAfterDonation: true};
+      return {regularGivingEnabled: false, requireEmailVerification: false, offerNewAccountAfterDonation: true};
   }
 }
 


### PR DESCRIPTION
Technically we should wait until the matchbot PR is merged but it's OK to have this slight breakage in dev only.

Thank you page without set password prompt:

![image](https://github.com/user-attachments/assets/aabcefff-d449-4667-be92-d6eb3de83d81)

We could replace the prompt with something saying look at your email for a way to set a password, but I think that overcomplicates the thanks page and we don't need it. 