### PR TITLE
DON-1152: Increase time to show errors for devs

### DIFF
--- a/src/app/BrowserErrorHandler.ts
+++ b/src/app/BrowserErrorHandler.ts
@@ -12,7 +12,7 @@ export class BrowserErrorHandler implements ErrorHandler {
     if (['development', 'regression'].includes(environment.environmentId)) {
       // don't show toast in prod because it won't be useful to real users, don't show in staging until we've
       // reviewed how it looks and if there are too many errors in dev env
-      this.toast.showError(error.name + ': ' + error.message);
+      this.toast.showError(error.name + ': ' + error.message, { minDurationMs: 5_000, maxDurationMs: 15_000 });
     }
 
     if (environment.environmentId !== 'development') {

--- a/src/app/toast.service.ts
+++ b/src/app/toast.service.ts
@@ -12,7 +12,7 @@ export class Toast {
 
   public showSuccess(message: string) {
     this.snackBar.open(message, undefined, {
-      duration: this.getDuration(message),
+      duration: this.getDuration(message, 2_000, 7_000),
       panelClass: 'success-bar',
     });
   }
@@ -21,9 +21,11 @@ export class Toast {
    * Displays an error message on screen as a "toast" popping up near the bottom of the screen. Longer messages
    * will display for a longer time.
    */
-  public showError(message: string) {
+  public showError(message: string, { minDurationMs = 2_000, maxDurationMs = 7_000 } = {}) {
+    const duration = this.getDuration(message, minDurationMs, maxDurationMs);
+
     this.snackBar.open(message, undefined, {
-      duration: this.getDuration(message),
+      duration: duration,
       panelClass: 'error-bar',
     });
   }
@@ -31,7 +33,7 @@ export class Toast {
   /**
    * formula for duration from https://ux.stackexchange.com/a/85898/7211
    */
-  private getDuration(message: string): number {
-    return Math.min(Math.max(message.length * 50, 2_000), 7_000);
+  private getDuration(message: string, minDurationMs: number, maxDurationMs: number): number {
+    return Math.min(Math.max(message.length * 50, minDurationMs), maxDurationMs);
   }
 }


### PR DESCRIPTION
Since (hopefully) every error will be unexepcted, I think it's worth always displaying it for at least 5s, and up to 15 if its wordy.

We can still look in the console to see it again after.

Think we misinterpreted the code before and didn't realise it will by default only show for 2s if the message is short.