### PR TITLE
MAT-405: Clarify that campaign parent target is only expected when us…

### DIFF
--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -64,7 +64,6 @@ export type Campaign = {
   championRef?: string;
   logoUri?: string;
   parentRef?: string;
-  parentTarget?: number;
   surplusDonationInfo?: string;
   target?: number;
   thankYouMessage?: string;
@@ -75,13 +74,14 @@ export type Campaign = {
    * */
   errors?: string[];
 } & (
-  | {
+  {
       // If parentUsesSharedFunds then we expect the backend to tell us how much of those parental shared funds are available
       parentUsesSharedFunds: true;
       parentDonationCount: number;
       parentMatchFundsRemaining: number;
-      parentAmountRaised?: number;
-    }
+      parentAmountRaised: number;
+      parentTarget: number;
+}
   | {
       parentUsesSharedFunds: false;
     }


### PR DESCRIPTION
…ing shared funds, and that in that case parentTarget + amountRaised should always be given

Parent target is very cheap to supply from backend but still probably worth clarifying this because it only makes sense to show parentTarget as part of a charity campaign if there are shared funds.