### PR TITLE
MAT-429: Expand static types to better reflect dynamic reality + allow resuming wallet paymeent donations

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -908,7 +908,10 @@ export class DonationStartFormComponent
    * and the donor is using donation funds.
    */
   async onStripeCardChange(
-    state: StripeElementChangeEvent & { complete: boolean; value?: { type: string; payment_method?: PaymentMethod } },
+    state: StripeElementChangeEvent & {
+      complete: boolean;
+      value?: { type: PaymentMethodType; payment_method?: PaymentMethod };
+    },
   ) {
     // Ensure we don't turn on card-specific validators if donation funds are to be used instead, otherwise we can
     // end up validating presence of invisible fields.

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -961,9 +961,24 @@ export class DonationStartFormComponent
     }
 
     if (state.value?.type) {
-      const newType = ['card', 'apple_pay', 'google_pay'].includes(state.value?.type) ? 'card' : state.value?.type;
+      const elementEventType = state.value?.type;
+      let newType: PaymentMethodType;
+
+      switch (state.value?.type) {
+        case 'card':
+        case 'apple_pay':
+        case 'google_pay':
+          newType = 'card';
+          break;
+        case 'pay_by_bank':
+          newType = 'pay_by_bank';
+          break;
+        case 'customer_balance':
+          newType = 'customer_balance';
+      }
+
       console.log('payment method from event', selectedSavedPaymentMethod);
-      console.log('original type (phasing out)', state.value?.type);
+      console.log('original type (phasing out)', elementEventType);
       this.selectedPaymentMethodType = newType;
       if (newType !== this.donation.pspMethodType) {
         this.donation.pspMethodType = newType;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -910,7 +910,7 @@ export class DonationStartFormComponent
   async onStripeCardChange(
     state: StripeElementChangeEvent & {
       complete: boolean;
-      value?: { type: PaymentMethodType; payment_method?: PaymentMethod };
+      value?: { type: PaymentMethodType | 'apple_pay' | 'google_pay'; payment_method?: PaymentMethod };
     },
   ) {
     // Ensure we don't turn on card-specific validators if donation funds are to be used instead, otherwise we can
@@ -961,7 +961,9 @@ export class DonationStartFormComponent
     }
 
     if (state.value?.type) {
-      const newType = state.value?.type;
+      const newType = ['card', 'apple_pay', 'google_pay'].includes(state.value?.type) ? 'card' : state.value?.type;
+          console.log('payment method from event', selectedSavedPaymentMethod);
+    console.log('original type (phasing out)', state.value?.type);
       this.selectedPaymentMethodType = newType;
       if (newType !== this.donation.pspMethodType) {
         this.donation.pspMethodType = newType;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -962,8 +962,8 @@ export class DonationStartFormComponent
 
     if (state.value?.type) {
       const newType = ['card', 'apple_pay', 'google_pay'].includes(state.value?.type) ? 'card' : state.value?.type;
-          console.log('payment method from event', selectedSavedPaymentMethod);
-    console.log('original type (phasing out)', state.value?.type);
+      console.log('payment method from event', selectedSavedPaymentMethod);
+      console.log('original type (phasing out)', state.value?.type);
       this.selectedPaymentMethodType = newType;
       if (newType !== this.donation.pspMethodType) {
         this.donation.pspMethodType = newType;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -273,7 +273,14 @@ export class DonationStartFormComponent
 
   private stripeElements: StripeElements | undefined;
   /** A method from the Payment Element, if one's been chosen **/
-  private selectedPaymentMethodType: 'card' | 'customer_balance' | 'pay_by_bank' | null = null;
+  private selectedPaymentMethodType:
+    | 'card'
+    | 'customer_balance'
+    | 'pay_by_bank'
+    | 'apple_pay'
+    | 'google_play'
+    | (string & {})
+    | null = null;
   private paymentReadinessTracker!: PaymentReadinessTracker;
   public paymentStepErrors: string = '';
   private donationRetryTimeout: number | undefined = undefined;
@@ -958,10 +965,7 @@ export class DonationStartFormComponent
     }
 
     if (state.value?.type) {
-      const newType: 'card' | 'customer_balance' | 'pay_by_bank' = state.value?.type as
-        | 'card'
-        | 'customer_balance'
-        | 'pay_by_bank';
+      const newType = state.value?.type;
       this.selectedPaymentMethodType = newType;
       if (newType !== this.donation.pspMethodType) {
         this.donation.pspMethodType = newType;
@@ -2466,7 +2470,13 @@ export class DonationStartFormComponent
     }
   }
 
-  private getPaymentMethodType(): 'customer_balance' | 'card' | 'pay_by_bank' {
+  private getPaymentMethodType():
+    | 'customer_balance'
+    | 'card'
+    | 'pay_by_bank'
+    | 'apple_pay'
+    | 'google_pay'
+    | (string & {}) {
     return this.creditPenceToUse > 0 ? 'customer_balance' : (this.selectedPaymentMethodType ?? 'card');
   }
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -273,14 +273,7 @@ export class DonationStartFormComponent
 
   private stripeElements: StripeElements | undefined;
   /** A method from the Payment Element, if one's been chosen **/
-  private selectedPaymentMethodType:
-    | 'card'
-    | 'customer_balance'
-    | 'pay_by_bank'
-    | 'apple_pay'
-    | 'google_play'
-    | (string & {})
-    | null = null;
+  private selectedPaymentMethodType: PaymentMethodType | null = null;
   private paymentReadinessTracker!: PaymentReadinessTracker;
   public paymentStepErrors: string = '';
   private donationRetryTimeout: number | undefined = undefined;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -42,7 +42,7 @@ import { Campaign } from '../../campaign.model';
 import { CardIconsService } from '../../card-icons.service';
 import { campaignHiddenMessage } from '../../../environments/common';
 import { countryOptions } from '../../countries';
-import { Donation, maximumDonationAmount, OVERSEAS } from '../../donation.model';
+import { Donation, maximumDonationAmount, OVERSEAS, PaymentMethodType } from '../../donation.model';
 import { DonationCreatedResponse } from '../../donation-created-response.model';
 import { DonationService } from '../../donation.service';
 import { DonationStartMatchConfirmDialogComponent } from '../donation-start-match-confirm-dialog.component';
@@ -2470,13 +2470,7 @@ export class DonationStartFormComponent
     }
   }
 
-  private getPaymentMethodType():
-    | 'customer_balance'
-    | 'card'
-    | 'pay_by_bank'
-    | 'apple_pay'
-    | 'google_pay'
-    | (string & {}) {
+  private getPaymentMethodType(): PaymentMethodType {
     return this.creditPenceToUse > 0 ? 'customer_balance' : (this.selectedPaymentMethodType ?? 'card');
   }
 

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -25,10 +25,7 @@ export const maximumDonationAmountForFundedDonation = 200_000;
 export type PaymentMethodType =
   | 'card'
   | 'customer_balance'
-  | 'pay_by_bank'
-  | 'apple_pay'
-  | 'google_pay'
-  | (string & {});
+  | 'pay_by_bank';
 
 /**
  * Placeholder for postcode and country code used when a donor from outside the UK claims gift aid

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -16,12 +16,6 @@ export function maximumDonationAmount(currencyCode: string, creditPenceToUse: nu
 export const maximumDonationAmountForCardDonation = 25_000;
 export const maximumDonationAmountForFundedDonation = 200_000;
 
-/**
- * payment method type identifier as returned from Stripe. We include `string & {}` in the union instead of than `never`
- * to account for possible other methods stripe could be configured to use in future, and rather than simply `string`
- * to prevent Tyepscript from simplifying the entire union down to string so that we can still see the likely options
- * when we use this type.
- */
 export type PaymentMethodType = 'card' | 'customer_balance' | 'pay_by_bank';
 
 /**

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -78,7 +78,7 @@ export interface Donation {
 
   optInChampionEmail?: boolean;
 
-  pspMethodType: 'card' | 'customer_balance' | 'pay_by_bank';
+  pspMethodType: 'card' | 'customer_balance' | 'pay_by_bank' | 'apple_pay' | 'google_pay' | (string & {});
 
   /**
    * Unique ID for a CCampaign / project assigned by Big Give, in Salesforce

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -22,10 +22,7 @@ export const maximumDonationAmountForFundedDonation = 200_000;
  * to prevent Tyepscript from simplifying the entire union down to string so that we can still see the likely options
  * when we use this type.
  */
-export type PaymentMethodType =
-  | 'card'
-  | 'customer_balance'
-  | 'pay_by_bank';
+export type PaymentMethodType = 'card' | 'customer_balance' | 'pay_by_bank';
 
 /**
  * Placeholder for postcode and country code used when a donor from outside the UK claims gift aid

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -17,6 +17,20 @@ export const maximumDonationAmountForCardDonation = 25_000;
 export const maximumDonationAmountForFundedDonation = 200_000;
 
 /**
+ * payment method type identifier as returned from Stripe. We include `string & {}` in the union instead of than `never`
+ * to account for possible other methods stripe could be configured to use in future, and rather than simply `string`
+ * to prevent Tyepscript from simplifying the entire union down to string so that we can still see the likely options
+ * when we use this type.
+ */
+export type PaymentMethodType =
+  | 'card'
+  | 'customer_balance'
+  | 'pay_by_bank'
+  | 'apple_pay'
+  | 'google_pay'
+  | (string & {});
+
+/**
  * Placeholder for postcode and country code used when a donor from outside the UK claims gift aid
  * See also \MatchBot\Domain\Donation::OVERSEAS
  * */
@@ -78,7 +92,7 @@ export interface Donation {
 
   optInChampionEmail?: boolean;
 
-  pspMethodType: 'card' | 'customer_balance' | 'pay_by_bank' | 'apple_pay' | 'google_pay' | (string & {});
+  pspMethodType: PaymentMethodType;
 
   /**
    * Unique ID for a CCampaign / project assigned by Big Give, in Salesforce

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -474,8 +474,6 @@ export class DonationService {
     switch (pspMethodType) {
       case 'card':
       case 'pay_by_bank':
-      case 'apple_pay':
-      case 'google_pay':
         return true;
 
       case 'customer_balance':

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -6,7 +6,7 @@ import { firstValueFrom, Observable, of } from 'rxjs';
 import { ConfirmationToken, PaymentIntent, PaymentMethod, SetupIntent } from '@stripe/stripe-js';
 
 import { COUNTRY_CODE } from './country-code.token';
-import { CompleteDonation, Donation } from './donation.model';
+import { CompleteDonation, Donation, PaymentMethodType } from './donation.model';
 import { DonationCreatedResponse } from './donation-created-response.model';
 import { environment } from '../environments/environment';
 import { Person } from './person.model';
@@ -71,10 +71,7 @@ export class DonationService {
     return couplet.donation;
   }
 
-  isResumable(
-    donation: Donation,
-    paymentMethodType: 'card' | 'customer_balance' | 'pay_by_bank' | 'apple_pay' | 'google_pay' | (string & {}),
-  ): boolean {
+  isResumable(donation: Donation, paymentMethodType: PaymentMethodType): boolean {
     return (
       donation.status !== undefined &&
       (resumableStatuses as readonly DonationStatus[]).includes(donation.status) &&
@@ -90,7 +87,7 @@ export class DonationService {
    */
   getProbablyResumableDonation(
     projectId: string,
-    paymentMethodType: 'card' | 'customer_balance' | 'pay_by_bank',
+    paymentMethodType: PaymentMethodType,
   ): Observable<Donation | undefined> {
     this.removeOldLocalDonations();
 

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -71,7 +71,10 @@ export class DonationService {
     return couplet.donation;
   }
 
-  isResumable(donation: Donation, paymentMethodType: 'card' | 'customer_balance' | 'pay_by_bank'): boolean {
+  isResumable(
+    donation: Donation,
+    paymentMethodType: 'card' | 'customer_balance' | 'pay_by_bank' | 'apple_pay' | 'google_pay' | (string & {}),
+  ): boolean {
     return (
       donation.status !== undefined &&
       (resumableStatuses as readonly DonationStatus[]).includes(donation.status) &&

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -470,7 +470,19 @@ export class DonationService {
     );
   }
 
-  private isPaymentElementMethod(pspMethodType: string): boolean {
-    return ['card', 'pay_by_bank'].includes(pspMethodType);
+  private isPaymentElementMethod(pspMethodType: PaymentMethodType): boolean {
+    switch (pspMethodType) {
+      case 'card':
+      case 'pay_by_bank':
+      case 'apple_pay':
+      case 'google_pay':
+        return true;
+
+      case 'customer_balance':
+        return false;
+
+      default:
+        throw new Error('Unexpected payment method type: ' + pspMethodType);
+    }
   }
 }

--- a/src/app/my-donations/my-donations.component.ts
+++ b/src/app/my-donations/my-donations.component.ts
@@ -51,21 +51,10 @@ export class MyDonationsComponent implements OnInit {
     switch (donation.pspMethodType) {
       case 'card':
         return 'Card payment';
-      // in practice Apple Pay and Google Pay currently get saved as 'card' by matchbot so would end up being displayed
-      // here as card. But in case matchbot does start distinguishing them in future we may as well display them with their proper names:
-      case 'apple_pay':
-        return 'Apple Pay';
-      case 'google_pay':
-        return 'Google Pay';
       case 'customer_balance':
         return 'Donation Funds payment';
       case 'pay_by_bank':
         return 'Pay By Bank';
-      default:
-        console.error(
-          `Unexpected payment method type to display for donation: ${donation.donationId}: ${donation.pspMethodType}`,
-        );
-        return donation.pspMethodType;
     }
   }
 

--- a/src/app/my-donations/my-donations.component.ts
+++ b/src/app/my-donations/my-donations.component.ts
@@ -51,10 +51,21 @@ export class MyDonationsComponent implements OnInit {
     switch (donation.pspMethodType) {
       case 'card':
         return 'Card payment';
+      // in practice Apple Pay and Google Pay currently get saved as 'card' by matchbot so would end up being displayed
+      // here as card. But in case matchbot does start distinguishing them in future we may as well display them with their proper names:
+      case 'apple_pay':
+        return 'Apple Pay';
+      case 'google_pay':
+        return 'Google Pay';
       case 'customer_balance':
         return 'Donation Funds payment';
       case 'pay_by_bank':
         return 'Pay By Bank';
+      default:
+        console.error(
+          `Unexpected payment method type to display for donation: ${donation.donationId}: ${donation.pspMethodType}`,
+        );
+        return donation.pspMethodType;
     }
   }
 


### PR DESCRIPTION
Adding apple pay and also google pay and also (string & {}) in case there's anything else we missed. `(string & {})` is effectively the same as string but adding the {} part of it prevents typescript from simplifying the union, so we can see tha tthe type is any of various known methods, plus any other possible method according to stripe config.