### PR TITLE
Revert "Move GMF highlight card to start of list"

### DIFF
--- a/src/app/highlight-cards/HighlightCard.ts
+++ b/src/app/highlight-cards/HighlightCard.ts
@@ -118,18 +118,11 @@ function backgroundImage(sfApiHighlightCard: SfApiHighlightCard, donateUriPrefix
 }
 
 export function SFHighlightCardsToFEHighlightCards(apiHighlightCards: SfApiHighlightCard[]): HighlightCard[] {
-  const cards = apiHighlightCards.map(
-    card => SFAPIHighlightCardToHighlightCard(
-      environment.experienceUriPrefix,
-      environment.blogUriPrefix,
-      environment.donateUriPrefix,
-      card
-    ));
-
-  // temp code, remove after GMF 2025
-  cards.sort((cardA, cardB) =>
-    (Number)(cardB.campaignFamily === 'greenMatchFund') - (Number)(cardA.campaignFamily === 'greenMatchFund')
-  );
-
-  return cards
+  return apiHighlightCards.map(
+  card => SFAPIHighlightCardToHighlightCard(
+    environment.experienceUriPrefix,
+    environment.blogUriPrefix,
+    environment.donateUriPrefix,
+    card
+  ))
 }


### PR DESCRIPTION
This reverts commit 23451e9650c18007ea47b31ad92c220f1bfed3f7.

Was only intended for use during GMF live period