### PR TITLE
DON-1194: Show total to pay at start of donation form

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -172,13 +172,12 @@
         @if (donationAmount && donationAmount > 0 && !tipAmountField?.invalid) {
           <div class="stepOneAmountSummary">
             <p>
-            Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }} <br />
-            Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }}
-            <a role="button" tabindex="0" (click)="showTipExplanation()">(Why&nbsp;tip?)</a>
+              Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }}
+              <br />
+              Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }}
+              <a role="button" tabindex="0" (click)="showTipExplanation()">(Why&nbsp;tip?)</a>
             </p>
-            <p class="total">
-              Total to pay: {{ donationAmount + tipAmount() | exactCurrency: campaign.currencyCode }}
-            </p>
+            <p class="total">Total to pay: {{ donationAmount + tipAmount() | exactCurrency: campaign.currencyCode }}</p>
           </div>
         }
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -171,13 +171,14 @@
 
         @if (donationAmount && donationAmount > 0 && !tipAmountField?.invalid) {
           <div class="stepOneAmountSummary">
+            <p>
             Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }} <br />
             Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }}
             <a role="button" tabindex="0" (click)="showTipExplanation()">(Why tip?)</a>
-            <br />
-            <span class="total">
+            </p>
+            <p class="total">
               Total to pay: {{ donationAmount + tipAmount() | exactCurrency: campaign.currencyCode }}
-            </span>
+            </p>
           </div>
         }
 

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -166,38 +166,20 @@
                 }
               </div>
             }
-            <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = false">
-              <mat-expansion-panel-header>
-                <h3 class="b-rt-0 b-m-0 b-bold"><span class="span-hr"></span>How does Big Give use tips?</h3>
-              </mat-expansion-panel-header>
-              <p><strong>Everything we receive goes back into supporting charities:</strong></p>
-              <ul>
-                <li>We’re a charity, too — you help us keep our platform running!</li>
-                <li>
-                  Free training and resources build the resilience of charities that do not have access to the funds or
-                  publicity that others do.
-                </li>
-                <li>We give additional funds to help match donations in campaigns through our Anchor Match Fund.</li>
-              </ul>
-              <p>Thank you! If you have any questions about tips, please contact us at hello&#64;biggive.org.</p>
-            </mat-expansion-panel>
           </div>
         }
 
-        @if (
-          donationAmount &&
-          donationAmount > 0 &&
-          (! tipAmountField?.invalid)
-          ) {
+        @if (donationAmount && donationAmount > 0 && !tipAmountField?.invalid) {
           <div class="stepOneAmountSummary">
-            Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }} <br>
-            Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }} <br>
+            Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }} <br />
+            Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }}
+            <a role="button" tabindex="0" (click)="showTipExplanation()">(Why tip?)</a>
+            <br />
             <span class="total">
               Total to pay: {{ donationAmount + tipAmount() | exactCurrency: campaign.currencyCode }}
             </span>
           </div>
         }
-
 
         <div aria-live="polite">
           <div class="u-text-center">

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -58,7 +58,7 @@
             @if (creditPenceToUse === 0) {
               <div class="u-text-center">
                 @if (!showCustomTipInput) {
-                  <div class="donation-input donation-input-main">
+                  <div class="donation-input donation-input-main tipSliderWrapper">
                     <mat-slider
                       id="tipSlider"
                       [min]="minimumTipPercentage"
@@ -130,20 +130,6 @@
                   </div>
                 }
 
-                <!-- We could only reliably get new values from Material Slider at the end of a drag, so hide this during -->
-                @if (
-                  !showCustomTipInput &&
-                  !isTipSliderBeingDragged &&
-                  donationAmount &&
-                  donationAmount > 0 &&
-                  tipAmountField?.valid &&
-                  tipAmount() > 0
-                ) {
-                  <mat-hint>
-                    <p>{{ tipValue | exactCurrency: campaign.currencyCode }} donation to support Big Give</p>
-                  </mat-hint>
-                }
-
                 @if (showCustomTipInput) {
                   <p>
                     <a
@@ -197,6 +183,22 @@
             </mat-expansion-panel>
           </div>
         }
+
+        @if (
+          donationAmount &&
+          donationAmount > 0 &&
+          (! tipAmountField?.invalid)
+          ) {
+          <div class="stepOneAmountSummary">
+            Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }} <br>
+            Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }} <br>
+            <span class="total">
+              Total to pay: {{ donationAmount + tipAmount() | exactCurrency: campaign.currencyCode }}
+            </span>
+          </div>
+        }
+
+
         <div aria-live="polite">
           <div class="u-text-center">
             @if (donationCreateError) {

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -174,7 +174,7 @@
             <p>
             Donation to {{ campaign.charity.name }}: {{ donationAmount | exactCurrency: campaign.currencyCode }} <br />
             Tip Donation to support Big Give: {{ tipAmount() | exactCurrency: campaign.currencyCode }}
-            <a role="button" tabindex="0" (click)="showTipExplanation()">(Why tip?)</a>
+            <a role="button" tabindex="0" (click)="showTipExplanation()">(Why&nbsp;tip?)</a>
             </p>
             <p class="total">
               Total to pay: {{ donationAmount + tipAmount() | exactCurrency: campaign.currencyCode }}

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -62,7 +62,6 @@ div.mat-step-label.mat-step-label-selected {
   font-size: 17px !important;
   line-height: 20px;
   @media #{abstract.$breakpoint-lg} {
-    font-size: 20px !important;
     line-height: 27px;
   }
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -31,7 +31,6 @@
   margin-bottom: -1em;
   text-align: center;
   .total {
-    font-size: 20px;
     font-weight: bold;
     color: abstract.$colour-primary;
   }
@@ -62,6 +61,7 @@ div.mat-step-label.mat-step-label-selected {
   font-size: 17px !important;
   line-height: 20px;
   @media #{abstract.$breakpoint-lg} {
+    font-size: 20px !important;
     line-height: 27px;
   }
 }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.scss
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.scss
@@ -22,6 +22,21 @@
   width: 100%;
 }
 
+.donation-input.donation-input-main.tipSliderWrapper {
+  margin-bottom: 0;
+}
+
+.stepOneAmountSummary {
+  margin-top: 1em;
+  margin-bottom: -1em;
+  text-align: center;
+  .total {
+    font-size: 20px;
+    font-weight: bold;
+    color: abstract.$colour-primary;
+  }
+}
+
 .mat-stepper-horizontal,
 .mat-stepper-vertical {
   background: none;

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -72,6 +72,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { flags } from '../../featureFlags';
 import { createCardForm, createController, RyftCardFormComponentResponse, RyftControllerResponse } from '@ryftpay/web';
+import { DonationStartWhyTipDialogComponent } from '../donation-start-why-tip-dialog.component';
 
 declare let _paq: {
   push: (args: Array<string | object>) => void;
@@ -2834,5 +2835,9 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
       this.stripePaymentMethodReady = event.isValid;
     });
     this.ryftCardForm.mount('#ryft-card-form-container');
+  }
+
+  showTipExplanation(): void {
+    this.dialog.open(DonationStartWhyTipDialogComponent);
   }
 }

--- a/src/app/donation-start/donation-start-why-tip-dialog.component.ts
+++ b/src/app/donation-start/donation-start-why-tip-dialog.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { PopupStandaloneComponent } from '../popup-standalone/popup-standalone.component';
+import { MatExpansionPanel, MatExpansionPanelHeader } from '@angular/material/expansion';
+
+@Component({
+  selector: 'app-donation-start-why-tip-dialog',
+  templateUrl: 'donation-start-why-tip-dialog.html',
+  imports: [MatButtonModule, MatDialogModule, PopupStandaloneComponent, MatExpansionPanel, MatExpansionPanelHeader],
+})
+export class DonationStartWhyTipDialogComponent {}

--- a/src/app/donation-start/donation-start-why-tip-dialog.html
+++ b/src/app/donation-start/donation-start-why-tip-dialog.html
@@ -1,0 +1,20 @@
+<app-popup-standalone>
+  <h2 mat-dialog-title>How does Big Give use tips?</h2>
+  <mat-dialog-content class="mat-typography">
+    <p><strong>Everything we receive goes back into supporting charities:</strong></p>
+    <ul>
+      <li>We’re a charity, too — you help us keep our platform running!</li>
+      <li>
+        Free training and resources build the resilience of charities that do not have access to the funds or publicity
+        that others do.
+      </li>
+      <li>We give additional funds to help match donations in campaigns through our Anchor Match Fund.</li>
+    </ul>
+    <p>Thank you! If you have any questions about tips, please contact us at hello&#64;biggive.org.</p>
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button id="proceed-with-donation" mat-raised-button [mat-dialog-close]="true" cdkFocusInitial color="accent">
+      Close
+    </button>
+  </mat-dialog-actions>
+</app-popup-standalone>

--- a/src/assets/scss/_overwrite-mat.scss
+++ b/src/assets/scss/_overwrite-mat.scss
@@ -56,4 +56,11 @@ mat-spinner {
       value-indicator-border-radius: 4px,
     )
   );
+
+  @include mat.dialog-overrides(
+    (
+      supporting-text-color: abstract.$colour-black,
+      // overrides default grey
+    )
+  );
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -155,12 +155,3 @@ div.mat-expansion-panel-body {
   font-size: 18px;
   font-weight: normal;
 }
-
-:root {
-  @include mat.dialog-overrides(
-    (
-      supporting-text-color: abstract.$colour-black,
-      // overrides default grey
-    )
-  );
-}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -155,3 +155,12 @@ div.mat-expansion-panel-body {
   font-size: 18px;
   font-weight: normal;
 }
+
+:root {
+  @include mat.dialog-overrides(
+    (
+      supporting-text-color: abstract.$colour-black,
+      // overrides default grey
+    )
+  );
+}


### PR DESCRIPTION
<img width="674" height="679" alt="image" src="https://github.com/user-attachments/assets/272a06d7-ef51-42a9-be88-73feb726c04e" />

<img width="615" height="573" alt="image" src="https://github.com/user-attachments/assets/fd338ed1-70d1-43c4-b00f-5fc631811837" />

Not sure if there's any reason we'd really want the dialog text to be grey rather than black as it is here - because of defaults we're inheriting from the material design component - but that's the same as in our existing continue donation modal dialogs.