### PR TITLE
MAT-411: Use matchbot campaign api instead of salesforce to load donate pages in dev env

### DIFF
--- a/src/app/app-routing.ts
+++ b/src/app/app-routing.ts
@@ -1,7 +1,7 @@
 import { ActivatedRouteSnapshot, CanActivateFn, Resolve, ResolveFn, Route, Router } from '@angular/router';
 
 import { CampaignListResolver } from './campaign-list.resolver';
-import { CampaignResolver } from './campaign.resolver';
+import { MatchbotCampaignResolver, SalesforceCampaignResolver } from './campaign.resolver';
 import { CharityCampaignsResolver } from './charity-campaigns.resolver';
 import { CampaignStatsResolver } from './campaign-stats-resolver';
 import { HighlightCardsResolver } from './highlight-cards-resolver';
@@ -130,7 +130,7 @@ export const routes: (Route & {
     title: undefined, // set from inside component using campaign name
     pathMatch: 'full',
     resolve: {
-      campaign: CampaignResolver,
+      campaign: SalesforceCampaignResolver,
     },
     loadChildren: () => import('./campaign-details/campaign-details.module').then((c) => c.CampaignDetailsModule),
   },
@@ -148,7 +148,7 @@ export const routes: (Route & {
     title: undefined, // set from inside component using campaign name
     pathMatch: 'full',
     resolve: {
-      campaign: CampaignResolver,
+      campaign: flags.useMatchbotCampaignApi ? MatchbotCampaignResolver : SalesforceCampaignResolver,
     },
     loadChildren: () =>
       import('./donation-start/donation-start-container/donation-start-container.module').then(
@@ -190,7 +190,7 @@ export const routes: (Route & {
     title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
-      campaign: CampaignResolver,
+      campaign: SalesforceCampaignResolver,
       highlights: HighlightCardsResolver,
     },
     loadChildren: () => import('./explore/explore.module').then((c) => c.ExploreModule),
@@ -200,7 +200,7 @@ export const routes: (Route & {
     title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
-      campaign: CampaignResolver,
+      campaign: SalesforceCampaignResolver,
       highlights: HighlightCardsResolver,
     },
     loadChildren: () => import('./explore/explore.module').then((c) => c.ExploreModule),
@@ -243,7 +243,7 @@ export const routes: (Route & {
     title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
-      campaign: CampaignResolver,
+      campaign: SalesforceCampaignResolver,
       highlights: HighlightCardsResolver,
     },
     loadChildren: () => import('./explore/explore.module').then((c) => c.ExploreModule),
@@ -315,7 +315,7 @@ export const routes: (Route & {
     title: undefined, // set from inside component
     pathMatch: 'full',
     resolve: {
-      campaign: CampaignResolver,
+      campaign: SalesforceCampaignResolver,
       highlights: HighlightCardsResolver,
     },
     loadChildren: () => import('./explore/explore.module').then((c) => c.ExploreModule),
@@ -360,7 +360,7 @@ if (flags.regularGivingEnabled) {
     component: RegularGivingComponent,
     canActivate: [requireLogin],
     resolve: {
-      campaign: CampaignResolver,
+      campaign: SalesforceCampaignResolver,
       donor: LoggedInPersonResolver,
       donorAccount: DonorAccountResolver,
     },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { AppComponent } from './app.component';
 
 import { routes } from './app-routing';
 import { CampaignListResolver } from './campaign-list.resolver';
-import { CampaignResolver } from './campaign.resolver';
+import { MatchbotCampaignResolver, SalesforceCampaignResolver } from './campaign.resolver';
 import { CharityCampaignsResolver } from './charity-campaigns.resolver';
 import { TBG_DONATE_STORAGE } from './donation.service';
 import { environment } from '../environments/environment';
@@ -58,7 +58,8 @@ const matomoBaseUri = 'https://biggive.matomo.cloud';
   ],
   providers: [
     CampaignListResolver,
-    CampaignResolver,
+    SalesforceCampaignResolver,
+    MatchbotCampaignResolver,
     CampaignStatsResolver,
     CharityCampaignsResolver,
     HighlightCardsResolver,

--- a/src/app/campaign.resolver.ts
+++ b/src/app/campaign.resolver.ts
@@ -11,7 +11,7 @@ import { SearchService } from './search.service';
 import { logCampaignCalloutError } from './logCampaignCalloutError';
 
 @Injectable({ providedIn: 'root' })
-export class CampaignResolver implements Resolve<Campaign> {
+export abstract class CampaignResolver implements Resolve<Campaign> {
   constructor(
     public campaignService: CampaignService,
     private matomoTracker: MatomoTracker,
@@ -42,7 +42,7 @@ export class CampaignResolver implements Resolve<Campaign> {
         return EMPTY;
       }
 
-      return this.loadWithStateCache(campaignId, (identifier: string) => this.campaignService.getOneById(identifier));
+      return this.loadWithStateCache(campaignId, (identifier: string) => this.getOneById(identifier));
     }
 
     if (campaignSlug && fundSlug && campaignSlug !== 'campaign') {
@@ -71,6 +71,8 @@ export class CampaignResolver implements Resolve<Campaign> {
       this.campaignService.getOneBySlug(identifier),
     );
   }
+
+  abstract getOneById(identifier: string): Observable<Campaign>;
 
   private loadWithStateCache(
     identifier: string,
@@ -119,5 +121,19 @@ export class CampaignResolver implements Resolve<Campaign> {
    */
   private plausibleIdentifier(identifier: string): boolean {
     return !!identifier && identifier !== 'd' && identifier !== 'null';
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class MatchbotCampaignResolver extends CampaignResolver {
+  getOneById(identifier: string) {
+    return this.campaignService.getOneById(identifier, { dataSource: 'matchbot' });
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class SalesforceCampaignResolver extends CampaignResolver {
+  getOneById(identifier: string) {
+    return this.campaignService.getOneById(identifier, { dataSource: 'salesforce' });
   }
 }

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -105,7 +105,7 @@ describe('CampaignService', () => {
     );
 
     const request = httpMock.expectOne(
-      `${environment.apiUriPrefix}/campaigns/services/apexrest/v1.0/campaigns/a051r00001EywjpAAB`,
+      `${environment.sfApiUriPrefix}/campaigns/services/apexrest/v1.0/campaigns/a051r00001EywjpAAB`,
     );
     expect(request.request.method).toBe('GET');
     request.flush(dummyCampaign);

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -95,7 +95,7 @@ describe('CampaignService', () => {
 
     const dummyCampaign: Campaign = getDummyCampaign();
 
-    service.getOneById('a051r00001EywjpAAB').subscribe(
+    service.getOneById('a051r00001EywjpAAB', { dataSource: 'salesforce' }).subscribe(
       (campaign) => {
         expect(campaign).toEqual(dummyCampaign);
       },

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -219,7 +219,7 @@ export class CampaignService {
       case 'salesforce':
         return this.http.get<Campaign>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns/${campaignId}`);
       case 'matchbot':
-        return this.http.get<Campaign>(`${environment.donationsApiPrefix}/campaigns/${campaignId}`);
+        return this.http.get<Campaign>(`${environment.matchbotApiPrefix}/campaigns/${campaignId}`);
     }
   }
 

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -203,8 +203,24 @@ export class CampaignService {
     return this.http.get<CampaignSummary[]>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns`, { params });
   }
 
-  getOneById(campaignId: string): Observable<Campaign> {
-    return this.http.get<Campaign>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns/${campaignId}`);
+  /**
+   * Gets details of a campaign from a system. At time of writing this is always salesforce, but we are in
+   * process of changing it over to matchbot.
+   */
+  getOneById(
+    campaignId: string,
+    {
+      dataSource,
+    }: {
+      dataSource: 'salesforce' | 'matchbot';
+    },
+  ): Observable<Campaign> {
+    switch (dataSource) {
+      case 'salesforce':
+        return this.http.get<Campaign>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns/${campaignId}`);
+      case 'matchbot':
+        return this.http.get<Campaign>(`${environment.donationsApiPrefix}/campaigns/${campaignId}`);
+    }
   }
 
   getOneBySlug(campaignSlug: string): Observable<Campaign> {

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -149,7 +149,7 @@ export class CampaignService {
 
   getForCharity(charityId: string): Observable<CampaignSummary[]> {
     return this.http.get<CampaignSummary[]>(
-      `${environment.apiUriPrefix}${this.apiPath}/charities/${charityId}/campaigns`,
+      `${environment.sfApiUriPrefix}${this.apiPath}/charities/${charityId}/campaigns`,
     );
   }
 
@@ -200,11 +200,11 @@ export class CampaignService {
       params = params.append('term', searchQuery.term);
     }
 
-    return this.http.get<CampaignSummary[]>(`${environment.apiUriPrefix}${this.apiPath}/campaigns`, { params });
+    return this.http.get<CampaignSummary[]>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns`, { params });
   }
 
   getOneById(campaignId: string): Observable<Campaign> {
-    return this.http.get<Campaign>(`${environment.apiUriPrefix}${this.apiPath}/campaigns/${campaignId}`);
+    return this.http.get<Campaign>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns/${campaignId}`);
   }
 
   getOneBySlug(campaignSlug: string): Observable<Campaign> {
@@ -215,18 +215,18 @@ export class CampaignService {
       return new Observable();
     }
 
-    return this.http.get<Campaign>(`${environment.apiUriPrefix}${this.apiPath}/campaigns/slug/${campaignSlug}`);
+    return this.http.get<Campaign>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns/slug/${campaignSlug}`);
   }
 
   getCampaignImpactStats() {
     return this.http
-      .get<CampaignStats>(`${environment.apiUriPrefix}${this.apiPath}/campaigns/stats`)
+      .get<CampaignStats>(`${environment.sfApiUriPrefix}${this.apiPath}/campaigns/stats`)
       .pipe(map(formatCampaignStats));
   }
 
   getHomePageHighlightCards(): Observable<HighlightCard[]> {
     return this.http
-      .get<SfApiHighlightCard[]>(`${environment.apiUriPrefix}${this.apiPath}/highlight-service`)
+      .get<SfApiHighlightCard[]>(`${environment.sfApiUriPrefix}${this.apiPath}/highlight-service`)
       .pipe(map(SFHighlightCardsToFEHighlightCards));
   }
 }

--- a/src/app/donation-thanks/donation-thanks.component.ts
+++ b/src/app/donation-thanks/donation-thanks.component.ts
@@ -191,7 +191,7 @@ export class DonationThanksComponent implements OnInit {
     }
 
     this.donation = donation;
-    this.campaignService.getOneById(donation.projectId).subscribe((campaign) => {
+    this.campaignService.getOneById(donation.projectId, { dataSource: 'salesforce' }).subscribe((campaign) => {
       this.campaign = campaign;
       this.pageMeta.setCommon(`Thank you for donating to the "${campaign.title}" campaign`, ``, campaign.bannerUri);
       this.setSocialShares(campaign);

--- a/src/app/donation.service.spec.ts
+++ b/src/app/donation.service.spec.ts
@@ -89,7 +89,7 @@ describe('DonationService', () => {
         },
       );
 
-      const mockPost = httpMock.expectOne(`${environment.donationsApiPrefix}/donations`);
+      const mockPost = httpMock.expectOne(`${environment.matchbotApiPrefix}/donations`);
       expect(mockPost.request.method).toEqual('POST');
       expect(mockPost.cancelled).toBeFalsy();
       expect(mockPost.request.responseType).toEqual('json');
@@ -203,7 +203,7 @@ describe('DonationService', () => {
       // After it finds a local match, getProbablyResumableDonation() will hit the server for the latest copy via
       // `DonationService.get()`.
       const mockGet = httpMock.expectOne((request) =>
-        request.url.startsWith(`${environment.donationsApiPrefix}/donations/${inputDonation.donationId}`),
+        request.url.startsWith(`${environment.matchbotApiPrefix}/donations/${inputDonation.donationId}`),
       );
       expect(mockGet.request.method).toBe('GET');
       expect(mockGet.cancelled).toBeFalsy();

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -170,7 +170,7 @@ export class DonationService {
     }
 
     return this.http.put<Donation>(
-      `${environment.donationsApiPrefix}${this.apiPath}/${donation.donationId}`,
+      `${environment.matchbotApiPrefix}${this.apiPath}/${donation.donationId}`,
       donation,
       this.getAuthHttpOptions(donation),
     );
@@ -185,7 +185,7 @@ export class DonationService {
 
     const response = (await firstValueFrom(
       this.http.get(
-        `${environment.donationsApiPrefix}/people/${person.id}/payment_methods${cacheBuster}`,
+        `${environment.matchbotApiPrefix}/people/${person.id}/payment_methods${cacheBuster}`,
         getPersonAuthHttpOptions(jwt),
       ),
     )) as { data: PaymentMethod[]; regularGivingPaymentMethod?: PaymentMethod };
@@ -209,8 +209,8 @@ export class DonationService {
 
   create(donation: Donation, personId?: string, jwt?: string): Observable<DonationCreatedResponse> {
     const endpoint = personId
-      ? `${environment.donationsApiPrefix}/people/${personId}${this.apiPath}`
-      : `${environment.donationsApiPrefix}${this.apiPath}`;
+      ? `${environment.matchbotApiPrefix}/people/${personId}${this.apiPath}`
+      : `${environment.matchbotApiPrefix}${this.apiPath}`;
 
     return this.http.post<DonationCreatedResponse>(endpoint, donation, getPersonAuthHttpOptions(jwt));
   }
@@ -222,7 +222,7 @@ export class DonationService {
     const cacheBuster = Math.floor(new Date().getTime() / 1000);
 
     return this.http.get<Donation>(
-      `${environment.donationsApiPrefix}${this.apiPath}/${donation.donationId}?cb=${cacheBuster}`,
+      `${environment.matchbotApiPrefix}${this.apiPath}/${donation.donationId}?cb=${cacheBuster}`,
       this.getAuthHttpOptions(donation),
     );
   }
@@ -341,7 +341,7 @@ export class DonationService {
     }
 
     return this.http.delete<{ data: PaymentMethod[] }>(
-      `${environment.donationsApiPrefix}/people/${personId}/payment_methods/${paymentMethodId}`,
+      `${environment.matchbotApiPrefix}/people/${personId}/payment_methods/${paymentMethodId}`,
       getPersonAuthHttpOptions(jwt),
     );
   }
@@ -356,7 +356,7 @@ export class DonationService {
       expiry: { month: number; year: number };
     },
   ) {
-    const url = `${environment.donationsApiPrefix}/people/${person.id}/payment_methods/${paymentMethodId}/billing_details`;
+    const url = `${environment.matchbotApiPrefix}/people/${person.id}/payment_methods/${paymentMethodId}/billing_details`;
 
     return this.http.put<{ data: PaymentMethod[] }>(
       url,
@@ -383,7 +383,7 @@ export class DonationService {
     { confirmationToken }: { confirmationToken?: ConfirmationToken },
   ): Observable<{ paymentIntent: { status: PaymentIntent.Status; client_secret: string } }> {
     return this.http.post<{ paymentIntent: { status: PaymentIntent.Status; client_secret: string } }>(
-      `${environment.donationsApiPrefix}/donations/${donation.donationId}/confirm`,
+      `${environment.matchbotApiPrefix}/donations/${donation.donationId}/confirm`,
       {
         stripeConfirmationTokenId: confirmationToken?.id,
       },
@@ -404,7 +404,7 @@ export class DonationService {
         return this.http
           .get<{
             donations: CompleteDonation[];
-          }>(`${environment.donationsApiPrefix}/people/${person.id}/donations`, getPersonAuthHttpOptions(jwt))
+          }>(`${environment.matchbotApiPrefix}/people/${person.id}/donations`, getPersonAuthHttpOptions(jwt))
           .pipe(map((response) => response.donations));
       }),
     );
@@ -425,7 +425,7 @@ export class DonationService {
             donations: Donation[];
           }>(
             'DELETE',
-            `${environment.donationsApiPrefix}/people/${person.id}/donations?campaignId=${campaignId}&paymentMethodType=customer_balance`,
+            `${environment.matchbotApiPrefix}/people/${person.id}/donations?campaignId=${campaignId}&paymentMethodType=customer_balance`,
             getPersonAuthHttpOptions(jwt),
           )
           .pipe(map((response) => response.donations));
@@ -442,7 +442,7 @@ export class DonationService {
 
     return firstValueFrom(
       this.http.post(
-        `${environment.donationsApiPrefix}/people/${person.id}/create-customer-session`,
+        `${environment.matchbotApiPrefix}/people/${person.id}/create-customer-session`,
         { campaignId: campaign?.id },
         getPersonAuthHttpOptions(jwt),
       ) as Observable<StripeCustomerSession>,
@@ -455,7 +455,7 @@ export class DonationService {
     return (
       await firstValueFrom(
         this.http.post(
-          `${environment.donationsApiPrefix}/people/${person.id}/create-setup-intent`,
+          `${environment.matchbotApiPrefix}/people/${person.id}/create-setup-intent`,
           {},
           getPersonAuthHttpOptions(jwt),
         ) as Observable<{ setupIntent: SetupIntent }>,

--- a/src/app/donor-account.service.ts
+++ b/src/app/donor-account.service.ts
@@ -33,7 +33,7 @@ export class DonorAccountService {
           return of(null);
         }
 
-        return this.http.get(`${environment.donationsApiPrefix}/people/${identityPerson.id}/donor-account`, {
+        return this.http.get(`${environment.matchbotApiPrefix}/people/${identityPerson.id}/donor-account`, {
           headers: new HttpHeaders({ 'X-Tbg-Auth': jwt }),
         }) as Observable<DonorAccount>;
       }),

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -3,18 +3,24 @@ import { EnvironmentID } from '../environments/environment.interface';
 
 type flags = {
   readonly regularGivingEnabled: boolean;
+
+  /**
+   * The matchbot campaign is in development, see ticket MAT-405. Not ready yet for use in prod but should
+   * eventually replace the salesforce campaign api
+   */
+  readonly useMatchbotCampaignApi: boolean;
 };
 
 const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmentId: EnvironmentID) => {
   switch (environmentId) {
     case 'development':
-      return { regularGivingEnabled: true };
+      return { regularGivingEnabled: true, useMatchbotCampaignApi: true };
     case 'regression':
-      return { regularGivingEnabled: true };
+      return { regularGivingEnabled: true, useMatchbotCampaignApi: false };
     case 'staging':
-      return { regularGivingEnabled: true };
+      return { regularGivingEnabled: true, useMatchbotCampaignApi: false };
     case 'production':
-      return { regularGivingEnabled: false };
+      return { regularGivingEnabled: false, useMatchbotCampaignApi: false };
   }
 };
 

--- a/src/app/fund.service.spec.ts
+++ b/src/app/fund.service.spec.ts
@@ -38,7 +38,7 @@ describe('FundService', () => {
     );
 
     const request = httpMock.expectOne(
-      `${environment.apiUriPrefix}/funds/services/apexrest/v1.0/funds/slug/champion-fund-test-slug`,
+      `${environment.sfApiUriPrefix}/funds/services/apexrest/v1.0/funds/slug/champion-fund-test-slug`,
     );
     expect(request.request.method).toBe('GET');
     request.flush(dummyFund);

--- a/src/app/fund.service.ts
+++ b/src/app/fund.service.ts
@@ -14,6 +14,6 @@ export class FundService {
   constructor(private http: HttpClient) {}
 
   getOneBySlug(fundSlug: string): Observable<Fund> {
-    return this.http.get<Fund>(`${environment.apiUriPrefix}${this.apiPath}/slug/${fundSlug}`);
+    return this.http.get<Fund>(`${environment.sfApiUriPrefix}${this.apiPath}/slug/${fundSlug}`);
   }
 }

--- a/src/app/regularGiving.service.ts
+++ b/src/app/regularGiving.service.ts
@@ -73,7 +73,7 @@ export class RegularGivingService {
     return this.withLoggedInDonor((personAuthHttpOptions: PersonAuthHttpOptions) => {
       const IDAndJWT = this.identityService.getIdAndJWT()!;
       return this.http.post<unknown>(
-        `${environment.donationsApiPrefix}/people/${IDAndJWT.id}/regular-giving`,
+        `${environment.matchbotApiPrefix}/people/${IDAndJWT.id}/regular-giving`,
         mandate,
         personAuthHttpOptions,
       ) as Observable<MandateCreateResponse>;
@@ -90,7 +90,7 @@ export class RegularGivingService {
       return this.http
         .get<{
           mandates: Mandate[];
-        }>(`${environment.donationsApiPrefix}/regular-giving/my-donation-mandates`, personAuthHttpOptions)
+        }>(`${environment.matchbotApiPrefix}/regular-giving/my-donation-mandates`, personAuthHttpOptions)
         .pipe(map((response) => response.mandates));
     });
   }
@@ -100,7 +100,7 @@ export class RegularGivingService {
       return this.http
         .get<{
           mandate: Mandate;
-        }>(`${environment.donationsApiPrefix}/regular-giving/my-donation-mandates/${mandateId}`, personAuthHttpOptions)
+        }>(`${environment.matchbotApiPrefix}/regular-giving/my-donation-mandates/${mandateId}`, personAuthHttpOptions)
         .pipe(map((response) => response.mandate));
     });
   }
@@ -108,7 +108,7 @@ export class RegularGivingService {
   public cancel(mandate: Mandate, { cancellationReason }: { cancellationReason: string }): Observable<unknown> {
     return this.withLoggedInDonor((personAuthHttpOptions: PersonAuthHttpOptions) => {
       return this.http.post(
-        `${environment.donationsApiPrefix}/regular-giving/my-donation-mandates/${mandate.id}/cancel`,
+        `${environment.matchbotApiPrefix}/regular-giving/my-donation-mandates/${mandate.id}/cancel`,
         {
           cancellationReason: cancellationReason,
           mandateUUID: mandate.id,
@@ -155,7 +155,7 @@ export class RegularGivingService {
       this.withLoggedInDonor((personAuthHttpOptions: PersonAuthHttpOptions) => {
         const IDAndJWT = this.identityService.getIdAndJWT()!;
         return this.http.put<unknown>(
-          `${environment.donationsApiPrefix}/people/${IDAndJWT.id}/regular-giving/payment-method`,
+          `${environment.matchbotApiPrefix}/people/${IDAndJWT.id}/regular-giving/payment-method`,
           { paymentMethodId },
           personAuthHttpOptions,
         );
@@ -168,7 +168,7 @@ export class RegularGivingService {
       this.withLoggedInDonor((personAuthHttpOptions: PersonAuthHttpOptions) => {
         const IDAndJWT = this.identityService.getIdAndJWT()!;
         return this.http.delete<unknown>(
-          `${environment.donationsApiPrefix}/people/${IDAndJWT.id}/regular-giving/payment-method`,
+          `${environment.matchbotApiPrefix}/people/${IDAndJWT.id}/regular-giving/payment-method`,
           personAuthHttpOptions,
         );
       }),

--- a/src/app/transfer-funds/transfer-funds.component.ts
+++ b/src/app/transfer-funds/transfer-funds.component.ts
@@ -158,9 +158,11 @@ export class TransferFundsComponent implements AfterContentInit, OnInit {
     });
 
     // get the tips campaign data on page load
-    this.campaignService.getOneById(environment.creditTipsCampaign).subscribe((campaign) => {
-      this.campaign = campaign;
-    });
+    this.campaignService
+      .getOneById(environment.creditTipsCampaign, { dataSource: 'salesforce' })
+      .subscribe((campaign) => {
+        this.campaign = campaign;
+      });
   }
 
   ngAfterContentInit() {

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -16,7 +16,7 @@ export interface Environment {
   production: boolean;
   productionLike: boolean;
   creditTipsCampaign: string;
-  apiUriPrefix: string;
+  sfApiUriPrefix: string;
   creditDonationsEnabled: boolean;
 
   /** Prefix for pages served by this Angular application */

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -32,7 +32,7 @@ export interface Environment {
 
   /** Prefix for pages served by the SF Experience Cloud */
   experienceUriPrefix: string;
-  donationsApiPrefix: string;
+  matchbotApiPrefix: string;
   getSiteControlId: string;
   identityApiPrefix: string;
   matomoSiteId: number | null;

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -6,7 +6,7 @@ export const environment: Environment = {
   production: true,
   productionLike: true,
   creditTipsCampaign: 'a056900002LDXWgAAP',
-  apiUriPrefix: 'https://sf-api-production.thebiggive.org.uk',
+  sfApiUriPrefix: 'https://sf-api-production.thebiggive.org.uk',
   creditDonationsEnabled: true, // Whether the donation start page offers credit for settlement. Credit purchase page is always available.
   donateUriPrefix: 'https://donate.biggive.org',
   experienceUriPrefix: 'https://community.biggive.org',

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -12,7 +12,7 @@ export const environment: Environment = {
   experienceUriPrefix: 'https://community.biggive.org',
   blogUriPrefix: 'https://biggive.org',
   sharedCookieDomain: '.biggive.org',
-  donationsApiPrefix: 'https://matchbot-production.thebiggive.org.uk/v1',
+  matchbotApiPrefix: 'https://matchbot-production.thebiggive.org.uk/v1',
   getSiteControlId: '97792',
   identityApiPrefix: 'https://identity-production.thebiggive.org.uk/v1',
   matomoSiteId: 2,

--- a/src/environments/environment.regression.ts
+++ b/src/environments/environment.regression.ts
@@ -14,7 +14,7 @@ export const environment: Environment = {
   production: false,
   productionLike: true,
   creditTipsCampaign: 'a053O00000J1ROLQA3',
-  apiUriPrefix: 'https://sf-api-regression.thebiggivetest.org.uk',
+  sfApiUriPrefix: 'https://sf-api-regression.thebiggivetest.org.uk',
   creditDonationsEnabled: true, // Whether the donation start page offers credit for settlement. Credit purchase page is always available.
   donateUriPrefix: 'https://donate-regression.thebiggivetest.org.uk',
   sharedCookieDomain: '.thebiggivetest.org.uk',

--- a/src/environments/environment.regression.ts
+++ b/src/environments/environment.regression.ts
@@ -20,7 +20,7 @@ export const environment: Environment = {
   sharedCookieDomain: '.thebiggivetest.org.uk',
   blogUriPrefix: 'https://biggive.org',
   experienceUriPrefix: 'https://thebiggive--regtest1.sandbox.my.site.com',
-  donationsApiPrefix: 'https://matchbot-regression.thebiggivetest.org.uk/v1',
+  matchbotApiPrefix: 'https://matchbot-regression.thebiggivetest.org.uk/v1',
   getSiteControlId: '97792',
   identityApiPrefix: 'https://identity-regression.thebiggivetest.org.uk/v1',
   matomoSiteId: 4,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -20,7 +20,7 @@ export const environment: Environment = {
   blogUriPrefix: 'https://wp-staging.thebiggivetest.org.uk',
   sharedCookieDomain: '.thebiggivetest.org.uk',
   experienceUriPrefix: 'https://thebiggive--full.sandbox.my.site.com',
-  donationsApiPrefix: 'https://matchbot-staging.thebiggivetest.org.uk/v1',
+  matchbotApiPrefix: 'https://matchbot-staging.thebiggivetest.org.uk/v1',
   getSiteControlId: '97792',
   identityApiPrefix: 'https://identity-staging.thebiggivetest.org.uk/v1',
   matomoSiteId: 4,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -12,7 +12,7 @@ export const environment: Environment = {
   production: false,
   productionLike: true,
   creditTipsCampaign: 'a056900002LDXWgAAP',
-  apiUriPrefix: 'https://sf-api-staging.thebiggivetest.org.uk',
+  sfApiUriPrefix: 'https://sf-api-staging.thebiggivetest.org.uk',
   creditDonationsEnabled: true, // Whether the donation start page offers credit for settlement. Credit purchase page is always available.
   // For staging-like SSR testing local builds
   // donateUriPrefix: 'http://localhost:4000',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,7 +12,7 @@ export const environment: Environment = {
   production: false,
   productionLike: false,
   creditTipsCampaign: 'a056900002LDXWgAAP',
-  apiUriPrefix: 'https://sf-api-staging.thebiggivetest.org.uk',
+  sfApiUriPrefix: 'https://sf-api-staging.thebiggivetest.org.uk',
   creditDonationsEnabled: true, // Whether the donation start page offers credit for settlement. Credit purchase page is always available.
   donateUriPrefix: 'http://localhost:4200',
   blogUriPrefix: 'http://localhost:30003',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -18,7 +18,7 @@ export const environment: Environment = {
   blogUriPrefix: 'http://localhost:30003',
   sharedCookieDomain: 'localhost',
   experienceUriPrefix: 'https://thebiggive--full.sandbox.my.site.com',
-  donationsApiPrefix: 'http://localhost:30030/v1',
+  matchbotApiPrefix: 'http://localhost:30030/v1',
   getSiteControlId: '97792',
   identityApiPrefix: 'http://localhost:30050/v1',
   matomoSiteId: 4,

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ app.use(
         ...helmet.contentSecurityPolicy.getDefaultDirectives(),
         'connect-src': [
           'wss:', // For GetSiteControl. wss:// is for secure-only WebSockets.
-          new URL(environment.apiUriPrefix).host,
+          new URL(environment.sfApiUriPrefix).host,
           new URL(environment.donationsApiPrefix).host,
           new URL(environment.identityApiPrefix).host,
           matomoUriBase,

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,7 @@ app.use(
         'connect-src': [
           'wss:', // For GetSiteControl. wss:// is for secure-only WebSockets.
           new URL(environment.sfApiUriPrefix).host,
-          new URL(environment.donationsApiPrefix).host,
+          new URL(environment.matchbotApiPrefix).host,
           new URL(environment.identityApiPrefix).host,
           matomoUriBase,
           'api.getAddress.io',


### PR DESCRIPTION
FE (and readers of its code) should know when its talking to SF and when its not, since that is about to change.