### PR TITLE
Don 521 a11y improvements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,4 @@
 # github does this automatically.
 
 # setup prettier
-273e57eb2adb571
+273e57eb2adb5710dddcd2737e566fa1c606b62b

--- a/src/BigGiveTitleStrategy.ts
+++ b/src/BigGiveTitleStrategy.ts
@@ -1,8 +1,7 @@
 import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-
-const bigGiveName = 'Big Give';
+import { bigGiveName } from './environments/common';
 
 @Injectable()
 export class BigGiveTitleStrategy extends TitleStrategy {
@@ -24,8 +23,8 @@ export class BigGiveTitleStrategy extends TitleStrategy {
  * Appends our name to the end of a string to make a title (unless the string already contains that)
  */
 export function makeTitle(title: string): string {
-  if (!title.includes('Big Give')) {
-    title = `${title} – Big Give`;
+  if (!title.includes(bigGiveName)) {
+    title = `${title} – ${bigGiveName}`;
   }
 
   return title;

--- a/src/BigGiveTitleStrategy.ts
+++ b/src/BigGiveTitleStrategy.ts
@@ -1,0 +1,32 @@
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+
+const bigGiveName = 'Big Give';
+
+@Injectable()
+export class BigGiveTitleStrategy extends TitleStrategy {
+  constructor(private readonly title: Title) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot): void {
+    const title = this.buildTitle(routerState);
+    if (title !== undefined) {
+      this.title.setTitle(makeTitle(title));
+    } else {
+      this.title.setTitle(bigGiveName);
+    }
+  }
+}
+
+/**
+ * Appends our name to the end of a string to make a title (unless the string already contains that)
+ */
+export function makeTitle(title: string): string {
+  if (!title.includes('Big Give')) {
+    title = `${title} – Big Give`;
+  }
+
+  return title;
+}

--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -29,6 +29,7 @@ import { CancelMandateComponent } from './cancel-mandate/cancel-mandate.componen
 import { ChangeRegularGivingComponent } from './change-regular-giving/change-regular-giving.component';
 import { setupIntentResolver } from './setupIntent.resolver';
 import { EmailVerificationTokenResolver } from './email-verification-token.resolver';
+import { bigGiveName } from '../environments/common';
 
 export const registerPath = 'register';
 export const myAccountPath = 'my-account';
@@ -108,7 +109,7 @@ export const routes: (Route & {
       stats: CampaignStatsResolver,
       highlights: HighlightCardsResolver,
     },
-    title: undefined,
+    title: bigGiveName,
     loadChildren: () => import('./home/home.module').then((c) => c.HomeModule),
   },
   {

--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -1,4 +1,4 @@
-import { ActivatedRouteSnapshot, CanActivateFn, Router, Routes } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivateFn, Resolve, ResolveFn, Route, Router } from '@angular/router';
 
 import { CampaignListResolver } from './campaign-list.resolver';
 import { CampaignResolver } from './campaign.resolver';
@@ -17,7 +17,7 @@ import { MandateResolver } from './mandate.resolver';
 import { PaymentMethodsResolver } from './payment-methods.resolver';
 import { PastDonationsResolver } from './past-donations.resolver';
 import { isPlatformServer } from '@angular/common';
-import { inject, PLATFORM_ID } from '@angular/core';
+import { inject, PLATFORM_ID, Type } from '@angular/core';
 
 import { IdentityService } from './identity.service';
 import { LoggedInPersonResolver } from './logged-in-person.resolver';
@@ -29,6 +29,7 @@ import { CancelMandateComponent } from './cancel-mandate/cancel-mandate.componen
 import { ChangeRegularGivingComponent } from './change-regular-giving/change-regular-giving.component';
 import { setupIntentResolver } from './setupIntent.resolver';
 import { EmailVerificationTokenResolver } from './email-verification-token.resolver';
+
 export const registerPath = 'register';
 export const myAccountPath = 'my-account';
 export const transferFundsPath = 'transfer-funds';
@@ -93,7 +94,13 @@ const handleLogout: CanActivateFn = () => {
   return inject(Router).parseUrl('/');
 };
 
-export const routes: Routes = [
+export const routes: (Route & {
+  // every route should either have a title explicitly defined here, or explicitly have an undefined
+  // title and rely on a call to PageMetaService.setCommon once loaded.
+
+  // titles do not need to included 'Big Give' - if they don't it will be added by the BigGiveTitleStrategy class.
+  title: string | Type<Resolve<string>> | ResolveFn<string> | undefined;
+})[] = [
   {
     path: '',
     pathMatch: 'full',
@@ -101,21 +108,25 @@ export const routes: Routes = [
       stats: CampaignStatsResolver,
       highlights: HighlightCardsResolver,
     },
+    title: undefined,
     loadChildren: () => import('./home/home.module').then((c) => c.HomeModule),
   },
   {
     path: transferFundsPath,
     pathMatch: 'full',
     canActivate: [requireLogin],
+    title: 'Transfer Donation Funds',
     loadChildren: () => import('./transfer-funds/transfer-funds.module').then((c) => c.TransferFundsModule),
   },
   {
     path: 'buy-credits',
     pathMatch: 'full',
     redirectTo: '/transfer-funds',
+    title: undefined,
   },
   {
     path: 'campaign/:campaignId',
+    title: undefined, // set from inside component using campaign name
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -124,6 +135,7 @@ export const routes: Routes = [
   },
   {
     path: 'charity/:charityId',
+    title: undefined, // set from inside component using charity name
     pathMatch: 'full',
     resolve: {
       campaigns: CharityCampaignsResolver,
@@ -132,6 +144,7 @@ export const routes: Routes = [
   },
   {
     path: 'donate/:campaignId',
+    title: undefined, // set from inside component using campaign name
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -142,12 +155,8 @@ export const routes: Routes = [
       ),
   },
   {
-    path: 'donate-new-stepper/:campaignId',
-    pathMatch: 'full',
-    redirectTo: 'donate/:campaignId',
-  },
-  {
     path: `${myRegularGivingPath}/:mandateId/thanks`,
+    title: undefined, // set from inside component
     pathMatch: 'full',
     component: MandateComponent,
     data: {
@@ -160,6 +169,7 @@ export const routes: Routes = [
   },
   {
     path: `${myRegularGivingPath}/:mandateId`,
+    title: undefined, // set from inside component
     pathMatch: 'full',
     component: MandateComponent,
     canActivate: [requireLogin],
@@ -169,12 +179,14 @@ export const routes: Routes = [
   },
   {
     path: `${myRegularGivingPath}/:mandateId/cancel`,
+    title: undefined, // set from inside component
     pathMatch: 'full',
     component: CancelMandateComponent,
     canActivate: [requireLogin],
   },
   {
     path: 'metacampaign/:campaignId',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -184,6 +196,7 @@ export const routes: Routes = [
   },
   {
     path: 'metacampaign/:campaignId/:fundSlug',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -193,16 +206,19 @@ export const routes: Routes = [
   },
   {
     path: 'reset-password',
+    title: 'Reset your Password',
     pathMatch: 'full',
     loadChildren: () => import('./reset-password/reset-password.module').then((c) => c.ResetPasswordModule),
   },
   {
     path: 'thanks/:donationId',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     loadChildren: () => import('./donation-thanks/donation-thanks.module').then((c) => c.DonationThanksModule),
   },
   {
     path: 'my-account/donations',
+    title: undefined, // set from inside component
     resolve: {
       donations: PastDonationsResolver,
     },
@@ -212,6 +228,7 @@ export const routes: Routes = [
   },
   {
     path: 'my-account/payment-methods',
+    title: 'Your Payment Methods',
     pathMatch: 'full',
     resolve: {
       person: LoggedInPersonResolver,
@@ -222,6 +239,7 @@ export const routes: Routes = [
   },
   {
     path: ':campaignSlug/:fundSlug',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -231,6 +249,7 @@ export const routes: Routes = [
   },
   {
     path: 'explore',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
       campaigns: CampaignListResolver,
@@ -240,12 +259,14 @@ export const routes: Routes = [
   },
   {
     path: myAccountPath,
+    title: undefined, // set from inside component
     pathMatch: 'full',
     canActivate: [requireLogin],
     loadChildren: () => import('./my-account/my-account.module').then((c) => c.MyAccountModule),
   },
   {
     path: registerPath,
+    title: undefined, // set from inside component
     pathMatch: 'full',
     component: RegisterComponent,
     canActivate: [redirectIfAlreadyLoggedIn],
@@ -257,12 +278,14 @@ export const routes: Routes = [
   {
     component: LoginComponent, // Angular requires we set a component but it will never be used client-side as
     // `canActivate` always redirects there.
+    title: undefined,
     path: 'logout',
     pathMatch: 'full',
     canActivate: [handleLogout],
   },
   {
     path: 'login',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     component: LoginComponent,
     canActivate: [redirectIfAlreadyLoggedIn],
@@ -272,6 +295,7 @@ export const routes: Routes = [
     // else the site would look weird, so we load the homepage, and pass showCookiePreferences in data which the
     // app component will pick up to trigger auto opening the cookie preferences modal.
     path: 'cookie-preferences',
+    title: undefined, // shows as a modal, awkward to give it its own title.
     pathMatch: 'full',
     resolve: {
       stats: CampaignStatsResolver,
@@ -287,6 +311,7 @@ export const routes: Routes = [
   // match a campaign.
   {
     path: ':campaignSlug',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
       campaign: CampaignResolver,
@@ -297,6 +322,7 @@ export const routes: Routes = [
   // And this is our final 404 handler which actually says 'not found'; used for e.g. legacy /project/X/Y format paths.
   {
     path: '**',
+    title: 'Page not found',
     component: NotFoundComponent,
   },
 ];
@@ -304,6 +330,7 @@ export const routes: Routes = [
 if (flags.regularGivingEnabled) {
   routes.unshift({
     path: myRegularGivingPath,
+    title: undefined, // set from inside component
     resolve: {
       mandates: myMandatesResolver,
     },
@@ -314,6 +341,7 @@ if (flags.regularGivingEnabled) {
 
   routes.unshift({
     path: 'my-account/payment-methods/change-regular-giving',
+    title: 'Change Regular Giving Payment Method',
     resolve: {
       person: LoggedInPersonResolver,
       paymentMethods: PaymentMethodsResolver,
@@ -326,6 +354,7 @@ if (flags.regularGivingEnabled) {
 
   routes.unshift({
     path: 'regular-giving/:campaignId',
+    title: undefined, // set from inside component
     pathMatch: 'full',
     component: RegularGivingComponent,
     canActivate: [requireLogin],

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,7 @@ import {
 import { Observable, Subscription } from 'rxjs';
 import { supportedBrowsers } from '../supportedBrowsers';
 import { detect } from 'detect-browser';
+import { PageMetaService } from './page-meta.service';
 
 @Component({
   selector: 'app-root',
@@ -88,6 +89,7 @@ export class AppComponent implements AfterViewInit, OnDestroy, OnInit {
     @Inject(PLATFORM_ID) private platformId: object,
     private matomoTracker: MatomoTracker,
     private router: Router,
+    private pageMeta: PageMetaService,
   ) {
     this.isPlatformBrowser = isPlatformBrowser(this.platformId);
     this.userHasExpressedCookiePreference$ = this.cookiePreferenceService.userHasExpressedCookiePreference();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,7 +32,6 @@ import {
 import { Observable, Subscription } from 'rxjs';
 import { supportedBrowsers } from '../supportedBrowsers';
 import { detect } from 'detect-browser';
-import { PageMetaService } from './page-meta.service';
 
 @Component({
   selector: 'app-root',
@@ -89,7 +88,6 @@ export class AppComponent implements AfterViewInit, OnDestroy, OnInit {
     @Inject(PLATFORM_ID) private platformId: object,
     private matomoTracker: MatomoTracker,
     private router: Router,
-    private pageMeta: PageMetaService,
   ) {
     this.isPlatformBrowser = isPlatformBrowser(this.platformId);
     this.userHasExpressedCookiePreference$ = this.cookiePreferenceService.userHasExpressedCookiePreference();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { MAT_CHECKBOX_DEFAULT_OPTIONS } from '@angular/material/checkbox';
 import { MAT_RADIO_DEFAULT_OPTIONS } from '@angular/material/radio';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { RouterModule, RouterOutlet } from '@angular/router';
+import { RouterModule, RouterOutlet, TitleStrategy } from '@angular/router';
 import { ComponentsModule } from '@biggive/components-angular';
 import { LOCAL_STORAGE } from 'ngx-webstorage-service';
 
@@ -23,6 +23,7 @@ import { CampaignStatsResolver } from './campaign-stats-resolver';
 import { PastDonationsResolver } from './past-donations.resolver';
 import { PaymentMethodsResolver } from './payment-methods.resolver';
 import { HighlightCardsResolver } from './highlight-cards-resolver';
+import { BigGiveTitleStrategy } from '../BigGiveTitleStrategy';
 
 const matomoBaseUri = 'https://biggive.matomo.cloud';
 
@@ -72,6 +73,7 @@ const matomoBaseUri = 'https://biggive.matomo.cloud';
     { provide: TBG_DONATE_STORAGE, useExisting: LOCAL_STORAGE },
     { provide: MAT_CHECKBOX_DEFAULT_OPTIONS, useValue: { color: 'primary' } },
     { provide: MAT_RADIO_DEFAULT_OPTIONS, useValue: { color: 'primary' } },
+    { provide: TitleStrategy, useClass: BigGiveTitleStrategy },
     provideHttpClient(withFetch()),
   ],
 })

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -153,7 +153,7 @@ export class ExploreComponent implements AfterViewChecked, OnDestroy, OnInit {
 
   protected get title() {
     if (!this.metaCampaign) {
-      return 'Big Give';
+      return 'Explore Campaigns - Big Give';
     }
 
     if (!this.fund) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -8,6 +8,7 @@ import { PageMetaService } from '../page-meta.service';
 import { HighlightCard } from '../highlight-cards/HighlightCard';
 import { environment } from '../../environments/environment';
 import { NavigationService } from '../navigation.service';
+import { bigGiveName, tagLine } from '../../environments/common';
 
 @Component({
   selector: 'app-home',
@@ -42,7 +43,7 @@ export class HomeComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.pageMeta.setCommon('Big Give', 'Big Give – discover campaigns and donate', '/assets/images/social-banner.png');
+    this.pageMeta.setCommon(bigGiveName, `${bigGiveName} – ${tagLine}`, '/assets/images/social-banner.png');
     this.stats = this.route.snapshot.data['stats'];
     this.highlightCards = this.route.snapshot.data['highlights'];
     const queryParams = this.route.snapshot.queryParams;

--- a/src/app/mandate/mandate.component.ts
+++ b/src/app/mandate/mandate.component.ts
@@ -7,6 +7,7 @@ import { MoneyPipe } from '../money.pipe';
 import { myRegularGivingPath } from '../app-routing';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { RegularGivingService } from '../regularGiving.service';
+import { PageMetaService } from '../page-meta.service';
 
 @Component({
   selector: 'app-mandate',
@@ -32,6 +33,7 @@ export class MandateComponent implements OnInit {
     private route: ActivatedRoute,
     private regularGivingService: RegularGivingService,
     private router: Router,
+    private readonly pageMeta: PageMetaService,
   ) {
     this.mandate = this.route.snapshot.data.mandate;
     this.cancelPath = `/${myRegularGivingPath}/${this.mandate.id}/cancel`;
@@ -47,6 +49,11 @@ export class MandateComponent implements OnInit {
       // they just want to review and/or manage it.
       await this.router.navigateByUrl(`/${myRegularGivingPath}/${this.mandate.id}`);
     }
+
+    const title = this.isThanksPage
+      ? 'Thank you! Your Regular Giving to ' + this.mandate.charityName
+      : 'Your Regular Giving to ' + this.mandate.charityName;
+    this.pageMeta.setCommon(title);
   }
 
   /**

--- a/src/app/page-meta.service.ts
+++ b/src/app/page-meta.service.ts
@@ -4,6 +4,7 @@ import { Meta, Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 
 import { environment } from '../environments/environment';
+import { makeTitle } from '../BigGiveTitleStrategy';
 
 /**
  * Encapsulates common logic for setting pages' key metadata consistently across basic HTML meta tags and
@@ -20,7 +21,7 @@ export class PageMetaService {
     private title: Title,
   ) {}
 
-  setCommon(title: string, description: string, imageUri: string | null) {
+  setCommon(title: string, description: string = '', imageUri: string | null = null) {
     const baseUri = environment.donateUriPrefix;
     const canonicalUri = `${baseUri}${this.router.url}`;
     const links = this.dom.getElementsByTagName('link');
@@ -31,9 +32,7 @@ export class PageMetaService {
     const link = links[0];
     link.setAttribute('href', canonicalUri);
 
-    if (!title.includes('Big Give')) {
-      title = `${title} – Big Give`;
-    }
+    title = makeTitle(title);
 
     this.title.setTitle(title);
     this.meta.updateTag({ property: 'og:title', content: title });

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -16,6 +16,7 @@ import { environment as stagingEnvironment } from '../environments/environment.s
 import { Donation } from './donation.model';
 import { Campaign } from './campaign.model';
 import { countryISO2 } from './countries';
+import { bigGiveName } from '../environments/common';
 
 @Injectable({
   providedIn: 'root',
@@ -240,7 +241,7 @@ export class StripeService {
           },
         },
       },
-      business: { name: 'Big Give' },
+      business: { name: bigGiveName },
     });
   }
 

--- a/src/environments/common.ts
+++ b/src/environments/common.ts
@@ -9,3 +9,6 @@ export const campaignHiddenMessage =
  */
 export const currencyPipeDigitsInfo = '1.0-0';
 export const minPasswordLength = 12;
+
+export const bigGiveName = 'Big Give';
+export const tagLine = `discover campaigns and donate`;


### PR DESCRIPTION
Previously a few pages (e.g. http://localhost:4200/transfer-funds and http://localhost:4200/explore ) did not set specific titles so we just showed 'Big Give' which is unhelpful in a list of tabs.

This commit makes sure every component has a title, and that the entry in our routes array explicitly declares a title entry (although it may be undefined) for every route.