### PR TITLE
BG2-2972: Refactor, narrow tip percentage default type

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -205,7 +205,7 @@ export class DonationStartFormComponent implements AfterContentInit, OnDestroy, 
     { minDonation: 100, tipPercentage: 12 },
     { minDonation: 300, tipPercentage: 10 },
     { minDonation: 1_000, tipPercentage: 8 },
-  ];
+  ] as const;
   readonly tipPercentageDefaultsByPercent = [...this.tipPercentageDefaults].sort(
     (a, b) => a.tipPercentage - b.tipPercentage,
   );
@@ -261,7 +261,7 @@ export class DonationStartFormComponent implements AfterContentInit, OnDestroy, 
   private previousDonation?: Donation;
   private tipPercentageChanged = false;
 
-  tipPercentage = this.tipPercentageDefaults[0].tipPercentage;
+  tipPercentage: number = this.tipPercentageDefaults[0].tipPercentage;
   tipValue: number | undefined;
 
   private idCaptchaCode?: string;


### PR DESCRIPTION
Marking this as readonly just prevents TS from auto-widening the type and so lets us see what the numbers are e.g. when we hover on references to `this.tipPercentageDefaults`