### PR TITLE
DON-1192: Fix lint error around Ryft payment and show error if ryft p…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1068,9 +1068,13 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
             throw new Error('Ryft payment session id is falsy');
           }
 
-          const result = await firstValueFrom(
-            this.donationService.confirmRyftPayment(this.donation, session.amount, session.id),
-          );
+          try {
+            await firstValueFrom(this.donationService.confirmRyftPayment(this.donation, session.amount, session.id));
+          } catch (_error) {
+            this.paymentStepErrors = 'Sorry, we were not able to take your payment';
+            this.toast.showError('Sorry, we were not able to take your payment');
+            return;
+          }
 
           await this.exitPostDonationSuccess(this.donation, this.getPaymentMethodType());
 
@@ -1078,8 +1082,10 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
         }
         if (session.lastError) {
           // Payment failed – show error to customer
-          const message = ryftPaymentAttemptResponse.userFacingErrorMessage;
-          this.toast.showError(message || 'Sorry, we were not able to take your payment');
+          const message =
+            ryftPaymentAttemptResponse.userFacingErrorMessage || 'Sorry, we were not able to take your payment';
+          this.toast.showError(message);
+          this.paymentStepErrors = message;
         }
       } else if (ryftPaymentAttemptResponse.type == 'action-required') {
         // @todo BG2-3106   - deal with ryft action-required result if possible - although I'm not clear

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -402,12 +402,8 @@ export class DonationService {
     );
   }
 
-  confirmRyftPayment(
-    donation: Donation,
-    amountInPence: number,
-    paymentSessionId: string,
-  ): Observable<{ paymentIntent: { status: PaymentIntent.Status; client_secret: string } }> {
-    return this.http.post<{ paymentIntent: { status: PaymentIntent.Status; client_secret: string } }>(
+  confirmRyftPayment(donation: Donation, amountInPence: number, paymentSessionId: string): Observable<unknown> {
+    return this.http.post(
       `${environment.matchbotApiPrefix}/donations/${donation.donationId}/confirm`,
       {
         psp: 'ryft',


### PR DESCRIPTION
…ayment fails

Matchbot will return an HTTP error code if the payment can't be captured. Eventually we may want to show details of the error but for a first working version it may be enough to just clearly tell the user that we weren't able to take the payment.