### PR TITLE
DON-1120: Fix metacampaign info box postion

### DIFF
--- a/src/app/explore/meta-campaign-banner/meta-campaign-banner.component.scss
+++ b/src/app/explore/meta-campaign-banner/meta-campaign-banner.component.scss
@@ -27,7 +27,7 @@ div.banner {
 div.sleeve {
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: center;
   justify-content: flex-start;
   max-width: 1200px;
   margin-left: auto;
@@ -43,7 +43,8 @@ div.sleeve {
   @media (min-width: #{abstract.$smallish + 30px}) {
     // adding 30px to standard breakpoint to match padding.
     padding-left: 20px;
-    align-items: center;
+
+    align-items: start;
     height: 600px;
   }
 }


### PR DESCRIPTION
Should be centered on small screens, to the left on wide screens, not the other way around.