### PR TITLE
MAT-405: Load campaign list for charity page from matchbot in prod

### DIFF
--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -59,7 +59,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         regularGivingEnabled: true,
         useMatchbotCampaignApi: true,
         useMatchbotCampaignSearchApi: true,
-        useMatchbotCharityApi: false,
+        useMatchbotCharityApi: true,
         useMatchbotMetaCampaignApi: true,
       };
   }


### PR DESCRIPTION
Another part of MAT-405, hadn't realised until now that this wasn't switched over in prod. Can wait till tomorrow to merge.