### PR TITLE
DON-1148 – refresh Payment Element when possibly necessary

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -928,6 +928,7 @@ export class DonationStartFormComponent
     this.paymentReadinessTracker.onStripeCardChange(state);
 
     if (state.error) {
+      await this.stripeElements?.fetchUpdates();
       this.stripeError = getStripeFriendlyError(state.error, 'card_change');
       this.toast.showError(this.stripeError);
       this.stripeResponseErrorCode = state.error.code;
@@ -1458,13 +1459,14 @@ export class DonationStartFormComponent
     }
   }
 
-  private prepareStripeElements() {
+  private async prepareStripeElements() {
     if (!this.donation) {
       console.log('Donation not ready for Stripe');
       return;
     }
 
     if (this.stripeElements) {
+      await this.stripeElements.fetchUpdates();
       this.stripeService.updateAmount(this.stripeElements, this.donation);
     } else {
       this.stripeElements = this.stripeService.stripeElementsForDonation(
@@ -1475,6 +1477,7 @@ export class DonationStartFormComponent
     }
 
     if (this.stripePaymentElement) {
+      await this.stripeElements.fetchUpdates();
       // Payment element was already ready & we presume mounted.
       return;
     }
@@ -1568,11 +1571,12 @@ export class DonationStartFormComponent
     this.stripePaymentMethodReady = true;
   }
 
-  private handleStripeError(
+  private async handleStripeError(
     error: StripeError | { message: string; code: string; decline_code?: string } | undefined,
     context: 'method_setup' | 'card_change' | 'confirm',
   ) {
     this.submitting = false;
+    await this.stripeElements?.fetchUpdates();
     this.stripeError = getStripeFriendlyError(error, context);
     this.toast.showError(this.stripeError);
     this.stripeResponseErrorCode = error?.code;

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -506,6 +506,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     this.stripePaymentMethodReady = state.complete;
 
     if (state.error) {
+      await this.stripeElements?.fetchUpdates();
       this.stripeError = getStripeFriendlyError(state.error, 'card_change');
       this.toast.showError(this.stripeError);
     } else {


### PR DESCRIPTION
Aiming to fix rare edge cases where the choice to setup the payment method for future usage or not is 'null' after an initial decline.

Broadly I'm trying to call the fetch fn whenever:
1. there was just a decline, and
2. we might be about to reconfigure or recycle an Element that wasn't fully destroyed, perhaps in a recovery edge case we haven't specifically thought about