### PR TITLE
DON-1104: Allow retrying setting up donation and stripe connection in…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -613,6 +613,18 @@
               if this message persists.
             </p>
           }
+          @if (finalPreSubmitUpdateFailed) {
+            <button
+              style="width: 40%"
+              type="button"
+              class="continue b-w-100 b-rt-0"
+              mat-raised-button
+              color="primary"
+              (click)="runFinalPreSubmitUpdate()"
+            >
+              Retry
+            </button>
+          }
           @if (retrying) {
             <p class="error" aria-live="polite">It looks like our system is a bit busy, one moment please&hellip;</p>
           }
@@ -670,7 +682,7 @@
               </tr>
             </table>
           }
-          @if (!submitting && !runningFinalPreSubmitUpdate) {
+          @if (!submitting && !runningFinalPreSubmitUpdate && !finalPreSubmitUpdateFailed) {
             <button
               (click)="submit()"
               (keyup.enter)="submit()"

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -163,29 +163,39 @@
           </div>
         }
         <div aria-live="polite">
-          @if (donationCreateError) {
-            <p class="error">
-              Sorry, we can't register your donation right now. Please try again in a moment or
-              <a href="https://biggive.org/faqs/" target="_blank">
-                <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
-                contact us</a
+          <div style="text-align: center">
+            @if (donationCreateError) {
+              <p class="error">
+                Sorry, we can't register your donation right now. Please try again in a moment or
+                <a href="https://biggive.org/faqs/" target="_blank">
+                  <mat-icon class="b-va-bottom" aria-hidden="false" aria-label="Open in new tab">open_in_new</mat-icon>
+                  contact us</a
+                >
+                if this message persists.
+              </p>
+              <button
+                style="width: 40%"
+                type="button"
+                class="continue b-w-100 b-rt-0"
+                mat-raised-button
+                color="primary"
+                (click)="retryDonationCreate()"
               >
-              if this message persists.
-            </p>
-          }
-        </div>
-
-        <div style="text-align: center">
-          <button
-            style="width: 40%"
-            type="button"
-            class="continue b-w-100 b-rt-0"
-            mat-raised-button
-            color="primary"
-            (click)="progressToNonAmountsStep()"
-          >
-            Continue
-          </button>
+                Retry
+              </button>
+            } @else {
+              <button
+                style="width: 40%"
+                type="button"
+                class="continue b-w-100 b-rt-0"
+                mat-raised-button
+                color="primary"
+                (click)="progressToNonAmountsStep()"
+              >
+                Continue
+              </button>
+            }
+          </div>
 
           @if (shouldShowCaptcha) {
             <div

--- a/src/app/stripe.service.ts
+++ b/src/app/stripe.service.ts
@@ -117,14 +117,14 @@ export class StripeService {
       return;
     }
 
-    this.didInit = true;
-
     // Initialising through the ES Module like this is not required, but is made available by
     // an official Stripe-maintained package and gives us TypeScript types for
     // the library's objects, which allows for better IDE hinting and more
     // checks that we are handling Stripe objects as intended.
     // See https://github.com/stripe/stripe-js
     this.stripe = await loadStripe(environment.psps.stripe.publishableKey);
+
+    this.didInit = true;
   }
 
   public stripeElementsForDonation(
@@ -300,6 +300,10 @@ export class StripeService {
       elements: stripeElements,
       redirect: 'if_required',
     });
+  }
+
+  get isInitialised(): boolean {
+    return this.didInit;
   }
 }
 


### PR DESCRIPTION
… case of unreliable connection

New retry button replaces continue in case we couldn't set up the pending donation:

![image](https://github.com/user-attachments/assets/a6645fb7-d96b-44d5-9d2d-c460fc37cf46)


PR also includes new handling to allow retrying stripe service initialisation, and require it to be initialised before progress to step 2 in donation form.