### PR TITLE
BG2-2926: Support line breaks in campaign summaries on campaign detai…

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -58,7 +58,9 @@
       </biggive-heading>
 
       <biggive-formatted-text default-text-colour="black">
-        <p>{{ campaign.summary }}</p>
+        <!-- we use pre-wrap to allow charities to create the effect of multiple paragraphs by using line-breaks
+             inside their campaign summaries -->
+        <p style="white-space: pre-wrap">{{ formattedCampaignSummary }}</p>
       </biggive-formatted-text>
 
       @if (campaign.charity.website) {

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -175,4 +175,16 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
       this.toast.showError(campaignHiddenMessage);
     }
   }
+
+  /**
+   * Collapses sequences of line breaks in the campaign summary then returns a version of the summary with
+   * each line break doubled to appear like a paragraph break.
+   */
+  public get formattedCampaignSummary(): string {
+    if (!this.campaign.summary) {
+      return '';
+    }
+
+    return this.campaign.summary.replace(/\n{2,}/g, '\n').replace(/\n/g, '\n\n');
+  }
 }


### PR DESCRIPTION
…l page

We assume any sequence of 1 or more line breaks was intended as a paragraph break.

Implemented fully in frontend rather than matchbot to avoid having anothering thing waiting for MAT-405 before it can work.

<img width="800" height="523" alt="image" src="https://github.com/user-attachments/assets/05f98516-c383-4005-bc09-6f32784a6c37" />
