### PR TITLE
Remove trailing '/' when making email verification token

### DIFF
--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -270,7 +270,7 @@ export class IdentityService {
   }
 
   async requestEmailAuthToken(emailAddress: string, { captcha_code }: { captcha_code: string }): Promise<object> {
-    const uri = `${environment.identityApiPrefix}/emailVerificationToken/`;
+    const uri = `${environment.identityApiPrefix}/emailVerificationToken`;
 
     return firstValueFrom(
       this.http.post(


### PR DESCRIPTION
I think the new version has been supported in Production for a long time, so we can simplify Identity if we switch this call over.