### PR TITLE
DON-1026 Add Matomo tracking for Regular Giving sign up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           # cache-from format is e.g. 123.dkr.ecr.eu-west-1.amazonaws.com/thebiggive-donate:staging
           extra_build_args: '--build-arg BUILD_ENV=<< parameters.env >> --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN} --cache-from "${AWS_US_ECR_ACCOUNT_URL}/${AWS_ECR_REPO_NAME}:<< parameters.env >>"'
           repo: "${AWS_ECR_REPO_NAME}"
-          region: 'us-east-1'
+          region: "us-east-1"
           account_id: ${AWS_ECR_REGISTRY_ID}
           tag: "<< parameters.env >>,<< parameters.env >>-${CIRCLE_SHA1}"
 

--- a/src/app/regular-giving/regular-giving.component.ts
+++ b/src/app/regular-giving/regular-giving.component.ts
@@ -31,6 +31,9 @@ import { requiredNotBlankValidator } from '../validators/notBlank';
 import { getCurrencyMinValidator } from '../validators/currency-min';
 import { getCurrencyMaxValidator } from '../validators/currency-max';
 import { Toast } from '../toast.service';
+import { MatomoTracker } from 'ngx-matomo-client';
+import { ConversionTrackingService } from '../conversionTracking.service';
+import { Donation } from '../donation.model';
 import { DonorAccount } from '../donorAccount.model';
 import { countryOptions } from '../countries';
 import { PageMetaService } from '../page-meta.service';
@@ -113,6 +116,8 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   private stripeService = inject(StripeService);
   private donationService = inject(DonationService);
   private readonly identityService = inject(IdentityService);
+  private matomoTracker = inject(MatomoTracker);
+  private conversionTrackingService = inject(ConversionTrackingService);
   protected friendlyCaptchaSiteKey = environment.friendlyCaptchaSiteKey;
   private donorAccountService = inject(DonorAccountService);
 
@@ -362,6 +367,8 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   stepChanged(event: StepperSelectionEvent) {
+    this.matomoTracker.trackEvent('donate', 'regular_giving_step_changed', `Entered step ${event.selectedStep.label}`);
+
     if (event.selectedStep.label === this.labelYourPaymentInformation) {
       this.prepareStripeElements();
     }
@@ -458,8 +465,27 @@ export class RegularGivingComponent implements OnInit, AfterViewInit, OnDestroy 
               // a way for donor to retry the 3DS or other next action on the existing mandate, without calling matchbot
               // to create a new one.
               return;
+            } else {
+              this.matomoTracker.trackEvent('donate', 'exit_requires_action_non_error', 'Assuming 3DS or PBB success');
             }
           }
+
+          const stripeMethod = confirmationToken?.payment_method_preview?.type || 'card';
+          this.matomoTracker.trackEvent(
+            'donate',
+            `stripe_${stripeMethod}_payment_success`,
+            `Stripe Intent processing or done for mandate ${response.mandate.id} to campaign ${this.campaign.id}, stripe method ${stripeMethod}`,
+          );
+
+          // We don't directly make a Donation so need a dummy one in order to share the same ecommerce
+          // tracking as the one-time donation journey.
+          const dummyDonation = {
+            donationAmount: response.mandate.donationAmount.amountInPence / 100,
+            donationId: response.mandate.id,
+            projectId: response.mandate.campaignId,
+            tipAmount: 0,
+          } as unknown as Donation;
+          this.conversionTrackingService.convert(dummyDonation, this.campaign, stripeMethod);
 
           await this.router.navigateByUrl(`/${myRegularGivingPath}/${response.mandate.id}/thanks`);
         },


### PR DESCRIPTION
Copies from one-time donate journey guided by Copilot / Gemini session.

The dummy Donation feels slightly messy but I don't have an immediate better idea.