### PR TITLE
MAT-411: Use new matchbot campaign API in all environments

### DIFF
--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -6,7 +6,9 @@ type flags = {
 
   /**
    * The matchbot campaign is in development, see ticket MAT-405. Not ready yet for use in prod but should
-   * eventually replace the salesforce campaign api
+   * eventually replace the salesforce campaign api.
+   *
+   * Now true in all environments, @todo remove flag when we're confident we won't need to switch it off.
    */
   readonly useMatchbotCampaignApi: boolean;
 };
@@ -20,7 +22,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
     case 'staging':
       return { regularGivingEnabled: true, useMatchbotCampaignApi: true };
     case 'production':
-      return { regularGivingEnabled: false, useMatchbotCampaignApi: false };
+      return { regularGivingEnabled: false, useMatchbotCampaignApi: true };
   }
 };
 


### PR DESCRIPTION
For now matchbot simply proxies data in real time from SF as long as SF is up and has the campaign, and sends a reconstruction of the same saved date if SF is down, but this should change very soon and matchbot will be the source of aggregated donation data such as total amount raised per campaign.