### PR TITLE
DON-1195: Show campaign summary near top of regular giving signup form

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -198,7 +198,10 @@ export const routes: (Route & {
     title: undefined, // set from inside component
     pathMatch: 'full',
     component: RegularGivingComponent,
-    canActivate: [requireLogin],
+    canActivate: [
+      (activatedRouteSnapshot, routerStateSnapshot) =>
+        flags.enableCondensedRegularGivingSignup || requireLogin(activatedRouteSnapshot, routerStateSnapshot),
+    ],
     resolve: {
       campaign: CampaignResolver,
       donor: LoggedInPersonResolver,

--- a/src/app/campaign-details/campaign-details.component.ts
+++ b/src/app/campaign-details/campaign-details.component.ts
@@ -5,7 +5,7 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 
 import { campaignHiddenMessage, currencyPipeDigitsInfo } from '../../environments/common';
-import { Campaign } from '../campaign.model';
+import { Campaign, formattedCampaignSummary } from '../campaign.model';
 import { CampaignService } from '../campaign.service';
 import { NavigationService } from '../navigation.service';
 import { PageMetaService } from '../page-meta.service';
@@ -78,9 +78,11 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
   currencyPipeDigitsInfo = currencyPipeDigitsInfo;
 
   private timer: number | NodeJS.Timeout | undefined; // State update setTimeout reference, for client side when donations open soon
+  protected formattedCampaignSummary!: string;
 
   ngOnInit() {
     this.campaign = this.route.snapshot.data.campaign;
+    this.formattedCampaignSummary = formattedCampaignSummary(this.campaign);
     this.setSecondaryProps(this.campaign);
   }
 
@@ -175,17 +177,5 @@ export class CampaignDetailsComponent implements OnInit, OnDestroy {
     if (campaign.hidden) {
       this.toast.showError(campaignHiddenMessage);
     }
-  }
-
-  /**
-   * Collapses sequences of line breaks in the campaign summary then returns a version of the summary with
-   * each line break doubled to appear like a paragraph break.
-   */
-  public get formattedCampaignSummary(): string {
-    if (!this.campaign.summary) {
-      return '';
-    }
-
-    return this.campaign.summary.replace(/\n{2,}/g, '\n').replace(/\n/g, '\n\n');
   }
 }

--- a/src/app/campaign.model.ts
+++ b/src/app/campaign.model.ts
@@ -10,6 +10,10 @@ export type Campaign = {
   currencyCode: 'GBP' | 'USD';
   hidden: boolean;
   ready: boolean;
+
+  /**
+   * General information about the campaign. Do not display directly - use formattedCampaignSummary instead.
+   */
   summary: string;
   amountRaised: number;
   /**
@@ -79,3 +83,15 @@ export type Campaign = {
       parentUsesSharedFunds: false;
     }
 );
+
+/**
+ * Collapses sequences of line breaks in the campaign summary then returns a version of the summary with
+ * each line break doubled to appear like a paragraph break.
+ */
+export function formattedCampaignSummary(campaign: Campaign): string {
+  if (!campaign.summary) {
+    return '';
+  }
+
+  return campaign.summary.replace(/\n{2,}/g, '\n').replace(/\n/g, '\n\n');
+}

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -192,7 +192,7 @@ export class DonationService {
     const person = await firstValueFrom(this.identityService.getLoggedInPerson());
 
     if (!person) {
-      throw new Error('logged in person required');
+      throw new Error('logged in person required for getPaymentMethods');
     }
 
     return { jwt, person };
@@ -424,7 +424,7 @@ export class DonationService {
     return person$.pipe(
       switchMap((person) => {
         if (!person) {
-          throw new Error('logged in person required');
+          throw new Error('logged in person required for getPastDonations');
         }
 
         return this.http
@@ -443,7 +443,7 @@ export class DonationService {
     return person$.pipe(
       switchMap((person) => {
         if (!person) {
-          throw new Error('logged in person required');
+          throw new Error('logged in person required for cancelDonationFundsToCampaign');
         }
 
         return this.http

--- a/src/app/donor-account.service.ts
+++ b/src/app/donor-account.service.ts
@@ -20,7 +20,7 @@ export class DonorAccountService {
   getLoggedInDonorAccount(): Observable<null | DonorAccount> {
     const jwt = this.identityService.getJWT();
     if (!jwt) {
-      throw new Error("Missing JWT, can't fetch donor account");
+      return of(null);
     }
 
     const identityPerson = this.identityService.getLoggedInPerson();

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -6,6 +6,12 @@ type flags = {
   enableWithdrawFunds: boolean;
   enableOrgAccount: boolean;
   enableSearchByLocation: boolean;
+
+  /**
+   * New process for regular giving where the donor doesn't have to have an account before they see the form,
+   * instead they have to create or login as a step within the stepper.
+   */
+  enableCondensedRegularGivingSignup: boolean;
 };
 
 const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmentId: EnvironmentID) => {
@@ -16,6 +22,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: true,
+        enableCondensedRegularGivingSignup: true,
       };
     case 'regression':
       return {
@@ -23,6 +30,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: true,
+        enableCondensedRegularGivingSignup: false,
       };
     case 'staging':
       return {
@@ -30,6 +38,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: true,
+        enableCondensedRegularGivingSignup: false,
       };
     case 'production':
       return {
@@ -37,6 +46,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: false,
+        enableCondensedRegularGivingSignup: false,
       };
   }
 };

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -85,7 +85,6 @@
                         matInput
                       />
                     </biggive-text-input>
-                    <mat-hint>We will email you to create an account.</mat-hint>
                   </div>
                 }
               </div>
@@ -140,6 +139,10 @@
                 <button type="button" class="continue" mat-raised-button color="primary" (click)="this.continue()">
                   {{ enableCondensedRegularGivingSignup ? "Send email" : "Continue" }}
                 </button>
+                @if (enableCondensedRegularGivingSignup) {
+                  <br />
+                  We will email you a temporary password for the next step, if you are not already registered.
+                }
               </div>
             </mat-step>
             <mat-step label="Gift Aid">

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -62,6 +62,8 @@
                 <p class="b-rt-0 b-m-0 b-bold">{{ campaign.charity.name }}</p>
               </div>
 
+              <p>{{ formattedCampaignSummary }}</p>
+
               <div class="donation-input donation-input-main">
                 <biggive-text-input currency="{{ campaign.currencyCode }}">
                   <label class="label-with-limited-space" slot="label" for="donationAmount">

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -71,6 +71,23 @@
                   </label>
                   <input maxlength="10" formControlName="donationAmount" id="donationAmount" matInput slot="input" />
                 </biggive-text-input>
+                @if (enableCondensedRegularGivingSignup) {
+                  <div>
+                    <biggive-text-input>
+                      <label slot="label" for="emailAddress">Email Address *</label>
+                      <input
+                        slot="input"
+                        formControlName="emailAddress"
+                        id="emailAddress"
+                        type="email"
+                        autocapitalize="off"
+                        autocomplete="email"
+                        matInput
+                      />
+                    </biggive-text-input>
+                    <mat-hint>We will email you to create an account.</mat-hint>
+                  </div>
+                }
               </div>
 
               @if (showUnmatchedDonationOption) {
@@ -111,11 +128,17 @@
                     {{ maximumMatchableDonation | money }}, or make an unmatched donation using the option above.
                   </p>
                 }
+
+                @if (emailErrorMessage) {
+                  <div class="error">
+                    {{ this.emailErrorMessage }}
+                  </div>
+                }
               </div>
 
               <div class="u-text-center">
                 <button type="button" class="continue" mat-raised-button color="primary" (click)="this.continue()">
-                  Continue
+                  {{ enableCondensedRegularGivingSignup ? "Send email" : "Continue" }}
                 </button>
               </div>
             </mat-step>

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -217,7 +217,7 @@
                      donor account - if donors want to edit them direct them to do so on the My Account page,
                      to make clear that it will affect existing mandates as well as the new one -->
 
-                @if (donorAccount.regularGivingPaymentMethod) {
+                @if (donorAccount?.regularGivingPaymentMethod) {
                   <!--
                   @todo-regular-giving-DON-1021: Consider showing existing payment method detail here here,
                     instead of just link to account. Might require either saving card brand and last4 to our matchbot

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Campaign, formattedCampaignSummary } from '../campaign.model';
 import {
@@ -118,8 +118,10 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   protected campaign!: Campaign;
   @ViewChild('stepper') private stepper!: MatStepper;
   readonly privacyUrl = 'https://biggive.org/privacy';
-  protected donor?: Person;
-  protected donorAccount!: DonorAccount;
+  protected donor?: Person | null;
+
+  /** May now be undefined as we will be allowing viewing of this page for new users before signup */
+  protected donorAccount: DonorAccount | undefined;
   protected countryOptionsObject = countryOptions;
   protected selectedBillingCountryCode!: string;
   private stripeElements: StripeElements | undefined;
@@ -185,11 +187,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   protected formattedCampaignSummary!: string;
 
   ngOnInit() {
-    const donor: Person | null = this.route.snapshot.data['donor'];
-    if (!donor) {
-      throw new Error('Must be logged in to see regular giving page');
-    }
-    this.donor = donor;
+    this.donor = this.route.snapshot.data['donor'];
     this.donorAccount = this.route.snapshot.data['donorAccount'];
 
     this.campaign = this.route.snapshot.data['campaign'];
@@ -210,21 +208,24 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
       this.campaign.banner?.uri,
     );
 
-    this.selectedBillingCountryCode = this.donorAccount.billingCountryCode ?? 'GB';
+    if (this.donorAccount) {
+      // @todo DON-1195 - make this run not jut OnInit but when the donorAccount is set and details available
+      this.selectedBillingCountryCode = this.donorAccount.billingCountryCode ?? 'GB';
 
-    this.mandateForm.patchValue({ billingPostcode: this.donorAccount.billingPostCode });
+      this.mandateForm.patchValue({ billingPostcode: this.donorAccount.billingPostCode });
 
-    this.stripeService.init().catch(console.error);
+      this.stripeService.init().catch(console.error);
 
-    this.donationService
-      .createCustomerSessionForRegularGiving({ campaign: this.campaign })
-      .then((session) => {
-        this.stripeCustomerSession = session;
-        if (!this.stripeElements && this.stepper.selected?.label === this.labelYourPaymentInformation) {
-          this.prepareStripeElements();
-        }
-      })
-      .catch(console.error);
+      this.donationService
+        .createCustomerSessionForRegularGiving({ campaign: this.campaign })
+        .then((session) => {
+          this.stripeCustomerSession = session;
+          if (!this.stripeElements && this.stepper.selected?.label === this.labelYourPaymentInformation) {
+            this.prepareStripeElements();
+          }
+        })
+        .catch(console.error);
+    }
 
     this.maximumMatchableDonation = this.maximumMatchableDonationGivenCampaign(this.campaign);
 
@@ -233,7 +234,11 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
       this.mandateForm.patchValue({ unmatched: true });
     }
 
-    this.preExistingActiveMandate$ = this.regularGivingService.activeMandate(this.campaign);
+    // @todo DON-1195 - run this check again if/when an existing donor logs in to stop them making another mandate for same campaign.
+    // I think it is already blocked in matchbot.
+    this.preExistingActiveMandate$ = this.donorAccount
+      ? this.regularGivingService.activeMandate(this.campaign)
+      : of([]);
   }
 
   ngOnDestroy() {
@@ -290,6 +295,12 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   async submit() {
+    if (!this.donorAccount) {
+      // this should never happen, we won't allow the donor to see the submit button while they aren't logged in to an
+      // account.
+      this.toast.showError('No donor account found, cannot create regular giving mandate');
+      return;
+    }
     const invalid = this.mandateForm.invalid;
     if (invalid) {
       let errorMessage = 'Form error: ';
@@ -650,7 +661,11 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   private validatePaymentInformationStep(): boolean {
     this.paymentInfoErrorMessage = undefined;
 
-    if (!this.stripePaymentMethodReady && !this.donorAccount.regularGivingPaymentMethod) {
+    if (!this.donorAccount) {
+      // likely this branch can never happen as we will check donor has an account before they see the payment information
+      // step
+      this.paymentInfoErrorMessage = 'Please login or create your donor account';
+    } else if (!this.stripePaymentMethodReady && !this.donorAccount.regularGivingPaymentMethod) {
       this.paymentInfoErrorMessage = 'Please complete your payment method details';
     } else if (this.stripeError) {
       this.paymentInfoErrorMessage = this.stripeError;

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Campaign } from '../campaign.model';
+import { Campaign, formattedCampaignSummary } from '../campaign.model';
 import {
   BiggiveButton,
   BiggiveFormFieldSelect,
@@ -182,6 +182,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
    * is quite baked into the logic for matching regular giving in matchbot.
    */
   public readonly standardNumberOfDonationsMatched = 3;
+  protected formattedCampaignSummary!: string;
 
   ngOnInit() {
     const donor: Person | null = this.route.snapshot.data['donor'];
@@ -192,6 +193,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     this.donorAccount = this.route.snapshot.data['donorAccount'];
 
     this.campaign = this.route.snapshot.data['campaign'];
+    this.formattedCampaignSummary = formattedCampaignSummary(this.campaign);
 
     if (!this.campaign.isRegularGiving) {
       console.error('Campaign ' + this.campaign.id + ' is not a regular giving campaign');

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -712,7 +712,16 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     }
 
     if (this.giftAid && !this.homeOutsideUK && !this.homePostcode?.match(postcodeRegExp)) {
-      errors.push('Please enter a UK postcode');
+      errors.push('Please enter a UK postcode.');
+    }
+
+    if (!this.donorAccount) {
+      // @todo-don-1195 - replace with a more detailed message based on exactly how far through logging in or creating the
+      // account they've got.
+      // also confirm if this error needs to come before they see the Gift Aid step or if it is actually OK for them to fill
+      // in the Gift Aid section of the form before logging in.
+      // and of course add the facility for them to actuall log in or signup into the stepper before they reach this point.
+      errors.push('Please login or create a donor account.');
     }
 
     this.giftAidErrorMessage = errors.join(' ');

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -45,6 +45,8 @@ import { CampaignService } from '../campaign.service';
 import { Observable, of } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { GIFT_AID_FACTOR, Money } from '../Money';
+import { EMAIL_REGEXP } from '../validators/patterns';
+import { flags } from '../featureFlags';
 
 // for now min & max are hard-coded, will change to be based on a field on
 // the campaign.
@@ -104,6 +106,11 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
       getCurrencyMaxValidator(maxAmount),
       Validators.pattern('^\\s*[£$]?[0-9]+?(\\.00)?\\s*$'),
     ]),
+    emailAddress: new FormControl('', [
+      requiredNotBlankValidator,
+      // Regex below originally based on EMAIL_REGEXP in donate-frontend/node_modules/@angular/forms/esm2020/src/validators.mjs
+      Validators.pattern(EMAIL_REGEXP),
+    ]),
     billingPostcode: new FormControl('', [requiredNotBlankValidator, Validators.pattern(billingPostcodeRegExp)]),
     optInCharityEmail: new FormControl(booleansDefaultValue, requiredNotBlankValidator),
     optInTbgEmail: new FormControl(booleansDefaultValue, requiredNotBlankValidator),
@@ -138,6 +145,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   protected submitting: boolean = false;
 
   protected amountErrorMessage: string | undefined;
+  protected emailErrorMessage: string | undefined;
   private stripePaymentMethodReady: boolean = false;
   protected stripeError: string | undefined;
   private cardHandler = this.onStripeCardChange.bind(this);
@@ -443,6 +451,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   protected giftAidErrorMessage: string | undefined = undefined;
+  protected enableCondensedRegularGivingSignup = flags.enableCondensedRegularGivingSignup;
 
   protected get homeOutsideUK(): boolean {
     return !!this.mandateForm.value.homeOutsideUK;
@@ -627,6 +636,28 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
         this.ageErrorMessage = undefined;
       }
     }
+
+    const emailErrors = this.mandateForm.controls.emailAddress.errors;
+    if (emailErrors && flags.enableCondensedRegularGivingSignup) {
+      for (const [key] of Object.entries(emailErrors)) {
+        switch (key) {
+          case 'required':
+            this.emailErrorMessage =
+              'Please enter your email address. You will be able to set up a new account or log in to any existing Big Give donor account';
+            break;
+          case 'pattern':
+            this.emailErrorMessage = `Sorry, your email address is not recognised - please enter a valid email address.`;
+            break;
+          default:
+            this.emailErrorMessage = 'Unexpected donation email address error';
+            console.error({ emailErrors });
+            break;
+        }
+      }
+      this.toast.showError(this.emailErrorMessage!);
+      errorFound = true;
+    }
+
     return errorFound;
   }
 

--- a/src/app/regularGiving.service.ts
+++ b/src/app/regularGiving.service.ts
@@ -127,7 +127,7 @@ export class RegularGivingService {
     return person$.pipe(
       switchMap((person) => {
         if (!person) {
-          throw new Error('logged in person required');
+          throw new Error('logged in person required for withLoggedInDonor');
         }
 
         return callable(personAuthHttpOptions);


### PR DESCRIPTION
This doesn't make clear that the summary is written by the charity not us, but I think we can trust our charities not to write anything harmful here.

Also wondering if we should make this page more like the ad-hoc donation campaign detail page (since this page is sharing the function of that one as well as showing the form) by making the charity name blue and perhaps removing the "you are supporting" text that may be redundant.

Also note that we still don't show the campaign name, since regular giving campaigns have all been to provide unrestricted funds to the charity so the campaign names didn't seem to be useful.

The campaign summary in this screenshot is "We can Save Matchbot 1"

<img width="1757" height="1459" alt="image" src="https://github.com/user-attachments/assets/90c805fa-bea7-4e7a-bb5c-db6ba304b7ed" />
