### PR TITLE
DON-1107: Adjust campaign detail info display for shared funds (i.e. …

### DIFF
--- a/src/app/campaign-info/campaign-info.component.html
+++ b/src/app/campaign-info/campaign-info.component.html
@@ -1,10 +1,12 @@
 <div>
   <biggive-campaign-highlights
     space-below="0"
-    [primaryFigureLabel]="this.campaign.parentUsesSharedFunds ? 'Overall total raised' : 'Amount raised'"
+    [primaryFigureLabel]="'Amount raised'"
     [primaryFigureAmount]="campaignRaised"
-    [secondaryFigureLabel]="this.campaign.parentUsesSharedFunds ? 'Overall target' : 'Campaign target'"
-    [secondaryFigureAmount]="campaignTarget"
+    [secondaryFigureLabel]="this.campaign.parentUsesSharedFunds ? 'Total Match Funds Available' : 'Campaign target'"
+    [secondaryFigureAmount]="
+      this.campaign.parentUsesSharedFunds ? this.campaign.parentMatchFundsRemaining : campaignTarget
+    "
     [progressBarCounter]="getPercentageRaised(campaign)?.toFixed(0)"
     primary-stat-icon="AlarmClock"
     [primaryStatText]="

--- a/src/app/campaign-info/campaign-info.component.ts
+++ b/src/app/campaign-info/campaign-info.component.ts
@@ -70,7 +70,7 @@ export class CampaignInfoComponent implements OnInit {
   }
 
   getPercentageRaised(campaign: Campaign): number | undefined {
-    return CampaignService.percentRaisedOfCampaignOrParent(campaign);
+    return CampaignService.percentRaisedOfCampaign(campaign);
   }
 
   getBeneficiaryIcon(beneficiary: string) {

--- a/src/app/campaign-summary.model.ts
+++ b/src/app/campaign-summary.model.ts
@@ -3,6 +3,8 @@ export type CampaignSummary = {
   isRegularGiving: boolean;
   id: string;
   amountRaised: number;
+  parentRef: string | null;
+  parentUsesSharedFunds: boolean;
   beneficiaries: string[];
   categories: string[];
   championName: string;

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -163,7 +163,7 @@ describe('CampaignService', () => {
     expect(CampaignService.percentRaisedOfCampaign(campaign)).toBe(49);
   });
 
-  it('should return undefined its parent does use shared funds', () => {
+  it('should return undefined when its parent does use shared funds', () => {
     const campaign = getDummyCampaign();
     campaign.parentUsesSharedFunds = true;
     if (!campaign.parentUsesSharedFunds) {

--- a/src/app/campaign.service.spec.ts
+++ b/src/app/campaign.service.spec.ts
@@ -160,10 +160,10 @@ describe('CampaignService', () => {
     campaign.amountRaised = 98;
     campaign.target = 200;
 
-    expect(CampaignService.percentRaisedOfCampaignOrParent(campaign)).toBe(49);
+    expect(CampaignService.percentRaisedOfCampaign(campaign)).toBe(49);
   });
 
-  it('should return the % raised for the parent campaign when its parent does use shared funds', () => {
+  it('should return undefined its parent does use shared funds', () => {
     const campaign = getDummyCampaign();
     campaign.parentUsesSharedFunds = true;
     if (!campaign.parentUsesSharedFunds) {
@@ -174,6 +174,6 @@ describe('CampaignService', () => {
     campaign.target = 200;
     campaign.parentTarget = 2000;
 
-    expect(CampaignService.percentRaisedOfCampaignOrParent(campaign)).toBe(50);
+    expect(CampaignService.percentRaisedOfCampaign(campaign)).toBe(undefined);
   });
 });

--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -96,9 +96,10 @@ export class CampaignService {
   /**
    * Gets % of the parent target if `parentUsesSharedFunds`, or the individual target otherwise.
    */
-  static percentRaisedOfCampaignOrParent(campaign: Campaign): number | undefined {
+  static percentRaisedOfCampaign(campaign: Campaign): number | undefined {
     if (campaign.parentUsesSharedFunds && campaign.parentTarget && campaign.parentAmountRaised) {
-      return Math.round((campaign.parentAmountRaised / campaign.parentTarget) * 100);
+      // percent raised is not meaningful when the campaign shares funds with others.
+      return undefined;
     }
 
     return CampaignService.percentRaisedOfIndividualCampaign(campaign);

--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -114,21 +114,19 @@
                 [donateButtonLabel]="campaign.isRegularGiving ? 'Donate monthly' : 'Donate now'"
                 [moreInfoButtonUrl]="'/campaign/' + campaign.id"
                 [organisationName]="campaign.charity.name"
-                [primaryFigureLabel]="campaign.isRegularGiving ? '' : 'Match Funds Remaining'"
+                [primaryFigureLabel]="
+                  campaign.isRegularGiving || campaign.parentUsesSharedFunds ? '' : 'Match Funds Remaining'
+                "
                 [primaryFigureAmount]="
-                  this.metaCampaign?.usesSharedFunds || campaign.isRegularGiving
-                    ? campaign.isRegularGiving
-                      ? ' '
-                      : null
+                  this.metaCampaign?.usesSharedFunds || campaign.isRegularGiving || campaign.parentUsesSharedFunds
+                    ? ' '
                     : (campaign.matchFundsRemaining
                       | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)
                 "
                 [progressBarCounter]="campaign.isRegularGiving ? null : getPercentageRaised(campaign)"
-                secondary-figure-label="Total Funds Raised"
+                secondary-figure-label="Amount Raised"
                 [secondaryFigureAmount]="
-                  this.metaCampaign?.usesSharedFunds
-                    ? null
-                    : (campaign.amountRaised | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo)
+                  campaign.amountRaised | currency: campaign.currencyCode : 'symbol' : currencyPipeDigitsInfo
                 "
                 [isFutureCampaign]="isInFuture(campaign)"
                 [isPastCampaign]="isInPast(campaign)"

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -382,7 +382,9 @@ export class ExploreComponent implements AfterViewChecked, OnDestroy, OnInit {
   }
 
   getPercentageRaised(childCampaign: CampaignSummary) {
-    if (this.metaCampaign?.usesSharedFunds) {
+    // second part of || condition below can be deleted when new matchbot is deployed to ensure we always have
+    // childCampaign.parentUsesSharedFunds set when appropriate.
+    if (childCampaign.parentUsesSharedFunds || this.metaCampaign?.usesSharedFunds) {
       // No progressbar on child cards when parent is e.g. a shared fund emergency appeal.
       return null;
     }


### PR DESCRIPTION
…emergency & regular-giving)

- Show "Amount raised" for this charity campaign instead of the overall total for the parent.
- Don't show any progress bar
- Show "Total Match Funds Available" using the parent match funds available figure, instead of the overall target

<img width="1466" height="768" alt="image" src="https://github.com/user-attachments/assets/4e19838b-d540-472a-a98f-0b972e6ddd52" />
