### PR TITLE
Stop checking old property `ready` when deciding if meta-campaign is open

### DIFF
--- a/src/app/campaign.service.ts
+++ b/src/app/campaign.service.ts
@@ -25,7 +25,7 @@ export class CampaignService {
    * See also the less forgiving variant `campaignIsOpenLessForgiving`.
    */
   static isOpenForDonations(campaign: Campaign | MetaCampaign): boolean {
-    if (campaign.hidden || !campaign.ready) {
+    if (campaign.hidden) {
       return false;
     }
 

--- a/src/app/metaCampaign.model.ts
+++ b/src/app/metaCampaign.model.ts
@@ -11,7 +11,6 @@ export type MetaCampaign = {
   currencyCode: 'GBP' | 'USD';
   status: 'Active' | 'Expired' | 'Preview' | null;
   hidden: boolean;
-  ready: boolean;
   summary: string;
   bannerUri: string | null;
   amountRaised: number;


### PR DESCRIPTION
Still keeping doubled-up date check logic for now, to account for e.g. cached MatchBot responses