### PR TITLE
MAT-390: Only save payment method from donation if donor tells stripe…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -399,7 +399,7 @@
             }
             <div>
               @if (showCardReuseMessage) {
-                Your card will only be saved for reuse if you set a password on the next page.
+                Your card will only be saved for reuse if you tick the box above and create a donor account
               }
             </div>
           </div>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -399,7 +399,7 @@
             }
             <div>
               @if (showCardReuseMessage) {
-                Your card will only be saved for reuse if you tick the box above and create a donor account
+                Your card will only be saved for reuse if you tick the box above and create a donor account.
               }
             </div>
           </div>

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -464,15 +464,15 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     if (this.stripeElements) {
       this.stripeElements.update({ amount: this.getDonationAmountPence() });
     } else {
-      this.stripeElements = this.stripeService.stripeElements(
-        {
+      this.stripeElements = this.stripeService.stripeElements({
+        money: {
           amount: this.getDonationAmountPence(),
           currency: this.campaign.currencyCode,
         },
-        'off_session',
-        this.campaign,
-        this.stripeCustomerSession.stripeSessionSecret,
-      );
+        futureUsage: 'off_session',
+        campaign: this.campaign,
+        customerSessionClientSecret: this.stripeCustomerSession.stripeSessionSecret,
+      });
     }
 
     if (this.stripePaymentElement) {

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -140,7 +140,15 @@ export class StripeService {
       amount: this.amountIncTipInMinorUnit(donation),
     };
 
-    return this.stripeElements(money, 'on_session', campaign, customerSessionClientSecret);
+    return this.stripeElements({
+      money: money,
+
+      // future usage is up to the donor to decide by ticking "Save payment details for future purchases" inside
+      // the iframe or not.
+      futureUsage: null,
+      campaign: campaign,
+      customerSessionClientSecret: customerSessionClientSecret,
+    });
   }
 
   /**
@@ -150,15 +158,17 @@ export class StripeService {
    * @param campaign
    * @param customerSessionClientSecret
    */
-  public stripeElements(
-    money: {
-      currency: string;
-      amount: number;
-    },
-    futureUsage: 'off_session' | 'on_session',
-    campaign: Campaign,
-    customerSessionClientSecret: string | undefined,
-  ) {
+  public stripeElements({
+    money,
+    futureUsage,
+    campaign,
+    customerSessionClientSecret,
+  }: {
+    money: { currency: string; amount: number };
+    futureUsage: 'off_session' | 'on_session' | null;
+    campaign: Campaign;
+    customerSessionClientSecret: string | undefined;
+  }) {
     if (!this.stripe) {
       throw new Error('Stripe not ready');
     }

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -140,12 +140,15 @@ export class StripeService {
       amount: this.amountIncTipInMinorUnit(donation),
     };
 
+    const mat390KeepOldBehavour = environment.environmentId === 'production';
+
     return this.stripeElements({
       money: money,
 
       // future usage is up to the donor to decide by ticking "Save payment details for future purchases" inside
-      // the iframe or not.
-      futureUsage: null,
+      // the iframe or not. But we currently we are passing on_session, and need to test this change carefully
+      // before changing in prod.
+      futureUsage: mat390KeepOldBehavour ? 'on_session' : null,
       campaign: campaign,
       customerSessionClientSecret: customerSessionClientSecret,
     });
@@ -153,10 +156,7 @@ export class StripeService {
 
   /**
    *
-   * @param money . Amount must be in minor units, e.g. pence
-   * @param futureUsage
-   * @param campaign
-   * @param customerSessionClientSecret
+   * @param money - amount must be in minor units
    */
   public stripeElements({
     money,


### PR DESCRIPTION
… to save it

Previiously we passed `futureUsage: 'on_session'` to stripe when creating the elements for a donation, which overrode the customer's choice to not save by using a tickbox (and we have to do extra work to ensure we never present those methods for re-use).

Hopefull this will make stripe save the method for re-use only in the right cases.