### PR TITLE
DON-1120: Limit new banner image width to 2,000px

### DIFF
--- a/src/app/explore/meta-campaign-banner/meta-campaign-banner.component.scss
+++ b/src/app/explore/meta-campaign-banner/meta-campaign-banner.component.scss
@@ -7,9 +7,11 @@ div.banner {
   img.background {
     object-fit: cover;
     position: absolute;
-    // todo - limit the width to 2,000px and while keeping centred.
+    max-width: 2000px;
     width: 100%;
     height: 100%;
+    left: 50%;
+    transform: translateX(-50%);
   }
 }
 


### PR DESCRIPTION
Letting the image grow much beyond 2,000px wide is a problem on big screens because then it becomes to tall and the bottom gets cropped off as the height is fixed at 600px