### PR TITLE
DON-521: Fix links not keyboard focusable/clickable

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -20,14 +20,10 @@
         </a>
       }
       @if (campaign.parentRef && !fromFund) {
-        <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
-        <!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
-        <a class="" mat-icon-button (click)="goBackToMetacampaign()">
+        <a href class="" mat-icon-button (click)="goBackToMetacampaign()">
           <mat-icon aria-hidden="false" aria-label="Back">keyboard_arrow_left</mat-icon>
           All participating campaigns
         </a>
-        <!-- eslint-enable @angular-eslint/template/interactive-supports-focus -->
-        <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
       }
       @if (!campaign.parentRef) {
         <a mat-icon-button routerLink="/explore">

--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -124,11 +124,7 @@
       <div>
         <p class="error" aria-live="polite">
           We can't find any campaigns matching this search but there are lots more to choose from.
-          <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
-          <!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
-          <a tabindex="0" (click)="clear()">View all campaigns here</a>.
-          <!-- eslint-enable @angular-eslint/template/interactive-supports-focus -->
-          <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
+          <a href (click)="clear()">View all campaigns here</a>.
         </p>
       </div>
     }

--- a/src/app/login-modal/login-modal.html
+++ b/src/app/login-modal/login-modal.html
@@ -63,11 +63,7 @@
     </form>
   </mat-dialog-content>
   <mat-dialog-actions style="justify-content: space-between">
-    <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
-    <!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
-    <a (click)="forgotPasswordClicked()">Forgot Password?</a>
-    <!-- eslint-enable @angular-eslint/template/interactive-supports-focus -->
-    <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
+    <a href (click)="forgotPasswordClicked()">Forgot Password?</a>
     <div>
       <button
         id="login-modal-submit"

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -46,11 +46,9 @@
                 </div>
                 <div class="actions">
                   <div>
-                    <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
-                    <!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
-                    <a (click)="this.forgotPassword = false">Return to Login page</a>
-                    <!-- eslint-enable @angular-eslint/template/interactive-supports-focus -->
-                    <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
+                    <!--                    Href attribute below is needed to make this act like a link for keyboard users, i.e focusable and-->
+                    <!--                    clickable using keyboard. -->
+                    <a href (click)="this.forgotPassword = false">Return to Login page</a>
                   </div>
                   <div id="reset-password-button">
                     @if (!userAskedForResetLink) {
@@ -124,11 +122,7 @@
           </form>
           <div class="actions">
             <div>
-              <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
-              <!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
-              <a (click)="this.forgotPassword = true">Forgot Password?</a>
-              <!-- eslint-enable @angular-eslint/template/interactive-supports-focus -->
-              <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
+              <a href (click)="this.forgotPassword = true">Forgot Password?</a>
             </div>
             <div id="login-button">
               <div aria-live="polite">

--- a/src/app/transfer-funds/transfer-funds.component.html
+++ b/src/app/transfer-funds/transfer-funds.component.html
@@ -44,22 +44,10 @@
             @if (donorHasPendingTipBalance) {
               <div>
                 <p>Thank you for choosing to tip Big Give {{ pendingTipBalance / 100 | exactCurrency: "GBP" }}.</p>
-
-                <!--
-                Following eslint rules disabled as they were not in place at the time this code was written, and also
-                to check that it's possible to disable rules in-place in Angular html files.
-
-                I'm also not sure why an `a` tag wouldn't support focus by default. Possibly because its doesn't have an
-                href. -->
-                <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
-                <!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
                 <p>
                   We will collect this tip when you make your bank transfer. Need to change this? You can
-                  <a (click)="cancelPendingTips()">cancel the tip</a>
+                  <a href (click)="cancelPendingTips()">cancel the tip</a>
                   and then optionally make a new one.
-
-                  <!-- eslint-enable @angular-eslint/template/interactive-supports-focus -->
-                  <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
                 </p>
               </div>
             }


### PR DESCRIPTION
I a couple of these and found it was a real issue that the link were not focusable with the tab key and not clickable with enter key. Fixed here.

Not sure if there's any more direct way to tell angular to make an `a` act like a link, I don't love the href attribute with no value but as we have eslint to remind us to put it in where needed it's OK.

The original sin might be HTML using the same element for links and link targets.