### PR TITLE
Infra 137 OIDC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@5.1.0
+  aws-cli: circleci/aws-cli@5.4.2
   aws-ecr: circleci/aws-ecr@9.3.4
   aws-ecs: circleci/aws-ecs@4.1.0
   aws-s3: circleci/aws-s3@4.0.0
@@ -55,8 +55,8 @@ jobs:
       - aws-ecr/build_and_push_image:
           auth:
             - aws-cli/setup:
-                aws_access_key_id: AWS_ACCESS_KEY_ID
-                aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+                role_arn: ${AWS_ROLE_ARN}
+                region: ${AWS_REGION}
           # cache-from format is e.g. 123.dkr.ecr.eu-west-1.amazonaws.com/thebiggive-donate:staging
           extra_build_args: '--build-arg BUILD_ENV=<< parameters.env >> --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN} --cache-from "${AWS_US_ECR_ACCOUNT_URL}/${AWS_ECR_REPO_NAME}:<< parameters.env >>"'
           repo: "${AWS_ECR_REPO_NAME}"
@@ -71,8 +71,8 @@ jobs:
       - image: "${AWS_US_ECR_ACCOUNT_URL}/${AWS_ECR_REPO_NAME}:<< parameters.env >>-${CIRCLE_SHA1}"
     steps:
       - aws-cli/setup:
-          aws_access_key_id: AWS_ACCESS_KEY_ID
-          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          role_arn: ${AWS_ROLE_ARN}
+          region: ${AWS_REGION}
 
       - aws-s3/sync: # Sync dist/donate-frontend/browser to S3 with 1 year lifetime
           from: /usr/src/app/dist/donate-frontend/browser
@@ -148,8 +148,8 @@ workflows:
           name: "Deploy Regression ECS with new image"
           auth:
             - aws-cli/setup:
-                aws_access_key_id: AWS_ACCESS_KEY_ID
-                aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+                role_arn: ${AWS_ROLE_ARN}
+                region: ${AWS_REGION}
           context:
             - ecs-deploys
           requires: ["Copy Regression ECR static to S3"]
@@ -180,8 +180,8 @@ workflows:
           name: "Deploy Staging ECS with new image"
           auth:
             - aws-cli/setup:
-                aws_access_key_id: AWS_ACCESS_KEY_ID
-                aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+                role_arn: ${AWS_ROLE_ARN}
+                region: ${AWS_REGION}
           context:
             - ecs-deploys
             - jira
@@ -220,8 +220,8 @@ workflows:
           name: "Deploy Production ECS with new image"
           auth:
             - aws-cli/setup:
-                aws_access_key_id: AWS_ACCESS_KEY_ID
-                aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+                role_arn: ${AWS_ROLE_ARN}
+                region: ${AWS_REGION}
           context:
             - ecs-deploys
             - jira


### PR DESCRIPTION
See chat with AI agent:

```
Why have deployments to production stopped working in the last few days? It should be being deployed by the build-ecr job in circleci/config.yml.
This is the error we're getting. The setup in general has been working for years, and I don't know that we've made any relevent changes recently.
....
```

```
Searched "**/*circleci*" 

**Root Cause Analysis**

Deployments to production (and all environments) in `donate-frontend` stopped working because AWS authentication in CircleCI was migrated to **OpenID Connect (OIDC)** as part of ticket **INFRA-137** on August 7, 2026.

As part of this migration:
1. The static IAM credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) in the shared CircleCI `ecs-deploys` context / AWS IAM were disabled, deleted, or replaced by OIDC role assumption.
2. The last successful deployment in `donate-frontend` ran on the morning of August 7, 2026 (prior to the merge of PR `#2082: INFRA-137 Have CircleCI use OIDC auth for AWS` in `matchbot` later that afternoon).
3. The first deployment attempt in `donate-frontend` after the migration was on August 14, 2026 (PR `#2431`), which immediately failed with `401 Unauthorized` when attempting to authenticate with ECR during `build-ecr`.

Because `donate-frontend/.circleci/config.yml` still references the static keys (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`), `aws-cli/setup` fails to authenticate with ECR, causing Docker BuildKit/Buildx to receive a `401 Unauthorized` response when querying cache manifests and pushing layers to the ECR registry.

---

**Solution / Required Changes**

Update `.circleci/config.yml` in `donate-frontend` to use OIDC role authentication (`role_arn`) via `aws-cli/setup` matching the configuration in `matchbot`:

1. **Update `aws-cli/setup` in the `build-ecr` job:**
```yaml
  build-ecr:
    steps:
      - aws-ecr/build_and_push_image:
          auth:
            - aws-cli/setup:
                role_arn: ${AWS_ROLE_ARN}
                region: ${AWS_REGION}
```

2. **Update `aws-cli/setup` in the `copy-ecr-static-to-s3` job:**
```yaml
  copy-ecr-static-to-s3:
    steps:
      - aws-cli/setup:
          role_arn: ${AWS_ROLE_ARN}
          region: ${AWS_REGION}
```

3. **Update `aws-cli/setup` in the deployment workflows (`deploy-regression`, `deploy-staging`, `deploy-production`):**
In `aws-ecs/deploy_service_update`:
```yaml
      - aws-ecs/deploy_service_update:
          auth:
            - aws-cli/setup:
                role_arn: ${AWS_ROLE_ARN}
                region: ${AWS_REGION}
```

4. **Verify `aws-cli` orb version:**
Ensure `circleci/aws-cli` orb version in `.circleci/config.yml` is at least `5.1.0` (which supports OIDC via `role_arn`).


```

```
Thanks. I've copied changes over from commit c4d37a2 in matchbot and committed here. Can you review please?
```


```
**Code Review: OIDC Authentication Migration in `donate-frontend`**

The changes committed in `donate-frontend` (`54e64d29`) correctly migrate AWS authentication to OpenID Connect (OIDC) and match the implementation in `matchbot` (`c4d37a2c`).

---

**Review Findings**

1. **Orb Updates & Version Compatibility**
   - `aws-cli` orb updated from `5.1.0` to `5.4.2` (`circleci/aws-cli@5.4.2`), ensuring full support for OIDC role assumption via `role_arn`.
   - Configuration was validated using the CircleCI CLI (`circleci config validate`) and passed successfully.

2. **Job-Level Authentication (`aws-cli/setup`)**
   - **`build-ecr`**: `aws-ecr/build_and_push_image` auth correctly updated to use `role_arn: ${AWS_ROLE_ARN}` and `region: ${AWS_REGION}`. This resolves the `401 Unauthorized` ECR authentication error during Docker cache manifest queries and image pushes.
   - **`copy-ecr-static-to-s3`**: Authentication step updated to use `role_arn` and `region` before running `aws-s3/sync` steps.

3. **Workflow-Level Deploy Steps (`aws-ecs/deploy_service_update`)**
   - **`deploy-regression`**, **`deploy-staging`**, and **`deploy-production`**: All `aws-ecs/deploy_service_update` jobs updated to use OIDC role authentication (`role_arn: ${AWS_ROLE_ARN}`, `region: ${AWS_REGION}`).
   - All relevant jobs include the `ecs-deploys` context where `AWS_ROLE_ARN` and `AWS_REGION` are defined.

4. **Completeness Check**
   - All occurrences of the legacy static credentials (`aws_access_key_id` / `aws_secret_access_key`) have been replaced.
   - No remaining unauthenticated AWS calls or syntax issues were found.

---

**Conclusion**

The changes are complete, syntactically valid, and ready to be merged/deployed.

``