### PR TITLE
DON-521: Fix broken links introduced in recent accessability fix

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -20,7 +20,7 @@
         </a>
       }
       @if (campaign.parentRef && !fromFund) {
-        <a href class="" mat-icon-button (click)="goBackToMetacampaign()">
+        <a href class="" mat-icon-button (click)="goBackToMetacampaign($event)">
           <mat-icon aria-hidden="false" aria-label="Back">keyboard_arrow_left</mat-icon>
           All participating campaigns
         </a>

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -67,7 +67,8 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
     }
   }
 
-  async goBackToMetacampaign() {
+  async goBackToMetacampaign(event: Event) {
+    event.preventDefault();
     const url = `/${this.campaign.parentRef}`;
 
     if (this.navigationService.isLastUrl(url)) {

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -3,7 +3,9 @@
     Customer: Email: {{ donor?.email_address }} <br />
     ID: {{ donor?.id }} <br />
     Stripe ID {{ donor?.stripe_customer_id }} <br /><br />
-    Donation {{ donation?.donationAmount }} <br />PSP customer ID: {{ donation?.pspCustomerId }}
+    Donation {{ donation?.donationAmount }} <br />PSP customer ID: {{ donation?.pspCustomerId }} <br />
+
+    <a href (click)="hideDebugInfo($event)">(dismiss)</a>
   </div>
 }
 @if (campaignOpenOnLoad) {

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -2376,4 +2376,10 @@ export class DonationStartFormComponent
   showCaptcha() {
     this.shouldShowCaptcha = true;
   }
+
+  hideDebugInfo(event: Event) {
+    event.preventDefault();
+
+    this.showDebugInfo = false;
+  }
 }

--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -124,7 +124,7 @@
       <div>
         <p class="error" aria-live="polite">
           We can't find any campaigns matching this search but there are lots more to choose from.
-          <a href (click)="clear()">View all campaigns here</a>.
+          <a href (click)="clear($event)">View all campaigns here</a>.
         </p>
       </div>
     }

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -347,7 +347,8 @@ export class ExploreComponent implements AfterViewChecked, OnDestroy, OnInit {
     }
   }
 
-  clear() {
+  clear(event: Event) {
+    event.preventDefault();
     this.searchService.reset(this.defaultSort, false);
   }
 

--- a/src/app/login-modal/login-modal.component.ts
+++ b/src/app/login-modal/login-modal.component.ts
@@ -109,7 +109,8 @@ export class LoginModalComponent implements OnInit, AfterViewInit {
     });
   }
 
-  forgotPasswordClicked(): void {
+  forgotPasswordClicked(event: Event): void {
+    event.preventDefault();
     this.forgotPassword = true;
   }
 }

--- a/src/app/login-modal/login-modal.html
+++ b/src/app/login-modal/login-modal.html
@@ -63,7 +63,7 @@
     </form>
   </mat-dialog-content>
   <mat-dialog-actions style="justify-content: space-between">
-    <a href (click)="forgotPasswordClicked()">Forgot Password?</a>
+    <a href (click)="forgotPasswordClicked($event)">Forgot Password?</a>
     <div>
       <button
         id="login-modal-submit"

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -48,7 +48,7 @@
                   <div>
                     <!--                    Href attribute below is needed to make this act like a link for keyboard users, i.e focusable and-->
                     <!--                    clickable using keyboard. -->
-                    <a href (click)="this.forgotPassword = false">Return to Login page</a>
+                    <a href="javascript:void(null)" (click)="this.forgotPassword = false">Return to Login page</a>
                   </div>
                   <div id="reset-password-button">
                     @if (!userAskedForResetLink) {
@@ -122,7 +122,7 @@
           </form>
           <div class="actions">
             <div>
-              <a href (click)="this.forgotPassword = true">Forgot Password?</a>
+              <a href="javascript:void(null)" (click)="this.forgotPassword = true">Forgot Password?</a>
             </div>
             <div id="login-button">
               <div aria-live="polite">

--- a/src/app/transfer-funds/transfer-funds.component.html
+++ b/src/app/transfer-funds/transfer-funds.component.html
@@ -46,7 +46,7 @@
                 <p>Thank you for choosing to tip Big Give {{ pendingTipBalance / 100 | exactCurrency: "GBP" }}.</p>
                 <p>
                   We will collect this tip when you make your bank transfer. Need to change this? You can
-                  <a href (click)="cancelPendingTips()">cancel the tip</a>
+                  <a href (click)="cancelPendingTips($event)">cancel the tip</a>
                   and then optionally make a new one.
                 </p>
               </div>

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -336,7 +336,8 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
     return Math.floor(creditAmount * (tipPercentage / 100));
   }
 
-  cancelPendingTips() {
+  cancelPendingTips(event: Event) {
+    event.preventDefault();
     this.donationService.cancelDonationFundsToCampaign(environment.creditTipsCampaign).subscribe(() => {
       // Theoretically this could be multiple tips, but in practice almost always 0 or 1, so singular is the less confusing copy.
       this.toast.showSuccess(


### PR DESCRIPTION
Adding href to these links in #1977 made them available to be used by keyboard, but also broke them since the href didn't point to any sensible place. Added a call to `Event.preventDefault()` for each one. Not sure if there might be any more elegant way to do this but this does seem to work fine when I test on local.

Also added a feature to dismiss the dubug info box on donation form, e.g. in case it gets in the way when wanting to make a screenshot. (Actually it was in adding that feature that I found all these links are broken)

I did a search for regex `href.*click` to see which lines needed editing