### PR TITLE
Fix missing DatePipe provider error on charity page

### DIFF
--- a/src/app/charity/charity.component.ts
+++ b/src/app/charity/charity.component.ts
@@ -14,6 +14,7 @@ import { OptimisedImagePipe } from '../optimised-image.pipe';
   templateUrl: './charity.component.html',
   styleUrl: 'charity.component.scss',
   imports: [RouterLink, BiggiveGrid, BiggiveCampaignCard, AsyncPipe, CurrencyPipe, OptimisedImagePipe],
+  providers: [DatePipe],
 })
 export class CharityComponent implements OnInit {
   private datePipe = inject(DatePipe);


### PR DESCRIPTION
Think this must have been broken since the angular 20 upgrade and switch from constructor injection to the 'inject' function. Other components that use 'DatePipe' already have it listed as a provider.

Apparently injecting DatePipe is not really reccomended and its better to use Angular's `formatDate` function, but this is an easier change to make sure we're not making any unintend change to what local or timezone we show the dates with.