### PR TITLE
DON-1134: Improve UI for making unmatched regular giving donation

### DIFF
--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -61,6 +61,18 @@
                   <input maxlength="10" formControlName="donationAmount" id="donationAmount" matInput slot="input" />
                 </biggive-text-input>
               </div>
+
+              @if (showUnmatchedDonationOption) {
+                <mat-checkbox formControlName="unmatched" id="unmatched">Make an unmatched donation</mat-checkbox>
+                <br />
+              }
+              <mat-checkbox formControlName="aged18OrOver" id="aged18OrOver"> I am aged 18 or older. </mat-checkbox>
+              @if (ageErrorMessage) {
+                <div class="error">
+                  {{ this.ageErrorMessage }}
+                </div>
+              }
+
               <p>This amount will be taken from your account today and once every month in future</p>
 
               <div aria-live="polite">
@@ -76,38 +88,23 @@
                     {{ this.amountErrorMessage }}
                   </div>
                 }
-                @if (maximumMatchableDonation.amountInPence === 0) {
+                <!--                insufficientMatchFundsAvailable: {{ insufficientMatchFundsAvailable }},-->
+                <!--                unmatched: {{ insufficientMatchFundsAvailable }},-->
+                <!--                newDonationAmountOverMaxMatchable: {{newDonationAmountOverMaxMatchable}}-->
+
+                @if (maximumMatchableDonation.amountInPence === 0 && !unmatched) {
                   <p>
                     There are no match funds currently available for this campaign. Remember, every penny helps. Please
                     continue to make an <strong>unmatched donation</strong> to the charity!
-                    @if (!matchFundsZeroOnLoad) {
-                      <mat-checkbox formControlName="unmatched" id="unmatched">
-                        Make an unmatched donation
-                      </mat-checkbox>
-                    }
                   </p>
-                } @else if (insufficientMatchFundsAvailable) {
+                } @else if (newDonationAmountOverMaxMatchable && !unmatched) {
                   <p>
                     <span class="error">There are limited match funds available</span>, but every penny helps, so you
-                    have two options:
+                    have two options: Reduce your donation amount to a maximum of
+                    {{ maximumMatchableDonation | money }}, or make an unmatched donation using the option above.
                   </p>
-                  <ol>
-                    <li>Reduce your donation amount to a maximum of {{ maximumMatchableDonation | money }}, or</li>
-                    <li>
-                      <mat-checkbox formControlName="unmatched" id="unmatched">
-                        Make an unmatched donation
-                      </mat-checkbox>
-                    </li>
-                  </ol>
                 }
               </div>
-
-              <mat-checkbox formControlName="aged18OrOver" id="aged18OrOver"> I am aged 18 or older. </mat-checkbox>
-              @if (ageErrorMessage) {
-                <div class="error">
-                  {{ this.ageErrorMessage }}
-                </div>
-              }
 
               <div style="text-align: center">
                 <button

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -88,10 +88,6 @@
                     {{ this.amountErrorMessage }}
                   </div>
                 }
-                <!--                insufficientMatchFundsAvailable: {{ insufficientMatchFundsAvailable }},-->
-                <!--                unmatched: {{ insufficientMatchFundsAvailable }},-->
-                <!--                newDonationAmountOverMaxMatchable: {{newDonationAmountOverMaxMatchable}}-->
-
                 @if (maximumMatchableDonation.amountInPence === 0 && !unmatched) {
                   <p>
                     There are no match funds currently available for this campaign. Remember, every penny helps. Please

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -262,6 +262,10 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     }
   }
 
+  protected get showUnmatchedDonationOption() {
+    return this.matchFundsZeroOnLoad || this.newDonationAmountOverMaxMatchable || this.unmatched;
+  }
+
   ngAfterViewInit() {
     // It seems the stepper doesn't provide a nice way to let us intercept each request to change step. Monkey-patching
     // the select function which is called when the user clicks a step heading, to let us check that all previous
@@ -277,6 +281,10 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
       },
       500, // delay to for the stepper to be initialised - otherwise its undefined and the callback can't run.
     );
+  }
+
+  protected get newDonationAmountOverMaxMatchable() {
+    return this.donationAmount.amountInPence > this.maximumMatchableDonation.amountInPence;
   }
 
   async interceptSubmitAndProceedInstead(event: Event) {


### PR DESCRIPTION
I think a checkbox inside a list doesn't really work well, so it makes more sense to make the two checkboxes (aged over 18 and making unmatched donation) sit together one after the other, and just use normal running copy to describe the error.

Also making the error appear and disappear reactively when the donation amount is reduced above or below the matchable maximum, and when unmatched option is clicked.