### PR TITLE
Use much smaller metacampaign banners again

### DIFF
--- a/src/app/explore/explore.component.html
+++ b/src/app/explore/explore.component.html
@@ -17,12 +17,12 @@
     </biggive-totalizer>
   }
 
-  @if (metaCampaign && !!metaCampaign.bannerLayout) {
+  @if (metaCampaign) {
     <biggive-heading-banner
       [logo]="fund?.logoUri ? { url: fund?.logoUri!, alt: fund?.name } : undefined"
       [mainTitle]="title"
       [teaser]="fund && fund.description ? fund.description : metaCampaign.summary"
-      [mainImageUrl]="metaCampaign.bannerUri"
+      [mainImageUrl]="metaCampaign.bannerUri | optimisedImage: 2000 | async"
       [backgroundColour]="metaCampaign.bannerLayout.backgroundColour"
       [focalPoint]="{
         x: metaCampaign.bannerLayout.focalArea.topLeftXpos,
@@ -35,17 +35,6 @@
       height="tall"
     >
     </biggive-heading-banner>
-  } @else if (metaCampaign) {
-    <biggive-hero-image
-      [logo]="fund?.logoUri"
-      [logoAltText]="fund?.name"
-      [mainTitle]="title"
-      [mainImage]="metaCampaign.bannerUri | optimisedImage: 2000 | async"
-      [mainImageShape]="campaignIdsWithRectangleImage.includes(metaCampaign.id) ? 'rectangle' : 'triangle'"
-      [teaser]="fund && fund.description ? fund.description : metaCampaign.summary"
-      [colourScheme]="campaignIdsWithRectangleImage.includes(metaCampaign.id) ? 'white' : 'primary'"
-      main-image-align-horizontal="right"
-    ></biggive-hero-image>
   } @else {
     <biggive-heading-banner
       slug="Explore Campaigns"

--- a/src/app/explore/explore.component.ts
+++ b/src/app/explore/explore.component.ts
@@ -19,7 +19,6 @@ import {
   BiggiveCampaignCardFilterGrid,
   BiggiveTotalizer,
   BiggiveTotalizerTickerItem,
-  BiggiveHeroImage,
   BiggivePageSection,
   BiggiveGrid,
   BiggiveCampaignCard,
@@ -66,7 +65,6 @@ const endPipeToken = new InjectionToken<TimeLeftPipe>('timeLeftToEndPipe');
   imports: [
     BiggiveTotalizer,
     BiggiveTotalizerTickerItem,
-    BiggiveHeroImage,
     BiggivePageSection,
     BiggiveCampaignCardFilterGrid,
     BiggiveGrid,

--- a/src/app/metaCampaign.model.ts
+++ b/src/app/metaCampaign.model.ts
@@ -43,7 +43,7 @@ export type MetaCampaign = {
   usesSharedFunds: boolean;
   shouldBeIndexed: boolean;
 
-  bannerLayout?: {
+  bannerLayout: {
     backgroundColour: string;
     textBackgroundColour: string;
     textColour: string;


### PR DESCRIPTION
via `optimisedImage` pipe.

e.g. webp in all modern browsers which reduces ER26 banner size by more than 10x.

Also retire the old hero component that no(?) metacampaigns use any more.