### PR TITLE
BG2-3310: Use a three column grid for four homepage highlight cards.

### DIFF
--- a/src/app/highlight-cards/highlight-cards.component.html
+++ b/src/app/highlight-cards/highlight-cards.component.html
@@ -19,7 +19,7 @@ card as a special case rather than changing the grid implemnation or replacing i
     />
   </div>
 } @else {
-  <biggive-grid [columnCount]="highlightCards.length" column-gap="3">
+  <biggive-grid [columnCount]="columnCount" column-gap="3">
     @for (card of highlightCards; track $index) {
       <biggive-basic-card
         [spaceBelow]="4"

--- a/src/app/highlight-cards/highlight-cards.component.ts
+++ b/src/app/highlight-cards/highlight-cards.component.ts
@@ -1,12 +1,39 @@
-import { Component, Input } from '@angular/core';
+import { Component, inject, Input, OnInit } from '@angular/core';
 import { HighlightCard } from './HighlightCard';
 import { BiggiveBasicCard, BiggiveGrid } from '@biggive/components-angular';
+import { ActivatedRoute } from '@angular/router';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-highlight-cards',
   imports: [BiggiveBasicCard, BiggiveGrid],
   templateUrl: './highlight-cards.component.html',
 })
-export class HighlightCardsComponent {
+export class HighlightCardsComponent implements OnInit {
   @Input({ required: true }) public highlightCards!: HighlightCard[];
+  private activatedRoute = inject(ActivatedRoute);
+
+  ngOnInit() {
+    if (environment.environmentId === 'production') {
+      return;
+    }
+
+    // allows testing the layout with space for an extra card - to artificially add one more card
+    // add `?repeatLastCard=true` on to the end of the URL when viewing anywhere but prod.
+
+    const params = this.activatedRoute?.snapshot?.queryParams;
+    if (params?.repeatLastCard && this.highlightCards) {
+      this.highlightCards.push(this.highlightCards[this.highlightCards.length - 1]);
+    }
+  }
+
+  get columnCount(): number {
+    const cardCount = this.highlightCards.length;
+
+    if (cardCount === 4) {
+      return 2;
+    }
+
+    return Math.min(this.highlightCards.length, 3);
+  }
 }


### PR DESCRIPTION
Use up to three columns for any other number of cards.

And to allow some testing this will detect the query string `?repeatLastCard=true` and add an extra copy of the last card to the page.

<img width="1284" height="894" alt="image" src="https://github.com/user-attachments/assets/dfbf1165-d793-4eb6-8c20-cdaaa659bb98" />
