### PR TITLE
BG2-2892: Output alt-text on campaign additional images if present

### DIFF
--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -199,10 +199,24 @@
 
               @if (campaign.additionalImageUris.length > 0) {
                 <div class="c-additional">
-                  <!-- I think we didn't collect alt-text from charities for these images, so can't show it here -->
-                  <!-- eslint-disable @angular-eslint/template/alt-text -->
                   @for (image of campaign.additionalImageUris; track $index) {
-                    <img [src]="image.uri | optimisedImage: 850 | async" class="c-additional__images" />
+                    <!--- at east for now, using typeof so we treat empty alt as distinct from missing alt. Ideally
+                          empty alt will mean someone has decided the image does not want alt-text, while missing alt
+                          means they haven't made that decision, probably because the image was uploaded at a time when
+                          we did not accept alt-text. Whether we'll actually build the data structure to allow
+                          distinguishing these cases remains to be decided.
+                          -->
+                    @if (typeof image.alt_text === "string") {
+                      <img
+                        [src]="image.uri | optimisedImage: 850 | async"
+                        class="c-additional__images"
+                        [alt]="image.alt_text"
+                      />
+                    } @else {
+                      <!-- I think we didn't collect alt-text from charities for these images, so can't show it here -->
+                      <!-- eslint-disable @angular-eslint/template/alt-text -->
+                      <img [src]="image.uri | optimisedImage: 850 | async" class="c-additional__images" />
+                    }
                   }
                   <!-- eslint-enable @angular-eslint/template/alt-text -->
                 </div>

--- a/src/app/campaign-details/campaign-details.component.html
+++ b/src/app/campaign-details/campaign-details.component.html
@@ -200,7 +200,7 @@
               @if (campaign.additionalImageUris.length > 0) {
                 <div class="c-additional">
                   @for (image of campaign.additionalImageUris; track $index) {
-                    <!--- at east for now, using typeof so we treat empty alt as distinct from missing alt. Ideally
+                    <!--- at least for now, using typeof so we treat empty alt as distinct from missing alt. Ideally
                           empty alt will mean someone has decided the image does not want alt-text, while missing alt
                           means they haven't made that decision, probably because the image was uploaded at a time when
                           we did not accept alt-text. Whether we'll actually build the data structure to allow

--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -29,7 +29,7 @@ export type Campaign = {
   endDate: string;
   matchFundsTotal: number;
   aims: string[];
-  additionalImageUris: Array<{ uri: string; order: number }>;
+  additionalImageUris: Array<{ uri: string; order: number; alt_text?: string | undefined }>;
   beneficiaries: string[];
   budgetDetails: Array<{ amount: number; description: string }>;
   categories: string[];


### PR DESCRIPTION
(We know it won't be present currently as we don't offer a way for charities to enter it, but hoping to implement that soon)

<img width="1377" height="981" alt="Screenshot From 2025-09-19 11-08-33" src="https://github.com/user-attachments/assets/8b9a0b50-6921-4dcf-9b6a-1c943974aa52" />
