### PR TITLE
DON-521: Add eslint rule 'no-positive-tabindex'

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,7 +74,9 @@ export default [
     files: ["**/*.html"],
 
     rules: {
-      // add any customisations wanted for rules in html files here.
+      "@angular-eslint/template/no-positive-tabindex": [
+        "error"
+      ],
     },
   },
 ];


### PR DESCRIPTION
https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/no-positive-tabindex.md

From MDN:

> Warning: You are recommended to only use 0 and -1 as tabindex values.
>
> Avoid using tabindex values greater than 0 and CSS properties that can
> change the order of focusable HTML elements (Ordering flex items). Doing
> so makes it difficult for people who rely on using keyboard for
> navigation or assistive technology to navigate and operate page content.
>
> Instead, write the document with the elements in a logical sequence.