### PR TITLE
BG2-3121: Allow donors to optionally view password while typing it anywhere on the site.

### DIFF
--- a/src/app/account/delete-account/delete-account.component.html
+++ b/src/app/account/delete-account/delete-account.component.html
@@ -31,13 +31,12 @@
         @if (person) {
           <biggive-text-input spaceBelow="0">
             <label slot="label" for="password">Confirm password *</label>
-            <input
-              slot="input"
-              id="password"
-              type="password"
-              autocomplete="password"
-              [formControl]="form.controls.password"
-            />
+            <div slot="input" style="display: flex">
+              <input id="password" type="password" autocomplete="password" [formControl]="form.controls.password" />
+              <button type="button" (click)="toggleShowPassword()">
+                {{ showPassword() ? "Hide" : "Show" }}
+              </button>
+            </div>
           </biggive-text-input>
 
           <div class="u-height-2em"></div>

--- a/src/app/account/delete-account/delete-account.ts
+++ b/src/app/account/delete-account/delete-account.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { PageMetaService } from '../../page-meta.service';
 import { DatePipe } from '@angular/common';
 import { IdentityService } from '../../identity.service';
@@ -27,6 +27,7 @@ export class DeleteAccount implements OnInit {
   public person!: Person;
 
   protected countryCode: string | null = null;
+  protected readonly showPassword = signal(false);
 
   protected form = new FormGroup({
     password: new FormControl('', [
@@ -59,6 +60,11 @@ export class DeleteAccount implements OnInit {
       return;
     }
 
+    if (this.showPassword()) {
+      this.showPassword.set(false);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     const actualAccountName = this.person.first_name + ' ' + this.person.last_name;
 
     if (this.form.value.accountName !== actualAccountName) {
@@ -86,4 +92,8 @@ export class DeleteAccount implements OnInit {
   }
 
   protected readonly flags = flags;
+
+  protected toggleShowPassword() {
+    this.showPassword.update((current) => !current);
+  }
 }

--- a/src/app/account/register/register.component.html
+++ b/src/app/account/register/register.component.html
@@ -71,7 +71,17 @@
 
           <biggive-text-input spaceBelow="4">
             <label slot="label" for="password">Password *</label>
-            <input slot="input" matInput type="password" id="password-post-donation" formControlName="password" />
+            <div slot="input" style="display: flex">
+              <input
+                matInput
+                [type]="showPassword() ? 'text' : 'password'"
+                id="password-post-donation"
+                formControlName="password"
+              />
+              <button type="button" (click)="toggleShowPassword()">
+                {{ showPassword() ? "Hide" : "Show" }}
+              </button>
+            </div>
           </biggive-text-input>
 
           <div aria-live="polite">
@@ -170,7 +180,17 @@
           @if (readyToTakeAccountDetails) {
             <biggive-text-input spaceBelow="4">
               <label slot="label" for="password">Password *</label>
-              <input slot="input" matInput type="password" id="password" formControlName="password" />
+              <div slot="input" style="display: flex">
+                <input
+                  matInput
+                  [type]="showPassword() ? 'text' : 'password'"
+                  id="password"
+                  formControlName="password"
+                />
+                <button type="button" (click)="toggleShowPassword()">
+                  {{ showPassword() ? "Hide" : "Show" }}
+                </button>
+              </div>
             </biggive-text-input>
           }
 

--- a/src/app/account/register/register.component.ts
+++ b/src/app/account/register/register.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild,
   inject,
   ChangeDetectorRef,
+  signal,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import {
@@ -97,6 +98,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   protected emailVerificationToken?: EmailVerificationToken;
   protected readonly enableOrgAccount = this.flags.enableOrgAccount;
   protected accountType: 'individual' | 'organisation' = 'individual';
+  protected readonly showPassword = signal(false);
 
   constructor() {
     this.emailVerificationToken = this.activatedRoute.snapshot.data.emailVerificationToken;
@@ -149,6 +151,11 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
 
   async register(): Promise<void> {
     this.errorHtml = this.error = undefined;
+
+    if (this.showPassword()) {
+      this.showPassword.set(false);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
 
     if (!this.registrationForm.valid && this.readyToTakeAccountDetails) {
       // Ensure the UI marks the fields as touched so any field-level UI (present or future) can react.
@@ -350,6 +357,11 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   };
 
   async registerPostDonation() {
+    if (this.showPassword()) {
+      this.showPassword.set(false);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     this.processing = true;
     this.registerPostDonationForm.markAllAsTouched();
     const password = this.registerPostDonationForm.value.password;
@@ -386,4 +398,8 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
       this.error = errorDescription(error);
     }
   };
+
+  protected toggleShowPassword() {
+    this.showPassword.update((current) => !current);
+  }
 }

--- a/src/app/login-modal/login-modal.component.ts
+++ b/src/app/login-modal/login-modal.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnInit, ViewChild, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
@@ -44,6 +44,7 @@ export class LoginModalComponent implements OnInit, AfterViewInit {
   @ViewChild('frccaptcha', { static: false })
   friendlyCaptcha!: ElementRef<HTMLElement>;
   private friendlyCaptchaWidget: WidgetInstance | undefined;
+  protected readonly showPassword = signal(false);
 
   ngOnInit() {
     this.loginForm = this.formBuilder.group({
@@ -69,7 +70,18 @@ export class LoginModalComponent implements OnInit, AfterViewInit {
 
     await this.friendlyCaptchaWidget.start();
   }
-  login(): void {
+  async login(): Promise<void> {
+    if (this.showPassword()) {
+      this.showPassword.set(false);
+
+      // wait for angular to update the view so that the browser
+      // doesn't think the password is something to save
+      // when the request is submitted.
+
+      // see https://technology.blog.gov.uk/2021/04/19/simple-things-are-complicated-making-a-show-password-option/
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     this.loggingIn = true;
     const credentials: Credentials = {
       captcha_code: this.captchaCode || '',
@@ -108,5 +120,9 @@ export class LoginModalComponent implements OnInit, AfterViewInit {
   forgotPasswordClicked(event: Event): void {
     event.preventDefault();
     this.forgotPassword = true;
+  }
+
+  protected toggleShowPassword() {
+    this.showPassword.update((current) => !current);
   }
 }

--- a/src/app/login-modal/login-modal.html
+++ b/src/app/login-modal/login-modal.html
@@ -53,10 +53,19 @@
         <mat-label for="loginEmailAddress">Email address</mat-label>
         <input matInput type="email" id="loginEmailAddress" formControlName="emailAddress" autocapitalize="off" />
       </mat-form-field>
-      <mat-form-field class="b-w-100" color="primary">
-        <mat-label for="loginPassword">Password</mat-label>
-        <input matInput type="password" id="loginPassword" formControlName="password" />
-      </mat-form-field>
+      <div style="display: flex">
+        <mat-form-field class="b-w-100" color="primary">
+          <mat-label for="loginPassword">Password</mat-label>
+          <input matInput [type]="showPassword() ? 'text' : 'password'" id="loginPassword" formControlName="password" />
+        </mat-form-field>
+        <button
+          type="button"
+          (click)="toggleShowPassword()"
+          style="height: 2em; margin-top: 1em; margin-left: 1em; min-width: 4em"
+        >
+          {{ showPassword() ? "Hide" : "Show" }}
+        </button>
+      </div>
       @if (loginError) {
       <p class="error" aria-live="assertive">Login error: {{ loginError }}</p>
       }

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -28,7 +28,6 @@
                   <biggive-text-input spaceBelow="4">
                     <label slot="label" for="loginEmailAddress">Email address *</label>
                     <input
-                      slot="input"
                       matInput
                       type="email"
                       id="ResetPasswordEmailAddress"
@@ -108,7 +107,17 @@
             </biggive-text-input>
             <biggive-text-input spaceBelow="4">
               <label slot="label" for="loginPassword">Password *</label>
-              <input slot="input" matInput type="password" id="loginPassword" formControlName="password" />
+              <div slot="input" style="display: flex">
+                <input
+                  matInput
+                  [type]="showLoginPassword() ? 'text' : 'password'"
+                  id="loginPassword"
+                  formControlName="password"
+                />
+                <button type="button" (click)="toggleShowLoginPassword()">
+                  {{ showLoginPassword() ? "Hide" : "Show" }}
+                </button>
+              </div>
             </biggive-text-input>
             <div aria-live="polite">
               @if (loginError) {

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,4 +1,14 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, PLATFORM_ID, ViewChild, inject } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  PLATFORM_ID,
+  ViewChild,
+  inject,
+  signal,
+} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { BiggiveButton, BiggiveHeading, BiggivePageSection, BiggiveTextInput } from '@biggive/components-angular';
 import { MatButtonModule } from '@angular/material/button';
@@ -72,6 +82,7 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
   private captchaCode: string | undefined;
   protected registerLink!: string;
   protected isNewRegistration: boolean = false;
+  protected showLoginPassword = signal(false);
 
   constructor() {
     const state: LoginNavigationState = <LoginNavigationState>this.router.currentNavigation()?.extras.state;
@@ -137,7 +148,18 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
     await this.friendlyCaptchaWidget.start();
   }
 
-  login(): void {
+  async login(): Promise<void> {
+    if (this.showLoginPassword()) {
+      this.showLoginPassword.set(false);
+
+      // wait for angular to update the view so that the browser
+      // doesn't think the password is something to save
+      // when the request is submitted.
+
+      // see https://technology.blog.gov.uk/2021/04/19/simple-things-are-complicated-making-a-show-password-option/
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     if (!this.loginForm.valid) {
       const emailErrors = this.loginForm.controls?.emailAddress?.errors;
       const passwordErrors = this.loginForm.controls?.password?.errors;
@@ -217,5 +239,9 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
       next: (_) => (this.resetPasswordSuccess = true),
       error: (_) => (this.resetPasswordSuccess = false),
     });
+  }
+
+  protected toggleShowLoginPassword() {
+    this.showLoginPassword.update((current) => !current);
   }
 }

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -49,13 +49,27 @@
     <div>
       <form [formGroup]="passwordForm">
         <p class="b-rt-0">Please enter your new password (min {{ minPasswordLength }} characters)</p>
-        <mat-form-field color="primary">
-          <mat-label>Password</mat-label>
-          <input matInput type="password" formControlName="password" />
-        </mat-form-field>
+        <div style="display: flex">
+          <mat-form-field color="primary">
+            <mat-label>Password</mat-label>
+            <input matInput [type]="showPassword() ? 'text' : 'password'" formControlName="password" />
+          </mat-form-field>
+          <button
+            type="button"
+            (click)="toggleShowPassword()"
+            style="height: 2em; margin-top: 1em; margin-left: 1em; min-width: 4em"
+          >
+            {{ showPassword() ? "Hide" : "Show" }}
+          </button>
+        </div>
         <mat-form-field color="primary">
           <mat-label>Re-enter your password</mat-label>
-          <input matInput type="password" formControlName="confirmPassword" (focus)="onPasswordConfirmationFocus()" />
+          <input
+            matInput
+            [type]="showPassword() ? 'text' : 'password'"
+            formControlName="confirmPassword"
+            (focus)="onPasswordConfirmationFocus()"
+          />
         </mat-form-field>
         @if (confirmPasswordField?.errors?.notSame) {
           <div class="error">Passwords must be the same!</div>

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { getPasswordValidator } from '../validators/validate-passwords-same';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -29,6 +29,7 @@ export class ResetPasswordComponent implements OnInit {
   errorMessageHtml: string | undefined;
   token!: string;
   tokenValid: boolean | undefined = undefined;
+  protected readonly showPassword = signal(false);
 
   constructor() {
     this.minPasswordLength = minPasswordLength;
@@ -64,7 +65,12 @@ export class ResetPasswordComponent implements OnInit {
     return this.passwordForm.controls.confirmPassword;
   }
 
-  saveNewPassword = () => {
+  saveNewPassword = async () => {
+    if (this.showPassword()) {
+      this.showPassword.set(false);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     this.savingNewPassword = true;
     this.identityService.resetPassword(this.passwordForm.controls.password!.value, this.token).subscribe({
       next: (_) => {
@@ -89,4 +95,8 @@ export class ResetPasswordComponent implements OnInit {
         getPasswordValidator(this.passwordForm.controls.password!.value),
       ]);
   };
+
+  protected toggleShowPassword() {
+    this.showPassword.update((current) => !current);
+  }
 }


### PR DESCRIPTION
Helps for anyone with difficulty typing accurately on their device, especially if their password is not a real word.

<img width="1939" height="1073" alt="image" src="https://github.com/user-attachments/assets/9027981d-c5c6-4353-96e3-63dbf506846c" />


<img width="834" height="557" alt="image" src="https://github.com/user-attachments/assets/87dd6bf4-2e08-452a-b02f-3bcbe681e4b4" />
