### PR TITLE
DON-1192: Allow donors who have saved funds to donate via ryft (not u…

### DIFF
--- a/src/app/donation-start/donation-start-container/donation-start-container.component.html
+++ b/src/app/donation-start/donation-start-container/donation-start-container.component.html
@@ -26,7 +26,9 @@
         [campaign]="campaign"
         [loggedInWithPassword]="this.loggedInWithPassword"
         [loginChangeEmitter]="identityService.loginStatusChanged"
-      ></app-donation-start-login>
+        [donorsCreditPence]="(this.donationStartForm && this.donationStartForm.donorsCreditPence) || 0"
+      >
+      </app-donation-start-login>
 
       @if (!campaignOpenOnLoad) {
         <p>

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -170,7 +170,8 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
 
   friendlyCaptchaSiteKey = environment.friendlyCaptchaSiteKey;
 
-  creditPenceToUse = 0; // Set non-zero if logged in and Customer has a credit balance to spend. Caps donation amount too in that case.
+  donorsCreditPence = 0; // Set non-zero if logged in and Customer has a credit balance in the right currency.
+  creditPenceToUse = 0; // Set non-zero if donorsCreditPence is non-zero and the campaign is one that can accept donor credit (i.e. on stripe)
   currencySymbol!: string;
 
   donationForm!: FormGroup;
@@ -1679,10 +1680,17 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
       person.cash_balance &&
       person.cash_balance[this.campaign.currencyCode.toLowerCase()]! > 0
     ) {
-      this.creditPenceToUse = parseInt(
+      this.donorsCreditPence = parseInt(
         person.cash_balance[this.campaign.currencyCode.toLowerCase()]!.toString() as string,
         10,
       );
+
+      if (this.campaign.charity.psp === 'stripe') {
+        // credit is stored at stripe so can't be used to donate to campaigns using any other PSP.
+
+        this.creditPenceToUse = this.donorsCreditPence;
+      }
+
       this.maximumDonationAmount = maximumDonationAmount(this.campaign.currencyCode, this.creditPenceToUse);
       this.stripePaymentMethodReady = true;
       this.paymentReadinessTracker.donationFundsPrepared(this.creditPenceToUse);

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.html
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.html
@@ -11,6 +11,15 @@
           {{ creditPenceToUse / 100 | exactCurrency: campaign.currencyCode }}
         </p>
       }
+      @if (donorsCreditPence > 0 && creditPenceToUse === 0 && this.campaign.charity.psp !== "stripe") {
+        <p>
+          You have a credit balance of
+          {{ donorsCreditPence / 100 | exactCurrency: campaign.currencyCode }}, but this charity's campaign does not use
+          Stripe as its payment processor, which means you can't use the stored credit on this page. You may donate
+          using a payment card here.
+        </p>
+      }
+
       <p>
         <button id="my-account-link" mat-raised-button routerLink="/my-account">My Account</button>
       </p>

--- a/src/app/donation-start/donation-start-login/donation-start-login.component.ts
+++ b/src/app/donation-start/donation-start-login/donation-start-login.component.ts
@@ -18,6 +18,7 @@ export class DonationStartLoginComponent {
   @Input({ required: true }) loadAuthedPersonInfo!: (dataId: string, dataJwt: string) => void;
   @Input({ required: true }) campaign!: Campaign;
   @Input({ required: true }) creditPenceToUse!: number;
+  @Input({ required: true }) donorsCreditPence!: number;
   @Input({ required: true }) email: string = '';
   @Input({ required: true }) personId: string | undefined;
   @Input({ required: false }) loggedInWithPassword?: boolean;


### PR DESCRIPTION
…sing those funds)

Funds are stored at Stripe so only usuable for charities on Stripe, but previously we assumed any stored funds could be used on any campaign as long as it had the right currency, which led to breakage when someone with funds would try to donate to a campaign on Ryft.