### PR TITLE
MAT-429 – allow resuming donation that was previously Pay By Bank

### DIFF
--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -75,7 +75,7 @@ export class DonationService {
     return (
       donation.status !== undefined &&
       (resumableStatuses as readonly DonationStatus[]).includes(donation.status) &&
-      donation.pspMethodType === paymentMethodType
+      this.isPaymentElementMethod(donation.pspMethodType) === this.isPaymentElementMethod(paymentMethodType)
     );
   }
 
@@ -468,5 +468,9 @@ export class DonationService {
         this.getAuthHttpOptions(donation),
       ),
     );
+  }
+
+  private isPaymentElementMethod(pspMethodType: string): boolean {
+    return ['card', 'pay_by_bank'].includes(pspMethodType);
   }
 }


### PR DESCRIPTION
By treating any Payment Element method as interchangeable for this purpose, knowing that a new page load will start with the method as `card` until it's told to use another method.