### PR TITLE
Tweak callout logs

### DIFF
--- a/src/app/campaign-list.resolver.ts
+++ b/src/app/campaign-list.resolver.ts
@@ -3,7 +3,7 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 import {MatomoTracker} from 'ngx-matomo-client';
 
 import { CampaignService } from './campaign.service';
-import {logCalloutError} from './logCalloutError';
+import {logCampaignCalloutError} from './logCampaignCalloutError';
 import {isPlatformBrowser} from '@angular/common';
 
 @Injectable(
@@ -27,7 +27,7 @@ export class CampaignListResolver {
     const resolverInitialSearch = this.campaignService.search(defaultListQuery);
     resolverInitialSearch.subscribe({
       error: (error) => {
-        logCalloutError(isPlatformBrowser(this.platformId), `CampaignListResolver: ${error.message}`, undefined, this.matomoTracker);
+        logCampaignCalloutError(isPlatformBrowser(this.platformId), `CampaignListResolver: ${error.message}`, undefined, this.matomoTracker);
       }
     });
 

--- a/src/app/campaign-stats-resolver.ts
+++ b/src/app/campaign-stats-resolver.ts
@@ -7,7 +7,7 @@ import {catchError} from 'rxjs/operators';
 
 import {CampaignService} from "./campaign.service";
 import {FormattedCampaignStats} from './campaign-stats.model';
-import {logCalloutError} from './logCalloutError';
+import {logCampaignCalloutError} from './logCampaignCalloutError';
 
 @Injectable(
   {providedIn: 'root'}
@@ -23,7 +23,7 @@ export class CampaignStatsResolver implements Resolve<FormattedCampaignStats>{
     return this.campaignService.getCampaignImpactStats().pipe(
       // If the HighlightCards API has any error we still want to show the rest of the homepage, so we catch the error
       catchError(error => {
-        logCalloutError(isPlatformBrowser((this.platformId)), `CampaignStatsResolver: ${error.message}`, undefined, this.matomoTracker);
+        logCampaignCalloutError(isPlatformBrowser((this.platformId)), `CampaignStatsResolver: ${error.message}`, undefined, this.matomoTracker);
         return of({totalRaisedFormatted: '£–', totalCountFormatted: '–'});
       })
     );

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -8,7 +8,7 @@ import { catchError } from 'rxjs/operators';
 import { Campaign } from './campaign.model';
 import {CampaignService, SearchQuery} from './campaign.service';
 import {SearchService} from "./search.service";
-import {logCalloutError} from './logCalloutError';
+import {logCampaignCalloutError} from './logCampaignCalloutError';
 
 @Injectable(
   {providedIn: 'root'}
@@ -55,7 +55,7 @@ export class CampaignResolver implements Resolve<Campaign>  {
       this.campaignService.search(query as SearchQuery).subscribe({
         next: () => {},
         error: () => {
-          logCalloutError(
+          logCampaignCalloutError(
             isPlatformBrowser(this.platformId),
             'CampaignResolver search to check fundSlug validity',
             `/${campaignSlug}/${fundSlug}`,
@@ -89,7 +89,7 @@ export class CampaignResolver implements Resolve<Campaign>  {
 
     const observable = method(identifier)
       .pipe(catchError(error => {
-        logCalloutError(isPlatformBrowser(this.platformId), `CampaignResolver main load: ${error.message}`, identifier, this.matomoTracker);
+        logCampaignCalloutError(isPlatformBrowser(this.platformId), `CampaignResolver main load: ${error.message}`, identifier, this.matomoTracker);
         // Because it happens server side & before resolution, `replaceUrl` seems not to
         // work, so just fall back to serving the Home content on the requested path.
         void this.router.navigateByUrl('/');

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -32,7 +32,7 @@ import {FundService} from "../fund.service";
 import {TimeLeftPipe} from "../time-left.pipe";
 import {environment} from "../../environments/environment";
 import {SESSION_STORAGE, StorageService} from "ngx-webstorage-service";
-import {logCalloutError} from '../logCalloutError';
+import {logCampaignCalloutError} from '../logCampaignCalloutError';
 
 const openPipeToken = 'TimeLeftToOpenPipe';
 const endPipeToken = 'timeLeftToEndPipe';
@@ -395,7 +395,7 @@ export class ExploreComponent implements AfterViewChecked, OnDestroy, OnInit {
         }
       },
       error: (error) => {
-        logCalloutError(
+        logCampaignCalloutError(
           isPlatformBrowser(this.platformId),
           `ExploreComponent.doCampaignSearch: ${error.message}`,
           undefined,

--- a/src/app/highlight-cards-resolver.ts
+++ b/src/app/highlight-cards-resolver.ts
@@ -6,7 +6,7 @@ import {Observable, of} from 'rxjs';
 
 import {CampaignService} from "./campaign.service";
 import {HighlightCard} from "./highlight-cards/HighlightCard";
-import {logCalloutError} from './logCalloutError';
+import {logCampaignCalloutError} from './logCampaignCalloutError';
 import {isPlatformBrowser} from '@angular/common';
 
 @Injectable(
@@ -23,7 +23,7 @@ export class HighlightCardsResolver implements Resolve<readonly HighlightCard[]>
     return this.campaignService.getHomePageHighlightCards().pipe(
       // If the HighlightCards API has any error we still want to show the rest of the homepage, so we catch the error
       catchError(error => {
-        logCalloutError(isPlatformBrowser((this.platformId)), `HighlightCardsResolver: ${error.message}`, undefined, this.matomoTracker);
+        logCampaignCalloutError(isPlatformBrowser((this.platformId)), `HighlightCardsResolver: ${error.message}`, undefined, this.matomoTracker);
         return of([]);
       })
     );

--- a/src/app/logCalloutError.ts
+++ b/src/app/logCalloutError.ts
@@ -3,20 +3,20 @@ import {MatomoTracker} from 'ngx-matomo-client';
 export const logCalloutError = (
   isBrowser: boolean,
   context: string,
-  calloutUrl?: string,
+  calloutIdentifier?: string,
   matomoTracker?: MatomoTracker,
 ) => {
   if (!isBrowser) {
-    console.error('Server-side error in: ' + context + '. Callout URL: ' + calloutUrl);
+    console.error('Server-side error in: ' + context + '. Callout identifier: ' + calloutIdentifier);
     return;
   }
 
-  console.error('Client-side error in: ' + context + '. Callout URL: ' + calloutUrl);
+  console.error('Client-side error in: ' + context + '. Callout identifier: ' + calloutIdentifier);
   if (matomoTracker) {
     matomoTracker.trackEvent(
-      'donate_error',
+      'campaign_error',
       'callout_error',
-      context + ' – ' + calloutUrl,
+      context + ' – ' + calloutIdentifier,
     );
   }
 };

--- a/src/app/logCampaignCalloutError.ts
+++ b/src/app/logCampaignCalloutError.ts
@@ -1,6 +1,6 @@
 import {MatomoTracker} from 'ngx-matomo-client';
 
-export const logCalloutError = (
+export const logCampaignCalloutError = (
   isBrowser: boolean,
   context: string,
   calloutIdentifier?: string,


### PR DESCRIPTION
Give them their own group, to separate from `donate_error`s easily, and a less misleading identifier intro