### PR TITLE
Use `polyfill-corejs3` for babel ES5 / tier 2 legacy builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@types/node": "^20.13.1",
         "angular-eslint": "21.2.0",
         "babel-loader": "^10.0.0",
+        "babel-plugin-polyfill-corejs3": "^1.0.0",
         "browser-sync": "^3.0.0",
         "cypress": "^15.15.0",
         "eslint": "^9.28.0",
@@ -9926,6 +9927,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/create-require": {
@@ -20144,16 +20155,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/node": "^20.13.1",
     "angular-eslint": "21.2.0",
     "babel-loader": "^10.0.0",
+    "babel-plugin-polyfill-corejs3": "^1.0.0",
     "browser-sync": "^3.0.0",
     "cypress": "^15.15.0",
     "eslint": "^9.28.0",

--- a/webpack.es5.config.js
+++ b/webpack.es5.config.js
@@ -85,6 +85,7 @@ module.exports = {
     // Disable scope hoisting for better ES5 compatibility
     concatenateModules: false,
   },
+  plugins: [["polyfill-corejs3", { method: "usage-global" }]],
   // Ensure proper source maps for debugging
   devtool: "source-map",
   // Target browsers that support ES5


### PR DESCRIPTION
`usage-global` sounds like it should reinstate the removed-from-babel option we were using until today. https://github.com/babel/babel-polyfills/blob/HEAD/docs/usage.md#method