### PR TITLE
DON-1192: Replace donation transactionId with 'referenceCode'.

### DIFF
--- a/src/app/account/my-donations/my-donations.component.html
+++ b/src/app/account/my-donations/my-donations.component.html
@@ -33,7 +33,7 @@
         </p>
 
         <biggive-grid columnCount="2">
-          @for (donation of donations; track donation.transactionId) {
+          @for (donation of donations; track donation.referenceCode) {
             <biggive-container-card card-colour="white" background-colour="primary">
               @if (donation.mandate) {
                 <div class="badge">Regular Giving</div>
@@ -62,7 +62,7 @@
                 <ul>
                   <li>Date: {{ donation.collectedTime | date: "mediumDate" }}</li>
                   <li>
-                    Payment Reference: <span class="reference">{{ donation.transactionId }}</span>
+                    Payment Reference: <span class="reference">{{ donation.referenceCode }}</span>
                   </li>
                 </ul>
               </div>

--- a/src/app/donation.model.ts
+++ b/src/app/donation.model.ts
@@ -145,9 +145,11 @@ export interface Donation {
   tipAmount: number;
 
   /**
-   * ID assigned by PSP upon checkout initiation.
+   * Reference code for the donor to quote to us when they want to discuss this donation. For a complete donation
+   * paid through stripe will currently be the stripe PI ID, for other donations is the UUID set in matchbot. Undefined
+   * only in case of a new donation generated within frontend, not retrieved from matchbot.
    */
-  transactionId?: string;
+  referenceCode?: string;
 
   /**
    * ISO 8601 formatted datetime

--- a/src/app/donation.service.spec.ts
+++ b/src/app/donation.service.spec.ts
@@ -37,7 +37,7 @@ describe('DonationService', () => {
       psp: 'stripe',
       status,
       tipAmount: 2.75,
-      transactionId: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+      referenceCode: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
       updatedTime: new Date().toISOString(),
     };
   };
@@ -78,7 +78,7 @@ describe('DonationService', () => {
           expect(result.donation.donationAmount).toEqual(1234.56);
           expect(result.donation.matchReservedAmount).toEqual(500.01);
           expect(result.donation.tipAmount).toEqual(2.75);
-          expect(result.donation.transactionId).toEqual('d290f1ee-6c54-4b01-90e6-d701748f0851');
+          expect(result.donation.referenceCode).toEqual('d290f1ee-6c54-4b01-90e6-d701748f0851');
         },
         () => {
           expect(false).toBe(true); // Always fail if observable errors


### PR DESCRIPTION
transactionId was stripe-specific, so using referenceCode instead that can work for any PSP.

Do not merge before https://github.com/thebiggive/matchbot/pull/1977

We could also adjust the copy here and remove the word "Payment":

<img width="1732" height="1164" alt="image" src="https://github.com/user-attachments/assets/43d1d485-f778-4f28-8696-6b237fecc3b7" />
