### PR TITLE
DON-1101: Add validation rule to prevent long numbers accidentally be…

### DIFF
--- a/src/app/donation-start/donation-start-form/PaymentReadinessTracker.ts
+++ b/src/app/donation-start/donation-start-form/PaymentReadinessTracker.ts
@@ -1,3 +1,5 @@
+import {LONG_NUMBER, MIN_LENGTH_BANNED} from '../../validators/noLongNumberValidator';
+
 /**
  * This object tracks whether a donor is ready to progress past the payment stage of the donation start form. At time of
  * writing it just returns a boolean from readyToProgressFromPaymentStep, but my plan is to add a function to return
@@ -79,6 +81,8 @@ export class PaymentReadinessTracker {
           return `Please enter your ${fieldName}.`;
         case 'pattern':
           return `Sorry, your ${fieldName} is not recognised - please enter a valid ${fieldName}.`;
+        case LONG_NUMBER:
+          return `We do not accept ${MIN_LENGTH_BANNED} consecutive numbers in the ${fieldName} field.`
         default:
           console.error(error);
           return `Sorry, there is an error with the ${fieldName} field.`;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -64,6 +64,7 @@ import {requiredNotBlankValidator} from "../../validators/notBlank";
 import {WidgetInstance} from "friendly-challenge";
 import {Toast} from "../../toast.service";
 import {GIFT_AID_FACTOR} from '../../Money';
+import {noLongNumberValidator} from '../../validators/noLongNumberValidator';
 
 declare var _paq: {
   push: (args: Array<string|object>) => void,
@@ -367,10 +368,12 @@ export class DonationStartFormComponent implements AfterContentChecked, AfterCon
         firstName: [null, [
           Validators.maxLength(40),
           requiredNotBlankValidator,
+          noLongNumberValidator,
         ]],
         lastName: [null, [
           Validators.maxLength(80),
           requiredNotBlankValidator,
+          noLongNumberValidator,
         ]],
         emailAddress: [null, [
           requiredNotBlankValidator,

--- a/src/app/validators/noLongNumberValidator.ts
+++ b/src/app/validators/noLongNumberValidator.ts
@@ -1,0 +1,18 @@
+import {AbstractControl, ValidatorFn} from '@angular/forms';
+
+export const LONG_NUMBER = 'LONG_NUMBER'
+export const MIN_LENGTH_BANNED = 6;
+
+// same regex as in matchbot, to catch six numbers in a row see
+// https://github.com/thebiggive/matchbot/blob/80173b9c95b821a81870a493ec3bba4a921a127f/src/Domain/DonorName.php#L31
+const sixDigitsRegex = /\d\s?\d\s?\d\s?\d\s?\d\s?\d/;
+
+export const noLongNumberValidator: ValidatorFn = (control: AbstractControl) => {
+
+  const valueAsString = control.value + '';
+  if (valueAsString.match(sixDigitsRegex)) {
+    return {[LONG_NUMBER]: true};
+  } else {
+    return null;
+  }
+}


### PR DESCRIPTION
Adds FE validation to stop names being entered with likely mistakes that matchbot will reject.

Matchbot validation is already done (in trunk branch), but that leads to a vague error near the bottom of the form. This shows a specific error directly on attempt to progress from the step where names are entered for donations.

![image](https://github.com/user-attachments/assets/cfc03839-bf5d-4e99-8b98-7c4c409d4513)
