### PR TITLE
BG2-2962 – add a Matomo log to help track payment method outcomes

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -964,7 +964,12 @@ export class DonationStartFormComponent implements AfterContentInit, OnDestroy, 
           newType = 'customer_balance';
       }
 
+      if (newType !== this.selectedPaymentMethodType) {
+        this.matomoTracker.trackEvent('donate', 'payment_method_type_set', `Selected ${newType}`);
+      }
+
       this.selectedPaymentMethodType = newType;
+
       if (newType !== this.donation.pspMethodType) {
         this.donation.pspMethodType = newType;
         this.donationService.updateLocalDonation(this.donation);


### PR DESCRIPTION
And evaluate Pay By Bank impact overall and completion vs. initial interest

A sample real-time log entry from my local test:
<img width="1038" height="153" alt="Screenshot 2025-09-30 at 13 42 00" src="https://github.com/user-attachments/assets/6881b595-f75d-4d33-83e9-fc66512245ca" />

I'm not 100% sure but I think using Event Name like this is probably just as flexible as if each method had its own Event Action. It looks like Goal configs can use either so I am assuming other ways of splitting up traffic can too.