### PR TITLE
MAT-405: Clarify whether campaign page being viewed is an early / pri…

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -53,7 +53,7 @@
         html-element="h1"
         size="3"
         align="left"
-        [text]="campaign.title"
+        [text]="isEarlyPreview() ? 'PREVIEW: ' + campaign.title : campaign.title"
       >
       </biggive-heading>
 

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -1,5 +1,5 @@
 import { DatePipe, isPlatformBrowser, Location, AsyncPipe, CurrencyPipe } from '@angular/common';
-import { Component, OnDestroy, OnInit, PLATFORM_ID, ViewEncapsulation, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, PLATFORM_ID, ViewEncapsulation, inject, input, effect } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 
@@ -25,6 +25,7 @@ import { MatIcon } from '@angular/material/icon';
 import { CampaignInfoComponent } from '../campaign-info/campaign-info.component';
 import { MatTabGroup, MatTab } from '@angular/material/tabs';
 import { OptimisedImagePipe } from '../optimised-image.pipe';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   // https://stackoverflow.com/questions/45940965/angular-material-customize-tab
@@ -55,6 +56,7 @@ import { OptimisedImagePipe } from '../optimised-image.pipe';
   ],
 })
 export class CampaignDetailsComponent implements OnInit, OnDestroy {
+  isEarlyPreview = input(false);
   private datePipe = inject(DatePipe);
   private location = inject(Location);
   private navigationService = inject(NavigationService);
@@ -64,6 +66,7 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private sanitizer = inject(DomSanitizer);
   private toast = inject(Toast);
+  private snackBar = inject(MatSnackBar);
   timeLeftPipe = inject(TimeLeftPipe);
 
   campaign!: Campaign;
@@ -91,6 +94,23 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
         }
       })
       .catch(console.error);
+
+    effect(() => {
+      if (this.isEarlyPreview()) {
+        // would have ideally had a dismissable toast but that doesn't seem to be offered by snackbar - we have
+        // to call a function to dismiss it instead of just passing an option to make it user dismissable. I think
+        // non-dismissable is OK. It appears no the bottom of the screen so the user can still take a screenshot of the
+        // top of the page and crop it out if they want that.
+
+        this.snackBar.open(
+          'This is a privaate preview of your campaign page. Do not share this page with the public.',
+          undefined,
+          {
+            panelClass: 'success-bar',
+          },
+        );
+      }
+    });
   }
 
   ngOnDestroy() {
@@ -134,7 +154,11 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
       summaryStart = `${campaign.charity.name}'s campaign, ${campaign.title}`;
     }
 
-    this.pageMeta.setCommon(campaign.title, summaryStart, campaign.bannerUri);
+    if (this.isEarlyPreview()) {
+      this.pageMeta.setCommon('PREVIEW: ' + campaign.title, summaryStart, campaign.bannerUri, true);
+    } else {
+      this.pageMeta.setCommon(campaign.title, summaryStart, campaign.bannerUri);
+    }
 
     // As per https://angular.io/guide/security#bypass-security-apis constructing `SafeResourceUrl`s with these appends should be safe.
     if (campaign.video && campaign.video.provider === 'youtube') {

--- a/src/app/page-meta.service.ts
+++ b/src/app/page-meta.service.ts
@@ -18,7 +18,7 @@ export class PageMetaService {
   private router = inject(Router);
   private title = inject(Title);
 
-  setCommon(title: string, description: string = '', imageUri: string | null = null) {
+  setCommon(title: string, description: string = '', imageUri: string | null = null, noIndex = false) {
     const baseUri = environment.donateUriPrefix;
     const canonicalUri = `${baseUri}${this.router.url}`;
     const links = this.dom.getElementsByTagName('link');
@@ -45,6 +45,12 @@ export class PageMetaService {
       this.meta.updateTag({ property: 'twitter:card', content: 'summary_large_image' });
     } else {
       this.meta.updateTag({ property: 'twitter:card', content: 'summary' });
+    }
+
+    if (noIndex) {
+      this.meta.updateTag({ property: 'robots', content: 'noindex' });
+    } else {
+      this.meta.removeTag('robots');
     }
   }
 }


### PR DESCRIPTION
…vate preview

Previews are intended for charity use only, not for public viewing, but there are currently no technical limits to stop the public seeing them.

So for now on a public preview we use a snackbar message, 'PREVIEW' in the html title and in the heading on the page, and noIndex for robots to discourage sharing with the public.

We could also add a link to the public page (same URL bout without '-preview', but that will only work when the campaign is ready. Not sure if it's better to do that here or in the charity portal.

Also trying out using signals and route data input binding a bit more.