### PR TITLE
MAT-411: Display campaign errors on donation page

### DIFF
--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -73,6 +73,12 @@ export type Campaign = {
   target?: number;
   thankYouMessage?: string;
   video?: { provider: string; key: string };
+
+  /**
+   * List of errors encountered by the backend in rendering this campaign. Intended to help us catch any issues
+   * that come up in MAT-405 work before release.
+   * */
+  errors?: string[];
 } & (
   | {
       // If parentUsesSharedFunds then we expect the backend to tell us how much of those parental shared funds are available

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.html
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.html
@@ -64,6 +64,26 @@
           </div>
           <app-campaign-info [campaign]="campaign"></app-campaign-info>
         </div>
+        @if (showDebugInfo) {
+          <div style="outline: 1px solid black; padding: 1em">
+            <strong>Debug info</strong>
+            <br />
+            Customer: Email: {{ donor?.email_address }} <br />
+            ID: {{ donor?.id }} <br />
+            Stripe ID {{ donor?.stripe_customer_id }} <br /><br />
+            Donation {{ donation?.donationAmount }} <br />PSP customer ID: {{ donation?.pspCustomerId }} <br />
+
+            <a href (click)="hideDebugInfo($event)">(dismiss)</a>
+          </div>
+        }
+        @if (campaign.errors && environment.environmentId !== "production") {
+          <strong style="color: red">Campaign Errors</strong>
+          <ol>
+            @for (error of campaign.errors; track error) {
+              <li>{{ error }}</li>
+            }
+          </ol>
+        }
       }
     </div>
   </div>

--- a/src/app/donation-start/donation-start-container/donation-start-container.component.ts
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.ts
@@ -32,8 +32,10 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit {
   public reservationExpiryDate: Date | undefined = undefined;
   public donor: Person | undefined;
   public bannerUri!: string | null;
+  protected readonly environment = environment;
 
   isOffline$: Observable<boolean>;
+  showDebugInfo = environment.showDebugInfo;
 
   constructor(
     public identityService: IdentityService,
@@ -128,4 +130,10 @@ export class DonationStartContainerComponent implements AfterViewInit, OnInit {
     this.donation = donation;
     this.updateReservationExpiryTime();
   };
+
+  hideDebugInfo(event: Event) {
+    event.preventDefault();
+
+    this.showDebugInfo = false;
+  }
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -1,13 +1,3 @@
-@if (showDebugInfo) {
-  <div style="outline: solid green 1px; position: fixed; top: 200px; left: 50px; width: 400px; background: white">
-    Customer: Email: {{ donor?.email_address }} <br />
-    ID: {{ donor?.id }} <br />
-    Stripe ID {{ donor?.stripe_customer_id }} <br /><br />
-    Donation {{ donation?.donationAmount }} <br />PSP customer ID: {{ donation?.pspCustomerId }} <br />
-
-    <a href (click)="hideDebugInfo($event)">(dismiss)</a>
-  </div>
-}
 @if (campaignOpenOnLoad) {
   <form class="c-donate-form" (keydown.enter)="interceptSubmitAndProceedInstead($event)" [formGroup]="donationForm">
     <mat-vertical-stepper id="stepper" linear #stepper (selectionChange)="stepChanged($event)" [@.disabled]>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -129,8 +129,6 @@ export class DonationStartFormComponent
   maximumDonationAmount!: number;
   maximumTipPercentage = 30 as const;
 
-  showDebugInfo = environment.showDebugInfo;
-
   /**
    * This is a suggested minimum, the lowest people can select using the slider. We still let them select any tip amount
    * of custom tip, including zero.
@@ -2414,11 +2412,5 @@ export class DonationStartFormComponent
 
   showCaptcha() {
     this.shouldShowCaptcha = true;
-  }
-
-  hideDebugInfo(event: Event) {
-    event.preventDefault();
-
-    this.showDebugInfo = false;
   }
 }


### PR DESCRIPTION
Should help us see what needs to be fixed to get matchbot campaign API compatible as a replacement for salesforce API, including testing against several different campaigns in staging.

Also moved the existing "debug info" developer panel on donate page to the sidebar so it stops being in the way of the actual donation form. Maybe now its dismiss function is unecassary but I've left it, I guess useful if we want to take a screenshot without showing this.

![image](https://github.com/user-attachments/assets/ff13f37e-d65f-492c-a3b4-14e3a7470683)
