### PR TITLE
MAT-405: Switch to calling matchbot instead of SF for metacampaign de…

### DIFF
--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -39,21 +39,21 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         regularGivingEnabled: true,
         useMatchbotCampaignApi: true,
         useMatchbotCharityApi: false,
-        useMatchbotMetaCampaignApi: false,
+        useMatchbotMetaCampaignApi: true, // none of our regression test scenarios actually look at a metacampaign so this doesn't matter.
       };
     case 'staging':
       return {
         regularGivingEnabled: true,
         useMatchbotCampaignApi: true,
-        useMatchbotCharityApi: false,
-        useMatchbotMetaCampaignApi: false,
+        useMatchbotCharityApi: false, // campaign data is not quite complete or up to date enough to use yet in staging
+        useMatchbotMetaCampaignApi: true, // but metacampaign data **is**, since there are only a few relavent metacampaigns
       };
     case 'production':
       return {
         regularGivingEnabled: false,
-        useMatchbotCampaignApi: true,
-        useMatchbotCharityApi: false,
-        useMatchbotMetaCampaignApi: false,
+        useMatchbotCampaignApi: true, // must be false for now as campaign data isn't yet complete and up to date in prod matchbot db.
+        useMatchbotCharityApi: false, // ditto for charities
+        useMatchbotMetaCampaignApi: false, // matchbot metaCampaign table is empty in prod right now so must be false
       };
   }
 };


### PR DESCRIPTION
…tails in staging

Pages at URIs like https://donate-staging.thebiggivetest.org.uk/some-meta-campaign-2025 will now load the details of the metacampaign from matchbot not directly from SF. Will error if the given metacampaign is not yet in the matchbot DB.