### PR TITLE
DON-1142: Show browser not cmpatible message on any browser that does…

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -24,10 +24,6 @@
     <div style="display: none; margin-left: 1em; margin-right: 1em" id="unsupported-message">
       <h1 style="text-align: center">Big Give</h1>
       <p>
-        <a href="https://biggive.org/our-story/">Our Story</a>
-      </p>
-      <hr />
-      <p>
         Sorry, our donations site is not compatible with your web browser or device.
         <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
       </p>


### PR DESCRIPTION
… not supprot the optional chaining ES2020 feature

Also expand the browser not compatible page to show our Big Give name, basic details and link to our story, as well as the link to browsehappy.

<img width="494" height="985" alt="image" src="https://github.com/user-attachments/assets/2554ec3b-8006-4410-b865-fba910a43ca7" />
