### PR TITLE
BG2-2971: Replace all links to mailjet signup form with links to new …

### DIFF
--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -12,7 +12,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
     case 'staging':
       return { mailingListSignup: true };
     case 'production':
-      return { mailingListSignup: false };
+      return { mailingListSignup: true };
   }
 };
 

--- a/src/app/highlight-cards/HighlightCard.ts
+++ b/src/app/highlight-cards/HighlightCard.ts
@@ -55,7 +55,8 @@ const replaceURLOrigin = (
   const href = urlFromApi
     .replace('https://donate.biggive.org', donateUriPrefix)
     .replace('https://biggive.org', blogUriPrefix)
-    .replace('https://community.biggive.org', experienceUriPrefix);
+    .replace('https://community.biggive.org', experienceUriPrefix)
+    .replace('https://mailchi.mp/biggive/news', donateUriPrefix + '/donor-mailing-list'); // @todo - change this upstream in SF and delete this line
   return new URL(href);
 };
 

--- a/src/app/my-donations/my-donations.component.html
+++ b/src/app/my-donations/my-donations.component.html
@@ -17,14 +17,13 @@
           </p>
           <p>
             <a href="https://biggive.org/funders/">Learn more about joining our Champion community</a> and
-            <a href="https://mailchi.mp/biggive/news">join our mailing list</a> to stay up to date on upcoming
-            campaigns.
+            <a href="/donor-mailing-list">join our mailing list</a> to stay up to date on upcoming campaigns.
           </p>
         } @else {
           <p>
             Thank you for your generous support. Every donation you have made has helped to make an extraordinary
-            difference. <a href="https://mailchi.mp/biggive/news">Join our mailing list</a> to stay up to date on
-            upcoming campaigns.
+            difference. <a href="/donor-mailing-list">Join our mailing list</a> to stay up to date on upcoming
+            campaigns.
           </p>
         }
 


### PR DESCRIPTION
…form that creates SF comms preference

(and so will indirectly add records to mailjet)

Enabling this new form and linking to it instead of the mailchimp form:

<img width="1989" height="1307" alt="image" src="https://github.com/user-attachments/assets/06b13c75-5293-4172-87ee-d03f1269511e" />
