### PR TITLE
MAT-405: Adjust Campaign / MetaCampaign status type to better reflect…

### DIFF
--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -54,7 +54,7 @@ type CampaignOrMetaCampaign = {
    **/
   startDate: string;
   // More on Campaign status semantics defined in Salesforce `docs/campaign-status-definitions`.
-  status: 'Active' | 'Expired' | 'Preview';
+  status: 'Active' | 'Expired' | 'Preview' | null;
   summary: string;
   title: string;
   updates: Array<{ content: string; modifiedDate: Date }>;


### PR DESCRIPTION
… what SF can send

Campaigns that are not yet approved to launch on the BG site have null status, and should not be findable by the public but may be previewed by the people creating them.