### PR TITLE
DON-1212 exit step tuning

### DIFF
--- a/src/app/account/register/register.component.html
+++ b/src/app/account/register/register.component.html
@@ -57,7 +57,7 @@
           >.
         </p>
 
-        <form [formGroup]="registerPostDonationForm" (keydown.enter)="registerPostDonation()">
+        <form [formGroup]="registerPostDonationForm" (ngSubmit)="registerPostDonation()">
           <div class="savedDetails">
             <div class="label">Email Address</div>
             <div class="value">
@@ -131,7 +131,7 @@
           <a href="/register">Register a new Big Give account</a>
         </p>
       } @else {
-        <form [formGroup]="registrationForm" (keydown.enter)="register()">
+        <form [formGroup]="registrationForm" (ngSubmit)="register()">
           @if (readyToTakeAccountDetails) {
             @if (enableOrgAccount) {
               <biggive-form-field-select

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -1,7 +1,7 @@
 @if (campaignOpenOnLoad) {
   <form class="c-donate-form" (ngSubmit)="interceptSubmitAndProceedInstead($event)" [formGroup]="donationForm">
     <!-- Hidden submit button to ensure mobile / soft keyboards consistently trigger form submission -->
-    <button type="submit" class="b-hidden" style="display: none" aria-hidden="true"></button>
+    <button type="submit" class="b-hidden" aria-hidden="true"></button>
 
     <mat-vertical-stepper id="stepper" linear #stepper (selectionChange)="stepChanged($event)" animationDuration="0">
       <mat-step

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -1,7 +1,7 @@
 @if (campaignOpenOnLoad) {
   <form class="c-donate-form" (ngSubmit)="interceptSubmitAndProceedInstead($event)" [formGroup]="donationForm">
     <!-- Hidden submit button to ensure mobile / soft keyboards consistently trigger form submission -->
-    <button type="submit" class="b-hidden" style="display: none;" aria-hidden="true"></button>
+    <button type="submit" class="b-hidden" style="display: none" aria-hidden="true"></button>
 
     <mat-vertical-stepper id="stepper" linear #stepper (selectionChange)="stepChanged($event)" animationDuration="0">
       <mat-step
@@ -50,7 +50,7 @@
         @if (!donorHasDonationFunds()) {
           <div>
             <hr class="u-margin-auto-y-20" />
-            <h2 class="b-rt-0 b-m-0 b-bold">Support Big Give</h2>
+            <h2 id="supportBigGiveHeading" tabindex="-1" class="b-rt-0 b-m-0 b-bold">Support Big Give</h2>
             <p>
               Tips to Big Give (registered charity number 1136547) enable us to deliver our charitable mission and help
               us provide match funds to our charity partners. We truly appreciate any tip you can give - no matter the
@@ -179,7 +179,7 @@
         }
 
         <div aria-live="polite">
-          <div class="u-text-center">
+          <div id="step1Continue" class="u-text-center">
             @if (donationCreateError) {
               <p class="error">
                 Sorry, we can't register your donation right now. Please try again in a moment or
@@ -685,13 +685,7 @@
             </table>
           }
           @if (!submitting && !runningFinalPreSubmitUpdate && !finalPreSubmitUpdateFailed) {
-            <button
-              type="button"
-              (click)="submit()"
-              class="continue c-donate-button"
-              mat-raised-button
-              color="primary"
-            >
+            <button type="button" (click)="submit()" class="continue c-donate-button" mat-raised-button color="primary">
               Donate now
             </button>
           }

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -1,5 +1,8 @@
 @if (campaignOpenOnLoad) {
-  <form class="c-donate-form" (keyup.enter)="interceptSubmitAndProceedInstead($event)" [formGroup]="donationForm">
+  <form class="c-donate-form" (ngSubmit)="interceptSubmitAndProceedInstead($event)" [formGroup]="donationForm">
+    <!-- Hidden submit button to ensure mobile / soft keyboards consistently trigger form submission -->
+    <button type="submit" class="b-hidden" style="display: none;" aria-hidden="true"></button>
+
     <mat-vertical-stepper id="stepper" linear #stepper (selectionChange)="stepChanged($event)" animationDuration="0">
       <mat-step
         formGroupName="amounts"
@@ -683,8 +686,8 @@
           }
           @if (!submitting && !runningFinalPreSubmitUpdate && !finalPreSubmitUpdateFailed) {
             <button
+              type="button"
               (click)="submit()"
-              (keyup.enter)="submit()"
               class="continue c-donate-button"
               mat-raised-button
               color="primary"

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -1338,8 +1338,47 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
     }
   }
 
+  /**
+   * Proceed based on things like keyboard enter, including virtual mobile keyboards, iff:
+   * 1. the donor is *not* on a touch device (like a phone) AND they have the full tip information visible; or
+   * 2. they are on a later step than the first (amount and tips).
+   *
+   * When it's not appropriate to auto exit step 1, scroll down if applicable to move the tip information into view.
+   *
+   * Mobile is handled differently because of the high probability that a software keyboard is obscuring tip information
+   * in a way we can't detect. Directly pressing Continue or navigating by pressing step headers still work without
+   * this interception.
+   */
   async interceptSubmitAndProceedInstead(event: Event) {
     event.preventDefault();
+
+    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+
+    if (this.stepper.selected?.label === stepLabels.yourDonation && !this.donorHasDonationFunds()) {
+      // @ViewChild seemed not to get current position, not sure why. Using the DOM directly is fine.
+      const heading = document.getElementById('supportBigGiveHeading');
+      const step1Continue = document.getElementById('step1Continue');
+
+      if (heading) {
+        const headingRect = heading.getBoundingClientRect();
+        const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+        const continueButtonBottom = step1Continue?.getBoundingClientRect().bottom || 0;
+
+        // 0 checks are a failsafe so that if DOM position values seem spurious we assume the worst and
+        // avoid advancing a step overzealously, to ensure donors see the info.
+        if (
+          isTouchDevice ||
+          continueButtonBottom > viewportHeight ||
+          headingRect.top === 0 ||
+          headingRect.height === 0
+        ) {
+          heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          setTimeout(() => heading.focus({ preventScroll: true }), 800);
+          return;
+        }
+      }
+    }
+
     await this.next();
   }
 

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -94,7 +94,7 @@
             </p>
             <p>You will be able to log-in any time to see your donations or cancel the agreement.</p>
           }
-          <form [formGroup]="loginForm" (keydown.enter)="login()">
+          <form [formGroup]="loginForm" (ngSubmit)="login()">
             <biggive-text-input spaceBelow="4">
               <label slot="label" for="loginEmailAddress">Email address *</label>
               <input
@@ -106,6 +106,8 @@
                 autocapitalize="off"
               />
             </biggive-text-input>
+
+
             <biggive-text-input spaceBelow="4">
               <label slot="label" for="loginPassword">Password *</label>
               <div slot="input" style="display: flex">
@@ -119,6 +121,8 @@
                   formControlName="password"
                 />
                 <biggive-button
+                  role="button"
+                  tabindex="0"
                   aria-controls="loginPassword"
                   colourScheme="clear-primary"
                   (doButtonClick)="toggleShowLoginPassword()"

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -107,7 +107,6 @@
               />
             </biggive-text-input>
 
-
             <biggive-text-input spaceBelow="4">
               <label slot="label" for="loginPassword">Password *</label>
               <div slot="input" style="display: flex">

--- a/src/app/mailing-list/mailing-list.component.html
+++ b/src/app/mailing-list/mailing-list.component.html
@@ -46,7 +46,7 @@
             }
           }
 
-          <form [formGroup]="mailingListForm" (keydown.enter)="onSubmit()">
+          <form [formGroup]="mailingListForm" (ngSubmit)="onSubmit()">
             <biggive-text-input spaceBelow="4">
               <label slot="label" for="firstName">First Name *</label>
               <input

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -42,7 +42,7 @@
       <biggive-page-section>
         <form
           class="c-regular-giving-form"
-          (keydown.enter)="interceptSubmitAndProceedInstead($event)"
+          (ngSubmit)="interceptSubmitAndProceedInstead($event)"
           [formGroup]="mandateForm"
         >
           <mat-vertical-stepper
@@ -434,8 +434,8 @@
               <div aria-live="polite" class="u-text-center">
                 @if (!submitting) {
                   <button
+                    type="button"
                     (click)="submit()"
-                    (keyup.enter)="submit()"
                     class="c-donate-button continue"
                     mat-raised-button
                     color="primary"

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -278,7 +278,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
 
   async interceptSubmitAndProceedInstead(event: Event) {
     event.preventDefault();
-    await this.next();
+    this.continue();
   }
 
   stepChanged(event: StepperSelectionEvent) {

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -287,10 +287,6 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     }
   }
 
-  async next() {
-    this.stepper.next();
-  }
-
   async submit() {
     const invalid = this.mandateForm.invalid;
     if (invalid) {

--- a/src/app/verify-email/verify-email.component.html
+++ b/src/app/verify-email/verify-email.component.html
@@ -2,7 +2,7 @@
 
 <p>Enter the 6-digit code we sent to {{ emailAddress }}</p>
 
-<form [formGroup]="emailConfirmationForm" (keydown.enter)="onFormSubmit()">
+<form [formGroup]="emailConfirmationForm" (ngSubmit)="onFormSubmit()">
   <biggive-text-input spaceBelow="4">
     <label slot="label" for="code">Verification code</label>
     <input slot="input" matInput type="email" id="code" formControlName="code" autocapitalize="off" [maxlength]="6" />


### PR DESCRIPTION
* [Standardise form submit interceptions](https://github.com/thebiggive/donate-frontend/pull/2361/changes/8a4308633fc744c5ea788bdf33d5ae47c8faefcf)
Primarily, in the two important donate forms, ensure the interception logic is independent of the input method.
* [Limit when pressing enter advances the donor from step 1, amount & tip](https://github.com/thebiggive/donate-frontend/pull/2361/changes/1b9f3a60a7fe7a62e0d83bd77e697d8724501a1c)
And when it's not suitable to advance, scroll them to the tip information. Never advances from this step on touch devices, as explained in code comments.

(Also make various less-critical forms where we just want simple submission not be needlessly coupled to input method.)

Input interception change tested in desktop Firefox and simulated iOS 26.2 mobile Safari with software keyboard enabled and pressing its enter key – which previously caused iOS to try to submit the whole form and show validation errors. Both LGTM so far with the change.

The hidden submit button is an AI suggestion, not 100% certain it's necessary but if it doesn't cause screen reader regressions we can identify then it sort of makes sense that it might let us be more sure of the same behaviour across platforms.