### PR TITLE
DON-1152: Fix ES5 build for older chrome versions

### DIFF
--- a/docs/es5-build.md
+++ b/docs/es5-build.md
@@ -1,0 +1,96 @@
+# ES5 Build for Legacy Browsers
+
+This document explains how we create a more compatible ES5 build for older browsers like Chrome 73 that cannot run modern JavaScript features or module syntax like `require()`.
+
+## Overview
+
+The ES5 build process uses a combination of Webpack and Babel to:
+
+1. Bundle JavaScript modules into browser-compatible code (removing `require()` statements)
+2. Transpile modern JavaScript syntax to ES5-compatible code
+3. Serve the resulting files from the `/d-es5/` path for legacy browsers
+
+## Files Involved
+
+- `webpack.es5.config.js` - Webpack configuration for bundling the ES5 build
+- `scripts/create-legacy-build.js` - Script that orchestrates the build process
+- `babel.config.json` - Babel configuration targeting Chrome 73
+- `scripts/test-es5-build.js` - Script to test the ES5 build process
+
+## How It Works
+
+1. The build process starts with the modern build output in `dist/donate-frontend/browser`
+2. Non-JavaScript assets are copied to `dist/donate-frontend/browser-es5`
+3. Webpack bundles the JavaScript files, resolving all module dependencies
+4. Babel transpiles the bundled JavaScript to ES5-compatible syntax
+5. HTML files are updated to reference the ES5 assets via `/d-es5/` paths
+6. The server detects legacy browsers and serves files from the ES5 build
+
+## How to Use
+
+### Building the ES5 Version
+
+Run the following command to create the ES5 build:
+
+```bash
+npm run babel
+```
+
+This will:
+1. Create the ES5 build in `dist/donate-frontend/browser-es5`
+2. Bundle and transpile all JavaScript files
+3. Update HTML files to reference the ES5 assets
+
+### Testing the ES5 Build
+
+To verify the ES5 build process:
+
+```bash
+node scripts/test-es5-build.js
+```
+
+This will run the build process and check that:
+- The ES5 build directory is created
+- JavaScript files are bundled (no `require()` statements)
+- HTML files are updated to use `/d-es5/` paths
+
+### Serving the ES5 Build
+
+The server automatically detects legacy browsers using the `isLegacyBrowser()` function in `server.ts` and serves the appropriate build:
+
+```javascript
+// From server.ts
+function isLegacyBrowser(userAgent: string): boolean {
+  // Chrome < 80, Safari < 13, Edge < 80, IE, etc.
+  return (
+    /Chrome\/([5-7][0-9])/.test(userAgent) ||
+    /MSIE|Trident/.test(userAgent) ||
+    /Safari\/(12|11|10|9|8|7|6|5|4|3|2|1)\./.test(userAgent) ||
+    /Edge\/(1[0-7]|[0-9])\./.test(userAgent)
+  );
+}
+```
+
+For legacy browsers, the server:
+1. Serves static files from `/d-es5/` instead of `/d/`
+2. Rewrites HTML to reference ES5 assets
+
+## Troubleshooting
+
+If you encounter issues with the ES5 build:
+
+1. Check that Webpack is bundling all JavaScript files correctly
+2. Verify that Babel is transpiling to ES5-compatible syntax
+3. Ensure HTML files are correctly updated to reference ES5 assets
+4. Check browser detection logic in `server.ts`
+
+## Dependencies
+
+The ES5 build process relies on:
+
+- Webpack (^5.94.0)
+- Webpack CLI (^4.5.0)
+- Babel CLI (^7.28.3)
+- @babel/preset-env (^7.28.3)
+
+These are already included in the project's devDependencies.

--- a/scripts/create-legacy-build.js
+++ b/scripts/create-legacy-build.js
@@ -3,24 +3,35 @@
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
+const process = require('process');
 
-const DIST_DIR = "dist/donate-frontend";
+process.chdir(__dirname + "/..");
+
+const DIST_DIR = "./dist/donate-frontend";
 const BROWSER_DIR = path.join(DIST_DIR, "browser");
 const BROWSER_ES5_DIR = path.join(DIST_DIR, "browser-es5");
 
 console.log("Creating ES5-compatible build...");
 
-// Step 1: Copy the entire browser directory to browser-es5
+// Step 1: Clean the browser-es5 directory if it exists
 if (fs.existsSync(BROWSER_ES5_DIR)) {
   fs.rmSync(BROWSER_ES5_DIR, { recursive: true, force: true });
 }
 
-console.log("Copying browser build to browser-es5...");
-execSync(`cp -r "${BROWSER_DIR}" "${BROWSER_ES5_DIR}"`);
+// Step 2: Create the browser-es5 directory
+fs.mkdirSync(BROWSER_ES5_DIR, { recursive: true });
 
-// Step 2: Transpile all JS files with babel
-console.log("Transpiling JavaScript files with babel...");
-execSync(`babel "${BROWSER_ES5_DIR}" --out-dir "${BROWSER_ES5_DIR}" --extensions ".js" --verbose`);
+// Step 3: Copy non-JS assets from browser to browser-es5
+console.log("Copying non-JS assets to browser-es5...");
+execSync(`find "${BROWSER_DIR}" -type f -not -name "*.js" -exec cp --parents {} "${BROWSER_ES5_DIR}" \\;`);
+
+// Step 4: Bundle JS files with webpack
+console.log("Bundling JavaScript files with webpack...");
+execSync("npx webpack --config webpack.es5.config.js", { stdio: 'inherit' });
+
+// Step 5: Transpile the bundled JS files with Babel
+console.log("Transpiling bundled JavaScript files with babel...");
+execSync(`npx babel "${BROWSER_ES5_DIR}" --out-dir "${BROWSER_ES5_DIR}" --extensions ".js" --verbose`);
 
 // Step 3: Update HTML files to reference the transpiled JS files
 console.log("Updating HTML file script references...");

--- a/scripts/test-es5-build.js
+++ b/scripts/test-es5-build.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Define paths
+const DIST_DIR = "dist/donate-frontend";
+const BROWSER_ES5_DIR = path.join(DIST_DIR, "browser-es5");
+
+console.log("Testing ES5 build process...");
+
+// Run the build script
+try {
+  console.log("Running create-legacy-build.js...");
+  execSync('node scripts/create-legacy-build.js', { stdio: 'inherit' });
+
+  // Check if the browser-es5 directory exists
+  if (fs.existsSync(BROWSER_ES5_DIR)) {
+    console.log(`✅ ${BROWSER_ES5_DIR} directory created successfully.`);
+
+    // Check for JS files
+    const jsFiles = fs.readdirSync(BROWSER_ES5_DIR)
+      .filter(file => file.endsWith('.js'));
+
+    if (jsFiles.length > 0) {
+      console.log(`✅ Found ${jsFiles.length} JavaScript files in ${BROWSER_ES5_DIR}.`);
+
+      // Check content of a JS file to ensure it doesn't contain require() statements
+      const sampleFile = path.join(BROWSER_ES5_DIR, jsFiles[0]);
+      const content = fs.readFileSync(sampleFile, 'utf8');
+
+      if (!content.includes('require(')) {
+        console.log(`✅ No 'require()' statements found in ${jsFiles[0]}.`);
+      } else {
+        console.log(`❌ 'require()' statements still present in ${jsFiles[0]}.`);
+      }
+    } else {
+      console.log(`❌ No JavaScript files found in ${BROWSER_ES5_DIR}.`);
+    }
+
+    // Check for HTML files
+    const htmlFiles = fs.readdirSync(BROWSER_ES5_DIR)
+      .filter(file => file.endsWith('.html'));
+
+    if (htmlFiles.length > 0) {
+      console.log(`✅ Found ${htmlFiles.length} HTML files in ${BROWSER_ES5_DIR}.`);
+
+      // Check if HTML files have been updated to use /d-es5/ paths
+      const sampleHtml = path.join(BROWSER_ES5_DIR, htmlFiles[0]);
+      const htmlContent = fs.readFileSync(sampleHtml, 'utf8');
+
+      if (htmlContent.includes('src="/d-es5/')) {
+        console.log(`✅ HTML files updated to use /d-es5/ paths.`);
+      } else {
+        console.log(`❌ HTML files not updated to use /d-es5/ paths.`);
+      }
+    } else {
+      console.log(`❌ No HTML files found in ${BROWSER_ES5_DIR}.`);
+    }
+  } else {
+    console.log(`❌ ${BROWSER_ES5_DIR} directory not created.`);
+  }
+
+  console.log("Test completed.");
+} catch (error) {
+  console.error("Error during test:", error);
+}

--- a/webpack.es5.config.js
+++ b/webpack.es5.config.js
@@ -1,0 +1,73 @@
+const path = require('path');
+const fs = require('fs');
+
+// Define paths
+const DIST_DIR = 'dist/donate-frontend';
+const BROWSER_DIR = path.join(DIST_DIR, 'browser');
+const BROWSER_ES5_DIR = path.join(DIST_DIR, 'browser-es5');
+
+// Function to recursively find all JS files in a directory
+function findJsFiles(dir, fileList = []) {
+  const files = fs.readdirSync(dir);
+
+  files.forEach(file => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory()) {
+      findJsFiles(filePath, fileList);
+    } else if (file.endsWith('.js')) {
+      fileList.push(filePath);
+    }
+  });
+
+  return fileList;
+}
+
+// Find all JS files in the browser directory
+const entryFiles = findJsFiles(BROWSER_DIR);
+
+  // Create entry object for webpack
+const entries = {};
+entryFiles.forEach(file => {
+  // Get the relative path from the browser directory
+  const relativePath = path.relative(BROWSER_DIR, file);
+  // Use the relative path (without .js extension) as the entry name
+  const entryName = relativePath.replace(/\.js$/, '');
+  // Add './' prefix to file paths to ensure proper resolution
+  entries[entryName] = './' + file;
+});
+
+module.exports = {
+  mode: 'production',
+  entry: entries,
+  output: {
+    path: path.resolve(__dirname, BROWSER_ES5_DIR),
+    filename: '[name].js',
+    // Ensure paths match the original structure
+    publicPath: '/d-es5/'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        // We'll use Babel CLI separately in the script instead of babel-loader
+        use: []
+      }
+    ]
+  },
+  optimization: {
+    // Minimize the output for production
+    minimize: true,
+    // Ensure proper code splitting
+    splitChunks: {
+      chunks: 'all',
+      name: false
+    }
+  },
+  // Ensure proper source maps for debugging
+  devtool: 'source-map',
+  // Target browsers that support ES5
+  target: ['web', 'es5']
+};


### PR DESCRIPTION
Implemented using junie, prompts:

> Our approach for serving a more-compatible but larger ES5 build for older browsers is
> coming along ok, but babel alone is not enough because e.g. Chrome 73 cannot run the
> require() etc. that are in the output. Could you propose a minimal Webpack configuration
> that will output something we can serve to such browsers in the browser-es5 folder?

---

> Please run `scripts/create-legacy-build.js` and fix the errors about `Requests that should resolve in the current directory need to start with './'.`.

> Output currently includes many lines like so:

> ```

> ERROR in reset-password.component-6S6KTTMX
> Module not found: Error: Can't resolve 'dist/donate-frontend/browser/reset-password.component-6S6KTTMX.js' in '/home/barney/projects/donate-frontend'
> Did you mean './dist/donate-frontend/browser/reset-password.component-6S6KTTMX.js'?
> Requests that should resolve in the current directory need to start with './'.
> Requests that start with a name are treated as module requests and resolve within module directories (node_modules).
> If changing the source code is not an option there is also a resolve options called 'preferRelative' which tries to resolve these kind of requests in the current directory too.

```