### PR TITLE
DON-521: Add live announcment for screen readers when match funding e…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.spec.ts
@@ -31,6 +31,7 @@ import { StripeService } from '../../stripe.service';
 import { Donation } from '../../donation.model';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { Toast } from '../../toast.service';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 
 function makeDonationStartFormComponent(donationService: DonationService) {
   const mockIdentityService = TestBed.inject(IdentityService);
@@ -61,6 +62,7 @@ function makeDonationStartFormComponent(donationService: DonationService) {
     {
       showError: () => {},
     } as unknown as Toast,
+    undefined as unknown as LiveAnnouncer,
   );
 
   donationStartFormComponent.campaign = { currencyCode: 'GBP' } as Campaign;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -64,6 +64,7 @@ import { WidgetInstance } from 'friendly-challenge';
 import { Toast } from '../../toast.service';
 import { GIFT_AID_FACTOR } from '../../Money';
 import { noLongNumberValidator } from '../../validators/noLongNumberValidator';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 
 declare let _paq: {
   push: (args: Array<string | object>) => void;
@@ -256,6 +257,7 @@ export class DonationStartFormComponent
     private router: Router,
     private stripeService: StripeService,
     private toast: Toast,
+    private liveAnnouncer: LiveAnnouncer,
   ) {
     this.defaultCountryCode = this.donationService.getDefaultCounty();
     this.selectedCountryCode = this.defaultCountryCode;
@@ -1862,6 +1864,8 @@ export class DonationStartFormComponent
       // and set this to 0. See also offerExistingDonation() which does the equivalent for donation
       // loaded from browser storage into a new load of this page.
       this.donation.matchReservedAmount = 0;
+
+      this.liveAnnouncer.announce('Match funding has expired');
 
       const continueDialog = this.dialog.open(DonationStartMatchingExpiredDialogComponent, {
         disableClose: true,


### PR DESCRIPTION
…xpires

In testing whith the stock Ubuntu screen reader sometimes the appearence of the modal seemd to trigger an announcmenet without adding this, and sometimes it didn't. Think it's worth having anyway.

There may be a wider redisgn of how we want to show match funding expired anyway, which might mean moving away from a modal having an aria-live region on the page instead into which we'd add the match funding expired message when necassary - we could then block progress through the form until the donor acknowledges the lack of match funding.

But I think this is good for now to make sure blind users know what the modal dialog is about.

To test on my local I reduced the timer duration in my environment.ts to 0.3 minutes, and also commented out some code to make the timer run even when there is zero match funds available.