### PR TITLE
DON-1142: Fix browser detection in index file for all environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ ARG BUILD_ENV
 
 RUN npm run supportedBrowsers
 
-RUN sed -i "s/GIT_COMMIT_ID/$(git rev-parse --short HEAD)/" src/index.html
-
 # Build client bundle and prepare for Server-Side Rendering
 RUN npm run build:${BUILD_ENV}
+
+RUN sed -i "s/GIT_COMMIT_ID/$(git rev-parse --short HEAD)/" src/index.html
 
 EXPOSE 4000
 

--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,6 @@
     </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      console.log("browserSupportsOptionalChaining:", window.browserSupportsOptionalChaining);
       if (ie || !window.browserSupportsOptionalChaining) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";

--- a/src/index.production.html
+++ b/src/index.production.html
@@ -14,18 +14,34 @@
     <link rel="icon" type="image/png" href="/assets/images/favicon.png" />
     <script src="/assets/custom-libs/modernizr.js"></script>
     <!-- Just webp support detection -->
+    <script>
+      let a = {};
+      a?.a?.a;
+      // One of the feature introduced in ES2020 that we rely on - the site will not be usable without it.
+      var browserSupportsOptionalChaining = true;
+    </script>
   </head>
   <body>
     <app-root id="app"></app-root>
-    <p style="display: none" id="unsupported-message">
-      <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
-    </p>
+    <div style="display: none; margin-left: 1em; margin-right: 1em" id="unsupported-message">
+      <h1 style="text-align: center">Big Give</h1>
+      <p>
+        Sorry, our donations site is not compatible with your web browser or device.
+        <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
+      </p>
+      <hr />
+      <div class="footer">
+        © 2007 – 2025 The Big Give Trust (1136547) | Company number 07273065 | Dragon Court, 27-29 Macklin Street,
+        London WC2B 5LX, United Kingdom
+      </div>
+    </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie) {
+      if (ie || !window.browserSupportsOptionalChaining) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }
     </script>
   </body>
+  <!-- donate-fronted commit ID GIT_COMMIT_ID -->
 </html>

--- a/src/index.regression.html
+++ b/src/index.regression.html
@@ -13,18 +13,34 @@
     <link rel="icon" type="image/png" href="/assets/images/favicon.png" />
     <script src="/assets/custom-libs/modernizr.js"></script>
     <!-- Just webp support detection -->
+    <script>
+      let a = {};
+      a?.a?.a;
+      // One of the feature introduced in ES2020 that we rely on - the site will not be usable without it.
+      var browserSupportsOptionalChaining = true;
+    </script>
   </head>
   <body>
     <app-root id="app"></app-root>
-    <p style="display: none" id="unsupported-message">
-      <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
-    </p>
+    <div style="display: none; margin-left: 1em; margin-right: 1em" id="unsupported-message">
+      <h1 style="text-align: center">Big Give</h1>
+      <p>
+        Sorry, our donations site is not compatible with your web browser or device.
+        <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
+      </p>
+      <hr />
+      <div class="footer">
+        © 2007 – 2025 The Big Give Trust (1136547) | Company number 07273065 | Dragon Court, 27-29 Macklin Street,
+        London WC2B 5LX, United Kingdom
+      </div>
+    </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie) {
+      if (ie || !window.browserSupportsOptionalChaining) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }
     </script>
   </body>
+  <!-- donate-fronted commit ID GIT_COMMIT_ID -->
 </html>

--- a/src/index.staging.html
+++ b/src/index.staging.html
@@ -14,18 +14,34 @@
     <link rel="icon" type="image/png" href="/assets/images/favicon.png" />
     <script src="/assets/custom-libs/modernizr.js"></script>
     <!-- Just webp support detection -->
+    <script>
+      let a = {};
+      a?.a?.a;
+      // One of the feature introduced in ES2020 that we rely on - the site will not be usable without it.
+      var browserSupportsOptionalChaining = true;
+    </script>
   </head>
   <body>
     <app-root id="app"></app-root>
-    <p style="display: none" id="unsupported-message">
-      <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
-    </p>
+    <div style="display: none; margin-left: 1em; margin-right: 1em" id="unsupported-message">
+      <h1 style="text-align: center">Big Give</h1>
+      <p>
+        Sorry, our donations site is not compatible with your web browser or device.
+        <a href="https://browsehappy.com/">Please upgrade your browser to continue.</a>
+      </p>
+      <hr />
+      <div class="footer">
+        © 2007 – 2025 The Big Give Trust (1136547) | Company number 07273065 | Dragon Court, 27-29 Macklin Street,
+        London WC2B 5LX, United Kingdom
+      </div>
+    </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie) {
+      if (ie || !window.browserSupportsOptionalChaining) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }
     </script>
   </body>
+  <!-- donate-fronted commit ID GIT_COMMIT_ID -->
 </html>


### PR DESCRIPTION
For now keeping the four files and copying new content into each one. It might be worth reducing it down to four files and just running a script to do specific replacements within the file for the parts that differ per environment.

Also kept the script to write the git commit ID into each file for now so I can see when it deploys. Can remove after I've seen it working but I think it might be worthwhile to have it to see easily what commit is deployed to each env, although it doesn't need to be in index.html necessarily - maybe worth making another file just for that so we could go e.g. donate.biggive.org/colophon and and that could be a page giving details including the git commit ID and timestamp.