### PR TITLE
DON-1142: Allow skipping outside-angular browser-compat-check

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,7 @@
     </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie || !window.browserSupportsOptionalChaining) {
+      if (ie || !window.browserSupportsOptionalChaining && ! window.location.search.includes('no-compat-check') ) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }

--- a/src/index.production.html
+++ b/src/index.production.html
@@ -37,7 +37,7 @@
     </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie || !window.browserSupportsOptionalChaining) {
+      if (ie || !window.browserSupportsOptionalChaining && ! window.location.search.includes('no-compat-check') ) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }

--- a/src/index.regression.html
+++ b/src/index.regression.html
@@ -36,7 +36,7 @@
     </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie || !window.browserSupportsOptionalChaining) {
+      if (ie || !window.browserSupportsOptionalChaining && ! window.location.search.includes('no-compat-check') ) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }

--- a/src/index.staging.html
+++ b/src/index.staging.html
@@ -37,7 +37,7 @@
     </div>
     <script>
       var ie = window.navigator.userAgent.indexOf("Trident/") > 0;
-      if (ie || !window.browserSupportsOptionalChaining) {
+      if (ie || !window.browserSupportsOptionalChaining && ! window.location.search.includes('no-compat-check') ) {
         document.getElementById("app").style.display = "none";
         document.getElementById("unsupported-message").style.display = "block";
       }


### PR DESCRIPTION
Sharing this as a draft PR since I found it uncommitted, but not realising its probably not needed since we can use remote chrome inspector to override this check anyway to see whether its blocking access to the site from devices that could actually make use of it.