### PR TITLE
Bg2 2900 increase font size

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,9 @@ body {
   // Asking the menu component to adjust the document body padding was flaky in some edge
   // cases, so declaratively do it here. These numbers need to stay in sync with the biggive-main-menu desktop & mobile heights.
   padding-top: 130px;
+  font-size: 17px;
+  line-height: 24px;
+  font-family: "Euclid Triangle", sans-serif;
   @media (max-width: 968px) {
     // must match components $screen-large
     padding-top: 60px;


### PR DESCRIPTION
Before:

<img width="1208" height="358" alt="image" src="https://github.com/user-attachments/assets/734cbe0e-7b7a-4be5-9f90-fb47cceae0ad" />


After:

<img width="1208" height="358" alt="image" src="https://github.com/user-attachments/assets/1e7cd2e4-ad06-4bed-bb32-e6313cf1fbf5" />

Production WP for reference at same zoom level:

<img width="1208" height="358" alt="image" src="https://github.com/user-attachments/assets/7d72a699-bfa6-4dea-b275-c3fd6eb09bb2" />

