### PR TITLE
DON-984: Don't serve sitemap outside prod

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -106,7 +106,8 @@ app.get('/robots.txt', (_req: Request, res: Response) => {
   if (environment.production) {
     res.send('User-agent: *\nAllow: /\n\n' + sitemapLine);
   } else {
-    res.send('User-agent: *\nDisallow: /\n\n' + sitemapLine);
+    // no need for sitemap outside prod.
+    res.send('User-agent: *\nDisallow: /\n');
   }
 });
 


### PR DESCRIPTION
I'd like to see the sitemap link from robots.txt working once in staging, then will merge this.