### PR TITLE
Don-1195 regular giving: Allow viewing form without logging in.

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -198,7 +198,10 @@ export const routes: (Route & {
     title: undefined, // set from inside component
     pathMatch: 'full',
     component: RegularGivingComponent,
-    canActivate: [requireLogin],
+    canActivate: [
+      (activatedRouteSnapshot, routerStateSnapshot) =>
+        flags.enableCondensedRegularGivingSignup || requireLogin(activatedRouteSnapshot, routerStateSnapshot),
+    ],
     resolve: {
       campaign: CampaignResolver,
       donor: LoggedInPersonResolver,

--- a/src/app/donation.service.ts
+++ b/src/app/donation.service.ts
@@ -192,7 +192,7 @@ export class DonationService {
     const person = await firstValueFrom(this.identityService.getLoggedInPerson());
 
     if (!person) {
-      throw new Error('logged in person required');
+      throw new Error('logged in person required for getPaymentMethods');
     }
 
     return { jwt, person };
@@ -424,7 +424,7 @@ export class DonationService {
     return person$.pipe(
       switchMap((person) => {
         if (!person) {
-          throw new Error('logged in person required');
+          throw new Error('logged in person required for getPastDonations');
         }
 
         return this.http
@@ -443,7 +443,7 @@ export class DonationService {
     return person$.pipe(
       switchMap((person) => {
         if (!person) {
-          throw new Error('logged in person required');
+          throw new Error('logged in person required for cancelDonationFundsToCampaign');
         }
 
         return this.http

--- a/src/app/donor-account.service.ts
+++ b/src/app/donor-account.service.ts
@@ -20,7 +20,7 @@ export class DonorAccountService {
   getLoggedInDonorAccount(): Observable<null | DonorAccount> {
     const jwt = this.identityService.getJWT();
     if (!jwt) {
-      throw new Error("Missing JWT, can't fetch donor account");
+      return of(null);
     }
 
     const identityPerson = this.identityService.getLoggedInPerson();

--- a/src/app/featureFlags.ts
+++ b/src/app/featureFlags.ts
@@ -6,6 +6,12 @@ type flags = {
   enableWithdrawFunds: boolean;
   enableOrgAccount: boolean;
   enableSearchByLocation: boolean;
+
+  /**
+   * New process for regular giving where the donor doesn't have to have an account before they see the form,
+   * instead they have to create or login as a step within the stepper.
+   */
+  enableCondensedRegularGivingSignup: boolean;
 };
 
 const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmentId: EnvironmentID) => {
@@ -16,6 +22,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: true,
+        enableCondensedRegularGivingSignup: true,
       };
     case 'regression':
       return {
@@ -23,6 +30,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: true,
+        enableCondensedRegularGivingSignup: false,
       };
     case 'staging':
       return {
@@ -30,6 +38,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: true,
+        enableCondensedRegularGivingSignup: false,
       };
     case 'production':
       return {
@@ -37,6 +46,7 @@ const flagsForEnvironment: (environmentId: EnvironmentID) => flags = (environmen
         enableWithdrawFunds: true,
         enableOrgAccount: true,
         enableSearchByLocation: false,
+        enableCondensedRegularGivingSignup: false,
       };
   }
 };

--- a/src/app/regular-giving/regular-giving.component.html
+++ b/src/app/regular-giving/regular-giving.component.html
@@ -217,7 +217,7 @@
                      donor account - if donors want to edit them direct them to do so on the My Account page,
                      to make clear that it will affect existing mandates as well as the new one -->
 
-                @if (donorAccount.regularGivingPaymentMethod) {
+                @if (donorAccount?.regularGivingPaymentMethod) {
                   <!--
                   @todo-regular-giving-DON-1021: Consider showing existing payment method detail here here,
                     instead of just link to account. Might require either saving card brand and last4 to our matchbot

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Campaign, formattedCampaignSummary } from '../campaign.model';
 import {
@@ -118,8 +118,10 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   protected campaign!: Campaign;
   @ViewChild('stepper') private stepper!: MatStepper;
   readonly privacyUrl = 'https://biggive.org/privacy';
-  protected donor?: Person;
-  protected donorAccount!: DonorAccount;
+  protected donor?: Person | null;
+
+  /** May now be undefined as we will be allowing viewing of this page for new users before signup */
+  protected donorAccount: DonorAccount | undefined;
   protected countryOptionsObject = countryOptions;
   protected selectedBillingCountryCode!: string;
   private stripeElements: StripeElements | undefined;
@@ -185,11 +187,7 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   protected formattedCampaignSummary!: string;
 
   ngOnInit() {
-    const donor: Person | null = this.route.snapshot.data['donor'];
-    if (!donor) {
-      throw new Error('Must be logged in to see regular giving page');
-    }
-    this.donor = donor;
+    this.donor = this.route.snapshot.data['donor'];
     this.donorAccount = this.route.snapshot.data['donorAccount'];
 
     this.campaign = this.route.snapshot.data['campaign'];
@@ -210,21 +208,24 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
       this.campaign.banner?.uri,
     );
 
-    this.selectedBillingCountryCode = this.donorAccount.billingCountryCode ?? 'GB';
+    if (this.donorAccount) {
+      // @todo DON-1195 - make this run not jut OnInit but when the donorAccount is set and details available
+      this.selectedBillingCountryCode = this.donorAccount.billingCountryCode ?? 'GB';
 
-    this.mandateForm.patchValue({ billingPostcode: this.donorAccount.billingPostCode });
+      this.mandateForm.patchValue({ billingPostcode: this.donorAccount.billingPostCode });
 
-    this.stripeService.init().catch(console.error);
+      this.stripeService.init().catch(console.error);
 
-    this.donationService
-      .createCustomerSessionForRegularGiving({ campaign: this.campaign })
-      .then((session) => {
-        this.stripeCustomerSession = session;
-        if (!this.stripeElements && this.stepper.selected?.label === this.labelYourPaymentInformation) {
-          this.prepareStripeElements();
-        }
-      })
-      .catch(console.error);
+      this.donationService
+        .createCustomerSessionForRegularGiving({ campaign: this.campaign })
+        .then((session) => {
+          this.stripeCustomerSession = session;
+          if (!this.stripeElements && this.stepper.selected?.label === this.labelYourPaymentInformation) {
+            this.prepareStripeElements();
+          }
+        })
+        .catch(console.error);
+    }
 
     this.maximumMatchableDonation = this.maximumMatchableDonationGivenCampaign(this.campaign);
 
@@ -233,7 +234,11 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
       this.mandateForm.patchValue({ unmatched: true });
     }
 
-    this.preExistingActiveMandate$ = this.regularGivingService.activeMandate(this.campaign);
+    // @todo DON-1195 - run this check again if/when an existing donor logs in to stop them making another mandate for same campaign.
+    // I think it is already blocked in matchbot.
+    this.preExistingActiveMandate$ = this.donorAccount
+      ? this.regularGivingService.activeMandate(this.campaign)
+      : of([]);
   }
 
   ngOnDestroy() {
@@ -290,6 +295,12 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   async submit() {
+    if (!this.donorAccount) {
+      // this should never happen, we won't allow the donor to see the submit button while they aren't logged in to an
+      // account.
+      this.toast.showError('No donor account found, cannot create regular giving mandate');
+      return;
+    }
     const invalid = this.mandateForm.invalid;
     if (invalid) {
       let errorMessage = 'Form error: ';
@@ -650,7 +661,11 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   private validatePaymentInformationStep(): boolean {
     this.paymentInfoErrorMessage = undefined;
 
-    if (!this.stripePaymentMethodReady && !this.donorAccount.regularGivingPaymentMethod) {
+    if (!this.donorAccount) {
+      // likely this branch can never happen as we will check donor has an account before they see the payment information
+      // step
+      this.paymentInfoErrorMessage = 'Please login or create your donor account';
+    } else if (!this.stripePaymentMethodReady && !this.donorAccount.regularGivingPaymentMethod) {
       this.paymentInfoErrorMessage = 'Please complete your payment method details';
     } else if (this.stripeError) {
       this.paymentInfoErrorMessage = this.stripeError;

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -712,7 +712,16 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
     }
 
     if (this.giftAid && !this.homeOutsideUK && !this.homePostcode?.match(postcodeRegExp)) {
-      errors.push('Please enter a UK postcode');
+      errors.push('Please enter a UK postcode.');
+    }
+
+    if (!this.donorAccount) {
+      // @todo-don-1195 - replace with a more detailed message based on exactly how far through logging in or creating the
+      // account they've got.
+      // also confirm if this error needs to come before they see the Gift Aid step or if it is actually OK for them to fill
+      // in the Gift Aid section of the form before logging in.
+      // and of course add the facility for them to actuall log in or signup into the stepper before they reach this point.
+      errors.push('Please login or create a donor account.');
     }
 
     this.giftAidErrorMessage = errors.join(' ');

--- a/src/app/regularGiving.service.ts
+++ b/src/app/regularGiving.service.ts
@@ -127,7 +127,7 @@ export class RegularGivingService {
     return person$.pipe(
       switchMap((person) => {
         if (!person) {
-          throw new Error('logged in person required');
+          throw new Error('logged in person required for withLoggedInDonor');
         }
 
         return callable(personAuthHttpOptions);


### PR DESCRIPTION
In the environments where this is enabled the donor can now progress through the form as far as the payment step, which will broken as stripe isn't loaded and they can't progress further. 

But I think this is fine to merge and we know that we now have to add elements into the form to allow and require the donor to login/signup before they reach the payment step.

<img width="2206" height="983" alt="image" src="https://github.com/user-attachments/assets/eaccfddd-2d77-4db0-aa4a-e1a5aa8b1fc6" />
