### PR TITLE
Don't accept donation amounts in case there is no usable PSP for a ch…

### DIFF
--- a/src/app/donation-start/donation-start-form/donation-start-form.component.html
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.html
@@ -38,6 +38,12 @@
             />
           </biggive-text-input>
         </div>
+        @if (noPsps) {
+          <p class="error">
+            Sorry, there is a technical issue with this campaign. We cannot take donations right now. Please try again
+            later.
+          </p>
+        }
         @if (
           donationAmountField?.invalid &&
           donationAmountField?.errors &&
@@ -631,12 +637,6 @@
           }
           @if (retrying) {
             <p class="error" aria-live="polite">It looks like our system is a bit busy, one moment please&hellip;</p>
-          }
-          @if (noPsps) {
-            <p class="error" aria-live="assertive">
-              Sorry, we are really busy and cannot take your donation right now. Please refresh the page in a few
-              minutes to try again.
-            </p>
           }
           @if (stripeError) {
             <p class="stripeError" aria-live="assertive">

--- a/src/app/donation-start/donation-start-form/donation-start-form.component.ts
+++ b/src/app/donation-start/donation-start-form/donation-start-form.component.ts
@@ -416,7 +416,7 @@ export class DonationStartFormComponent implements OnDestroy, OnInit, AfterViewI
     } = {
       amounts: this.formBuilder.group({
         donationAmount: [
-          null,
+          { value: null, disabled: this.noPsps },
           [
             requiredNotBlankValidator,
             getCurrencyMinValidator(1), // min donation is £1


### PR DESCRIPTION
…arity

Letting the donor get to the end and then giving an error message is a lot more confusing for us ot diagnose than blocking the donation from the start in case we don't have the PSP details set up for the charity.

Applies to saving us time dealing with incomplete test data as much as it should save donors time trying to donate to potential campaigns in prod that are not fully set up.

<img width="1316" height="1035" alt="image" src="https://github.com/user-attachments/assets/d6ec4b20-8907-4bcc-8e28-540fe2b52252" />

Copy is mine, we might want to try and make it a bit friendly if we can while still keeping it concise and clear.