### PR TITLE
DON-1150: Reduce two buttons in regular giving stepper to 40% width

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -166,7 +166,6 @@
                 if this message persists.
               </p>
               <button
-                style="width: 40%"
                 type="button"
                 class="continue b-w-100 b-rt-0"
                 mat-raised-button
@@ -177,9 +176,8 @@
               </button>
             } @else {
               <button
-                style="width: 40%"
                 type="button"
-                class="continue b-w-100 b-rt-0"
+                class="continue"
                 mat-raised-button
                 color="primary"
                 (click)="progressToNonAmountsStep()"
@@ -309,7 +307,7 @@
           <div style="text-align: center">
             <button
               type="button"
-              class="continue b-w-100 b-rt-0"
+              class="continue"
               mat-raised-button
               color="primary"
               (click)="progressFromStepGiftAid()"
@@ -447,13 +445,7 @@
           </p>
         }
         <div style="text-align: center">
-          <button
-            type="button"
-            class="continue b-w-100 b-rt-0"
-            mat-raised-button
-            color="primary"
-            (click)="continueFromPaymentStep()"
-          >
+          <button type="button" class="continue" mat-raised-button color="primary" (click)="continueFromPaymentStep()">
             Continue
           </button>
         </div>
@@ -572,7 +564,7 @@
         <div style="text-align: center">
           <button
             type="button"
-            class="continue b-w-100 b-rt-0"
+            class="continue"
             mat-raised-button
             color="primary"
             (click)="progressFromStepReceiveUpdates()"
@@ -609,7 +601,7 @@
             <button
               style="width: 40%"
               type="button"
-              class="continue b-w-100 b-rt-0"
+              class="continue"
               mat-raised-button
               color="primary"
               (click)="retryFinalPreSubmitUpdate()"
@@ -678,7 +670,7 @@
             <button
               (click)="submit()"
               (keyup.enter)="submit()"
-              class="c-donate-button b-donate-button b-w-100 b-rt-1"
+              class="continue c-donate-button"
               mat-raised-button
               color="primary"
             >

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -150,10 +150,6 @@ input:disabled {
   }
 }
 
-.b-rt-0 {
-  @include abstract.b-rt-0;
-}
-
 .b-rt-1 {
   @include abstract.b-rt-1;
 }
@@ -309,18 +305,6 @@ div#giftAidAddressContainer > div {
   .mat-icon {
     height: 14px;
   }
-}
-
-button.continue,
-.c-donate-button {
-  margin-top: 22px !important;
-  margin-bottom: 22px !important;
-  padding: 1.5rem;
-  max-width: 300px;
-}
-
-.c-donate-button {
-  @include abstract.make-donate-button;
 }
 
 .c-donate-button-amount {

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -103,14 +103,7 @@
               </div>
 
               <div style="text-align: center">
-                <button
-                  style="width: 40%"
-                  type="button"
-                  class="continue b-w-100 b-rt-0"
-                  mat-raised-button
-                  color="primary"
-                  (click)="this.continue()"
-                >
+                <button type="button" class="continue" mat-raised-button color="primary" (click)="this.continue()">
                   Continue
                 </button>
               </div>
@@ -222,14 +215,7 @@
               <p></p>
 
               <div style="text-align: center">
-                <button
-                  style="width: 40%"
-                  type="button"
-                  class="continue b-w-100 b-rt-0"
-                  mat-raised-button
-                  color="primary"
-                  (click)="this.continue()"
-                >
+                <button type="button" class="continue" mat-raised-button color="primary" (click)="this.continue()">
                   Continue
                 </button>
               </div>
@@ -297,14 +283,7 @@
               </div>
 
               <div style="text-align: center">
-                <button
-                  style="width: 40%"
-                  type="button"
-                  class="continue b-w-100 b-rt-0"
-                  mat-raised-button
-                  color="primary"
-                  (click)="this.continue()"
-                >
+                <button type="button" class="continue" mat-raised-button color="primary" (click)="this.continue()">
                   Continue
                 </button>
               </div>
@@ -391,14 +370,7 @@
               <p></p>
 
               <div style="text-align: center">
-                <button
-                  style="width: 40%"
-                  type="button"
-                  class="continue b-w-100 b-rt-0"
-                  mat-raised-button
-                  color="primary"
-                  (click)="this.continue()"
-                >
+                <button type="button" class="continue" mat-raised-button color="primary" (click)="this.continue()">
                   Continue
                 </button>
               </div>
@@ -473,8 +445,7 @@
                   <button
                     (click)="submit()"
                     (keyup.enter)="submit()"
-                    style="width: 40%"
-                    class="c-donate-button b-donate-button b-w-100 b-rt-1"
+                    class="c-donate-button continue"
                     mat-raised-button
                     color="primary"
                   >

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -230,6 +230,7 @@
 
               <div style="text-align: center">
                 <button
+                  style="width: 40%"
                   type="button"
                   class="continue b-w-100 b-rt-0"
                   mat-raised-button
@@ -474,11 +475,12 @@
                 }
               </div>
 
-              <div aria-live="polite">
+              <div aria-live="polite" style="text-align: center">
                 @if (!submitting) {
                   <button
                     (click)="submit()"
                     (keyup.enter)="submit()"
+                    style="width: 40%"
                     class="c-donate-button b-donate-button b-w-100 b-rt-1"
                     mat-raised-button
                     color="primary"

--- a/src/assets/scss/donation-common.scss
+++ b/src/assets/scss/donation-common.scss
@@ -36,3 +36,21 @@ table.summary {
 .total {
   color: abstract.$colour-primary;
 }
+
+.b-rt-0 {
+  @include abstract.b-rt-0;
+}
+
+.c-donate-button {
+  @include abstract.make-donate-button;
+}
+
+button.continue,
+.c-donate-button {
+  width: 40%;
+  margin-top: 22px !important;
+  margin-bottom: 22px !important;
+  padding: 1.5rem;
+  max-width: 300px;
+  @extend .b-rt-0;
+}


### PR DESCRIPTION
We had a mix of full width and 40% width buttons - making them all 40% width.

There's potential to refactor to reduce the duplication but not necassarily right now.

![image](https://github.com/user-attachments/assets/bebb98d7-ebd7-4d03-a95b-3b6a96a0e67c)

![image](https://github.com/user-attachments/assets/0a1cdbd5-d7f6-4939-9348-f10c7e8e2423)
